### PR TITLE
Remove file_defs.msid_root and arch_root from use in cron tools

### DIFF
--- a/Ska/engarchive/file_defs.py
+++ b/Ska/engarchive/file_defs.py
@@ -8,15 +8,18 @@ basename) defined.
 
 Msid files are the hdf5 files containing the entire mission telemetry for one MSID.
 Arch files are the CXC archive files containing a short interval of telemetry for
-all MSIDs in the same content-type group (e.g. ACIS2ENG). 
+all MSIDs in the same content-type group (e.g. ACIS2ENG).
 """
 import os
 
 SKA = os.environ.get('SKA') or '/proj/sot/ska'
 
 # Root directories for MSID files.  msid_root is prime, others are backups.
+# NOTE: msid_root(s) used ONLY in one-off or legacy code, not in update_archive.py or
+# transfer_stage.py
 msid_root = os.path.join(SKA, 'data', 'eng_archive')
 msid_roots = [msid_root]
+
 msid_files = {'filetypes':    'filetypes.dat',
               'msid_bad_times': 'msid_bad_times.dat',
               'contentdir':   'data/{{ft.content}}/',
@@ -30,6 +33,9 @@ msid_files = {'filetypes':    'filetypes.dat',
               'stats':        'data/{{ft.content}}/{{ft.interval}}/{{ft.msid | upper}}.h5',
               }
 
+
+# NOTE: arch_root used ONLY in one-off or legacy code, not in update_archive.py or
+# transfer_stage.py
 arch_root = '/data/cosmos2/eng_archive'
 arch_files = {'stagedir': 'stage/{{ft.content}}/',
               'rootdir': '',

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -33,7 +33,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (0, 36, 2, False)
+VERSION = (0, 36, 3, False)
 
 
 class SemanticVersion(object):

--- a/transfer_stage.py
+++ b/transfer_stage.py
@@ -124,8 +124,7 @@ loglevel = pyyaks.logger.VERBOSE
 logger = pyyaks.logger.get_logger(name='transfer_stage', level=loglevel,
                                   format="%(asctime)s %(message)s")
 
-arch_files = arch_files = pyyaks.context.ContextDict(
-    'arch_files', basedir=(opt.data_root or file_defs.arch_root))
+arch_files = pyyaks.context.ContextDict('arch_files', basedir=opt.data_root)
 arch_files.update(file_defs.arch_files)
 
 with Ska.File.chdir(arch_files['rootdir'].abs):

--- a/update_archive.py
+++ b/update_archive.py
@@ -91,10 +91,10 @@ if opt.create:
 
 ft = fetch.ft
 msid_files = pyyaks.context.ContextDict('update_archive.msid_files',
-                                        basedir=(opt.data_root or file_defs.msid_root))
+                                        basedir=opt.data_root)
 msid_files.update(file_defs.msid_files)
 arch_files = pyyaks.context.ContextDict('update_archive.arch_files',
-                                        basedir=(opt.data_root or file_defs.arch_root))
+                                        basedir=opt.data_root)
 arch_files.update(file_defs.arch_files)
 
 # Set up fetch so it will first try to read from opt.data_root if that is
@@ -529,7 +529,7 @@ def update_archive(filetype):
         if not os.path.exists(dirname):
             os.makedirs(dirname)
     else:
-        tmpdir = Ska.File.TempDir(dir=file_defs.arch_root)
+        tmpdir = Ska.File.TempDir(dir=opt.data_root)
         dirname = tmpdir.name
 
     with Ska.File.chdir(dirname):


### PR DESCRIPTION
The values in `file_defs.msid_root` and `file_defs.arch_root` were mostly being ignored in `update_archive.py` and `transfer_stage.py`, except for the location of temporary directories.  Instead `opt.data_root` was always defined and was always being used.  This makes `opt.data_root` the root dir in all cases, including temp dirs.