### PR TITLE
Interval overlaps

### DIFF
--- a/Ska/engarchive/tests/test_fetch.py
+++ b/Ska/engarchive/tests/test_fetch.py
@@ -1,5 +1,6 @@
-import numpy as np
+from copy import deepcopy
 
+import numpy as np
 import pytest
 
 from .. import fetch
@@ -26,6 +27,18 @@ DATES_EXPECT3 = np.array(['2008:002:21:48:10.000', '2008:002:21:48:20.000',
 BAD_TIMES = ['2008:292:00:00:00 2008:297:00:00:00',
              '2008:305:00:12:00 2008:305:00:12:03',
              '2010:101:00:01:12 2010:101:00:01:25']
+
+
+def test_filter_bad_times_overlap():
+    """
+    OK to supply overlapping bad times
+    """
+    msid_bad_times_cache = deepcopy(fetch.msid_bad_times)
+    dat = fetch.MSID('aogbias1', '2008:290', '2008:300', stat='daily')
+    fetch.read_bad_times(['aogbias1 2008:292:00:00:00 2008:297:00:00:00'])
+    fetch.read_bad_times(['aogbias1 2008:292:00:00:00 2008:297:00:00:00'])
+    dat.filter_bad_times()
+    fetch.msid_bad_times = msid_bad_times_cache
 
 
 def test_filter_bad_times_list():


### PR DESCRIPTION
Code like below was failing because user intervals overlapped with default bad time intervals:

```
import Ska.engarchive.fetch as fetch
import Chandra.Time
from Ska.Matplotlib import plot_cxctime

time_start = Chandra.Time.DateTime('2008:001:00:00:00.000').secs
time_stop  = Chandra.Time.DateTime('2014:096:00:00:00.000').secs
fetch.read_bad_times('bad_times.dat')

bias1_daily = fetch.MSID('aogbias1', time_start, time_stop, stat='daily')
bias1_daily.filter_bad_times()

/proj/sot/ska/test/arch/x86_64-linux_CentOS-5/lib/python2.7/site-packages/Ska.engarchive-0.28-py2.7.egg/Ska/engarchive/fetch.pyc in _get_table_intervals_as_list(table)
    303         # Check for overlaps
    304         if any(i0[1] > i1[0] for i0, i1 in izip(intervals[:-1], intervals[1:])):
--> 305             raise ValueError('Input intervals overlap')
    306
    307     return intervals

ValueError: Input intervals overlap
```

This changes the behavior so that no overlap checking is done in this case.
