### PR TITLE
Fix oba msids

### DIFF
--- a/NOTES.add_content
+++ b/NOTES.add_content
@@ -5,7 +5,12 @@ Log in to a machine with at least 16 Gb RAM and get into ska environment
   ssh kadi
   cd ~/git/eng_archive
   ln -s /export/tom/tmp/eng_archive data  # some local disk
+
+  # Do the following in general, but NOT if just updating stats data.
+  # Fetch ends up seeing the >= 2000 archfiles.db and it cannot fetch
+  # 1999 data properly.
   mkdir 1999; cd 1999; ln -s ../data data; cd ..
+
   ska
   export ENG_ARCHIVE=$PWD
   export CONTENT=<CONTENT>  # Upper case

--- a/Ska/engarchive/converters.py
+++ b/Ska/engarchive/converters.py
@@ -375,6 +375,22 @@ def obc4eng(dat):
                 q_index_wide = quality_index(out, msid_wide)
                 out['QUALITY'][mask, q_index] = out['QUALITY'][mask, q_index_wide]
 
+    # Fix the onboard oba average temperature calibration. This msid, 4OAVOBAT, is not measured
+    # directly, rather it is an average of all OBA thermistors and is calculated by the OBC.
+    #
+    # Since there are several minutes between the first and second patch uplinks, the calibration
+    # for this MSID will be innacurate for several updates until the second patch takes effect.
+    # The second patch time is used as the start for the new calibration for this MSID.
+    mask = out['TIME'] > patch_times['b']
+    msid = '4OAVOBAT'
+    msid_wide = '4OAVOBAT_WIDE'
+    print('Fixing MSID {}'.format(msid))
+    out[msid][mask] = out[msid_wide][mask]
+
+    q_index = quality_index(out, msid)
+    q_index_wide = quality_index(out, msid_wide)
+    out['QUALITY'][mask, q_index] = out['QUALITY'][mask, q_index_wide]
+
     return out
 
 

--- a/Ska/engarchive/converters.py
+++ b/Ska/engarchive/converters.py
@@ -350,7 +350,7 @@ def obc4eng(dat):
     # MSIDs OOBTHR<msid_num> that went to _WIDE after the patch, which was done in parts A
     # and B.
     msid_nums = {'a': '08 09 10 11 12 13 14 15 17 18 19 20 21 22 23 24 25 26 27 28 29'.split(),
-                 'b': '30 31 33 34 35 36 37 38 39 40 41 44 45 46 49 50 51 52 53 54'.split()
+                 'b': '30 31 33 34 35 36 37 38 39 40 41 44 45 46 49 50 51 52 53 54 4OAVOBAT'.split()
                  }
 
     # Convert using the baseline converter
@@ -366,30 +366,18 @@ def obc4eng(dat):
         mask = out['TIME'] > patch_times[patch]
         if np.any(mask):
             for msid_num in msid_nums[patch]:
-                msid = 'OOBTHR' + msid_num
-                msid_wide = msid + '_WIDE'
+                if '4OAVOBAT' in msid_num:
+                    msid = '4OAVOBAT'
+                    msid_wide = '4OAVOBAT_WIDE'
+                else:
+                    msid = 'OOBTHR' + msid_num
+                    msid_wide = msid + '_WIDE'
                 print('Fixing MSID {}'.format(msid))
                 out[msid][mask] = out[msid_wide][mask]
 
                 q_index = quality_index(out, msid)
                 q_index_wide = quality_index(out, msid_wide)
                 out['QUALITY'][mask, q_index] = out['QUALITY'][mask, q_index_wide]
-
-    # Fix the onboard oba average temperature calibration. This msid, 4OAVOBAT, is not measured
-    # directly, rather it is an average of all OBA thermistors and is calculated by the OBC.
-    #
-    # Since there are several minutes between the first and second patch uplinks, the calibration
-    # for this MSID will be innacurate for several updates until the second patch takes effect.
-    # The second patch time is used as the start for the new calibration for this MSID.
-    mask = out['TIME'] > patch_times['b']
-    msid = '4OAVOBAT'
-    msid_wide = '4OAVOBAT_WIDE'
-    print('Fixing MSID {}'.format(msid))
-    out[msid][mask] = out[msid_wide][mask]
-
-    q_index = quality_index(out, msid)
-    q_index_wide = quality_index(out, msid_wide)
-    out['QUALITY'][mask, q_index] = out['QUALITY'][mask, q_index_wide]
 
     return out
 

--- a/Ska/engarchive/converters.py
+++ b/Ska/engarchive/converters.py
@@ -368,10 +368,9 @@ def obc4eng(dat):
             for msid_num in msid_nums[patch]:
                 if '4OAVOBAT' in msid_num:
                     msid = '4OAVOBAT'
-                    msid_wide = '4OAVOBAT_WIDE'
                 else:
                     msid = 'OOBTHR' + msid_num
-                    msid_wide = msid + '_WIDE'
+                msid_wide = msid + '_WIDE'
                 print('Fixing MSID {}'.format(msid))
                 out[msid][mask] = out[msid_wide][mask]
 

--- a/Ska/engarchive/converters.py
+++ b/Ska/engarchive/converters.py
@@ -394,7 +394,7 @@ def tel2eng(dat):
     # 4OAVOBAT is modified by both patches since it is an average of MSIDs in both parts of the
     # patch. Use the second time value as this is when the process is complete. See obc4eng() for
     # both times and further details.
-    patch_time = DateTime('2014:342:16:32:45').secs}
+    patch_time = DateTime('2014:342:16:32:45').secs
 
     mask = out['TIME'] > patch_time
     if np.any(mask):

--- a/Ska/engarchive/derived/thermal.py
+++ b/Ska/engarchive/derived/thermal.py
@@ -446,7 +446,7 @@ class DP_OBA_AVE(DerivedParameterThermal):
         OSUM = data[self.rootparams[0]].vals
         for names in self.rootparams[1:]:
             OSUM = OSUM + data[names].vals
-        OBA_AVE = OSUM / 36
+        OBA_AVE = OSUM / 35
         return OBA_AVE
 
 

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -576,15 +576,19 @@ class MSID(object):
 
         if not hasattr(self, '_state_codes'):
             import Ska.tdb
-            states = Ska.tdb.msids[self.MSID].Tsc
-            if states is None or len(set(states['CALIBRATION_SET_NUM'])) != 1:
-                warnings.warn('MSID {} has string vals but no state codes '
-                              'or multiple calibration sets'.format(self.msid))
+            try:
+                states = Ska.tdb.msids[self.MSID].Tsc
+            except:
                 self._state_codes = None
             else:
-                states = np.sort(states.data, order='LOW_RAW_COUNT')
-                self._state_codes = [(state['LOW_RAW_COUNT'],
-                                      state['STATE_CODE']) for state in states]
+                if states is None or len(set(states['CALIBRATION_SET_NUM'])) != 1:
+                    warnings.warn('MSID {} has string vals but no state codes '
+                                  'or multiple calibration sets'.format(self.msid))
+                    self._state_codes = None
+                else:
+                    states = np.sort(states.data, order='LOW_RAW_COUNT')
+                    self._state_codes = [(state['LOW_RAW_COUNT'],
+                                          state['STATE_CODE']) for state in states]
         return self._state_codes
 
     @property

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -1622,7 +1622,8 @@ def _set_msid_files_basedir(datestart):
         if datestart < DATE2000_LO:
             # Note: don't use os.path.join because ENG_ARCHIVE and basedir must
             # use linux '/' convention but this might be running on Windows.
-            msid_files.basedir = msid_files.basedir + '/1999'
+            dirs = msid_files.basedir.split(':')
+            msid_files.basedir = ':'.join(dir_ + '/1999' for dir_ in dirs)
         yield
     finally:
         msid_files.basedir = cache_basedir

--- a/update_archive.py
+++ b/update_archive.py
@@ -347,8 +347,11 @@ def calc_stats_vals(msid, rows, indexes, interval):
     quantiles = (1, 5, 16, 50, 84, 95, 99)
     n_out = len(rows) - 1
 
+    # Check if data type is "numeric".  Boolean values count as numeric,
+    # partly for historical reasons, in that they support funcs like
+    # mean (with implicit conversion to float).
     msid_dtype = msid.vals.dtype
-    msid_is_numeric = issubclass(msid_dtype.type, np.number)
+    msid_is_numeric = issubclass(msid_dtype.type, (np.number, np.bool_))
 
     # Predeclare numpy arrays of correct type and sufficient size for accumulating results.
     out = OrderedDict()


### PR DESCRIPTION
@taldcroft 
@jeanconn 

This update includes a fix for the 4OAVOBAT telescope msid which continues to show the narrow range version of this msid where it should be reporting the wide range version after the associated patch was uplinked. This update also includes a minor fix for the DP_OBA_AVE derived parameter.
