### PR TITLE
Fix remote access for non-default usernames

### DIFF
--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -60,8 +60,7 @@ Return success status (True/False)
         sys.stdout.flush()
         try:
             _remote_client = IPython.parallel.Client(client_key_file,
-                                                     sshserver = hostname,
-                                                     username=username,
+                                                     sshserver=username+'@'+hostname,
                                                      password=password)
         except:
             print 'Error connecting to server ',hostname,': ',sys.exc_info()[0]


### PR DESCRIPTION
Fixed Ska archive remote access to work correctly when the username is
not the local user (the "username" argument does not work - it has to be
set in the servername: "<username>@<hostname>").

@mbaski - just discovered this commit which was orphaned in the remote-fetch-faster-stats branch.  You put this commit after I merged the original PR and I didn't realize (or maybe forgot).  I just rebased to get a clean new PR with just this update.
