### PR TITLE
Add midvals attr for stat fetch; fix ss_vector for missing tlm

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -196,6 +196,7 @@ class MSID(object):
         # consistent use of the 'vals' attribute and there is little use for the
         # original sampled version.
         if hasattr(self, 'means'):
+            self.midvals = self.vals
             self.vals = self.means
 
     @staticmethod

--- a/doc/fetch_tutorial.rst
+++ b/doc/fetch_tutorial.rst
@@ -312,7 +312,8 @@ Name        5min   daily  Supported types   Column type       Description
 times         x      x    int,float,string  float             Time at midpoint
 indexes       x      x    int,float,string  int               Interval index
 samples       x      x    int,float,string  int16             Number of samples
-vals          x      x    int,float,string  int,float,string  Sample at midpoint
+midvals       x      x    int,float,string  int,float,string  Sample at midpoint
+vals          x      x    int,float         int,float         Mean
 mins          x      x    int,float         int,float         Minimum
 maxes         x      x    int,float         int,float         Maximum
 means         x      x    int,float         float             Mean


### PR DESCRIPTION
When doing a stat='5min' or 'daily' fetch, the meaning of MSID.vals
was recently changed to refer to the mean instead of mid-point value.
This broke ss_vector, so a new attribute midvals was added and
ss_vector now uses that.

Also:
- Do some more consistency checking
- Do PEP-8 fixes for utils.py
- Update fetch_tutorial to reference midvals attr

Closes #10
