### PR TITLE
Use correct alignment matrix for current FSS-B data

### DIFF
--- a/Ska/engarchive/add_derived.py
+++ b/Ska/engarchive/add_derived.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import re
 import os
 from pathlib import Path
 

--- a/Ska/engarchive/add_derived.py
+++ b/Ska/engarchive/add_derived.py
@@ -136,7 +136,7 @@ def main():
         colname = dp_class.__name__.upper()
         dp = dp_class()
         content = dp.content
-        if opt.content == [] or any(re.match(x + r'\d+', content) for x in opt.content):
+        if opt.content == [] or any(x == content for x in opt.content):
             dpd = content_defs.setdefault(content, {})
             dpd.setdefault('classes', {'TIME': None})
             dpd['content'] = content

--- a/Ska/engarchive/derived/pcad.py
+++ b/Ska/engarchive/derived/pcad.py
@@ -16,6 +16,27 @@ import numpy as np
 from numpy import sin, cos, tan, arctan2, sqrt, degrees, radians
 from . import base
 
+ODB_FSS_MISALIGN = np.zeros([4, 4, 3], dtype=np.float64)
+ODB_FSS_MISALIGN[1, 1, 1] = 9.999990450374580e-01
+ODB_FSS_MISALIGN[2, 1, 1] = -5.327615067743422e-07
+ODB_FSS_MISALIGN[3, 1, 1] = 1.381999959551952e-03
+ODB_FSS_MISALIGN[1, 2, 1] = 0.0
+ODB_FSS_MISALIGN[2, 2, 1] = 9.999999256947376e-01
+ODB_FSS_MISALIGN[3, 2, 1] = 3.855003493343671e-04
+ODB_FSS_MISALIGN[1, 3, 1] = -1.382000062241829e-03
+ODB_FSS_MISALIGN[2, 3, 1] = -3.854999811959735e-04
+ODB_FSS_MISALIGN[3, 3, 1] = 9.999989707322665e-01
+
+ODB_FSS_MISALIGN[1, 1, 2] = 9.999985515924564e-01
+ODB_FSS_MISALIGN[2, 1, 2] = 2.219418563716329e-06
+ODB_FSS_MISALIGN[3, 1, 2] = 1.702001193752122e-03
+ODB_FSS_MISALIGN[1, 2, 2] = 0.0
+ODB_FSS_MISALIGN[2, 2, 2] = 9.999991497861834e-01
+ODB_FSS_MISALIGN[3, 2, 2] = -1.304004183359718e-03
+ODB_FSS_MISALIGN[1, 3, 2] = -1.702002640818283e-03
+ODB_FSS_MISALIGN[2, 3, 2] = 1.304002294630222e-03
+ODB_FSS_MISALIGN[3, 3, 2] = 9.999977013798713e-01
+
 
 class DerivedParameterPcad(base.DerivedParameter):
     content_root = 'pcad'
@@ -324,21 +345,15 @@ class DP_PITCH_FSS(DerivedParameterPcad):
     def calc(self, data):
         in_fss_fov = (data['aosunprs'].vals == 'SUN ')
         data.bads = data.bads | ~in_fss_fov
+
         # rotation matrix from FSS to ACA frame
-        A_AF = np.array([[9.999990450374580e-01,
-                          0.0,
-                          -1.382000062241829e-03],
-                         [-5.327615067743422e-07,
-                          9.999999256947376e-01,
-                          -3.854999811959735e-04],
-                         [1.381999959551952e-03,
-                          3.855003493343671e-04,
-                          9.999989707322665e-01]])
+        fss_align = ODB_FSS_MISALIGN[1:4, 1:4, 2]
+
         # FSS's sun vector in FSS frame
         alpha = radians(data['aoalpang'].vals)
         beta = radians(data['aobetang'].vals)
         sun_fss = np.array([tan(beta), tan(alpha), -np.ones(len(alpha))])
-        sun_aca = A_AF.dot(sun_fss)
+        sun_aca = fss_align.dot(sun_fss)
         magnitude = sqrt((sun_aca * sun_aca).sum(axis=0))
         data.bads |= magnitude == 0.0
         magnitude[data.bads] = 1.0
@@ -456,21 +471,15 @@ class DP_ROLL_FSS(DerivedParameterPcad):
     def calc(self, data):
         in_fss_fov = (data['aosunprs'].vals == 'SUN ')
         data.bads = data.bads | ~in_fss_fov
+
         # rotation matrix from FSS to ACA frame
-        A_AF = np.array([[9.999990450374580e-01,
-                          0.0,
-                          -1.382000062241829e-03],
-                         [-5.327615067743422e-07,
-                          9.999999256947376e-01,
-                          -3.854999811959735e-04],
-                         [1.381999959551952e-03,
-                          3.855003493343671e-04,
-                          9.999989707322665e-01]])
+        fss_align = ODB_FSS_MISALIGN[1:4, 1:4, 2]
+
         # FSS's sun vector in FSS frame
         alpha = radians(data['aoalpang'].vals)
         beta = radians(data['aobetang'].vals)
         sun_fss = np.array([tan(beta), tan(alpha), -np.ones(len(alpha))])
-        sun_aca = A_AF.dot(sun_fss)
+        sun_aca = fss_align.dot(sun_fss)
         magnitude = sqrt((sun_aca * sun_aca).sum(axis=0))
         data.bads |= magnitude == 0.0
         magnitude[data.bads] = 1.0


### PR DESCRIPTION
EDIT Jan 2020: It appears that current master is still using the FSS-A alignment coefficients to generate FSS_PITCH AND FSS_ROLL derived parameters.  This PR would fix that.  From my inspection this is OK for merge, but clearly testing is needed.  Would likely want to reprocess from the time of the swap to FSS-B.

Original description: "Not completely sure what this is or where it was going without looking closer, but it was in the working state on my disk."

## Disposition

Do nothing until there is a need or FOT PCAD requests.  

After doing some initial work on this and reprocessing data from 2019:300 to 2019:320, it appears the impact of this change is to shift FSS pitch by 0.0175 deg, however the systematic (median) error is more like 0.2 deg.  So basically this is in the noise and nobody has complained (most likely for lack of usage where it matters).

https://nbviewer.jupyter.org/url/cxc.harvard.edu/mta/ASPECT/ipynb/cheta/validate-fix-fss.ipynb

## Testing

### Setup on kady in ~git/eng_archive
```
# DO NOT set ENG_ARCHIVE initially
cp -rp ~/ska/data/eng_archive/data/dp_pcad4 data/
python -m cheta.update_archive --truncate 2019:300 --content=dp_pcad4 
python -m cheta.update_archive --date-now=2019:320 --no-stats --content=DP_PCAD4
env ENG_ARCHIVE=$PWD python -m cheta.update_archive --date-now=2019:320 --no-full --content=DP_PCAD4
```
