### PR TITLE
Shorten the derived parameter archfile_time_step to reduce latency

### DIFF
--- a/update_archive.py
+++ b/update_archive.py
@@ -494,10 +494,10 @@ def update_derived(filetype):
     # Make a list of indexes that will correspond to the index/time ranges
     # for each pseudo-"archfile".  In this context an archfile just specifies
     # the time range covered by an ingest, but is needed by fetch to roughly
-    # locate rows in the H5 file for fast queries.  Each archfile is 50000 sec
+    # locate rows in the H5 file for fast queries.  Each archfile is 10000 sec
     # long, and when updating the database no more than 1000000 seconds of
     # telemetry will be read at one time.
-    archfile_time_step = 200000.0
+    archfile_time_step = 10000.0
     max_archfiles = int(1000000.0 / archfile_time_step)
 
     # Read data out to either date_now or the last available time in telemetry.


### PR DESCRIPTION
The original value of `archfile_time_step = 200000` was likely driven by
efficiency in the initial ingest.  This has the bad side effect of
making derived parameter values lag behind by up to ~3 days.  Shortening
the value to 10000 will reduce latency to less than 4 hours behind the
main telemetry.
