### PR TITLE
Add function to get time range

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -1274,6 +1274,40 @@ def get_interval(content, tstart, tstop):
     return get_interval_from_db(tstart, tstop, _split_path(msid_files['archfiles'].abs))
 
 
+def get_time_range(content):
+    """
+    Get the approximate time range for the ``content`` type.
+
+    :param content: content type (e.g. 'pcad3eng', 'thm1eng')
+
+    :returns: slice(start time (CXC seconds), stop time (CXC seconds))
+    """
+    
+    ft['content'] = content
+    
+    @local_or_remote_function("Getting time range from " +
+                              "DB on Ska eng archive server...")
+    def get_time_range_from_db(server):
+        
+        import Ska.DBI
+        
+        db = Ska.DBI.DBI(dbi='sqlite', server=os.path.join(*server))
+        
+        query_row = db.fetchone('SELECT tstart FROM archfiles '
+                                'order by filetime asc')
+        
+        tstart = query_row['tstart']
+        
+        query_row = db.fetchone('SELECT tstop FROM archfiles '
+                                 'order by filetime desc')
+        
+        tstop = query_row['tstop']
+        
+        return slice(tstart, tstop)
+    
+    return get_time_range_from_db(_split_path(msid_files['archfiles'].abs))
+
+
 @contextlib.contextmanager
 def _cache_ft():
     """


### PR DESCRIPTION
Add get_time_range function to efficiently (for remote use) get the time
span of a given type of msid (content type).  Tom, I didn't see any
other relatively efficient way to do this, but if there is, let me know
and we can drop this change.

I ran the regression test on Windows (remotely) and everything matched except for daily DP_SUN_XZ_ANGLE data.  However, this data has always been different when I run the test on Windows, so I'm calling it good.

old: dp_pcad4             DP_SUN_XZ_ANGLE  daily  2e460bcd1995c2e58732ee82537b6709
new: dp_pcad4             DP_SUN_XZ_ANGLE  daily  75b7927e65638775e6c775292a6a22b5
