### PR TITLE
Workaround for bug in DS L0 SIM decom of 3LDRTMEK and 3LDRTPOS

### DIFF
--- a/NOTES.add_content
+++ b/NOTES.add_content
@@ -10,6 +10,10 @@ Log in to a machine with at least 16 Gb RAM and get into ska environment
   export ENG_ARCHIVE=$PWD
   export CONTENT=<CONTENT>  # Upper case
 
+In order to use a local install of pyfits 2.3, which is *much* faster, do:
+
+  export PYTHONPATH=$PWD/local/lib/python2.7/site-packages
+
 Note that for adding new content the trick of soft links for the 1999 data is used.
 The archive update always goes to the ./data (non-1999) directory but fetch queries
 for pre-2000 data always look in 1999.  It's a little hacky but works.

--- a/Ska/engarchive/converters.py
+++ b/Ska/engarchive/converters.py
@@ -345,7 +345,6 @@ def sim_mrg(dat):
 
 
 hrc0ss = generic_converter2(MSID_TO_CXC['hrc0ss'])
-# sim_mrg = generic_converter(aliases=CXC_TO_MSID['sim_mrg'])
 
 
 def hrc0hk(dat):

--- a/Ska/engarchive/units.py
+++ b/Ska/engarchive/units.py
@@ -69,6 +69,7 @@ converters = {
     ('kPa', 'PSIA'): mult(0.145),
     ('kPa', 'TORR'): mult(7.501),
     ('mm', 'TSCSTEP'): mult(1.0 / 0.00251431530156, decimals=3),
+    ('TSCSTEP', 'mm'): mult(0.00251431530156),
     ('mm', 'FASTEP'): mm_to_FASTEP,
     ('PWM', 'PWMSTEP'): mult(16),
     }

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -33,7 +33,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (0, 36, 4, False)
+VERSION = (0, 36, 5, False)
 
 
 class SemanticVersion(object):

--- a/update_archive.py
+++ b/update_archive.py
@@ -666,16 +666,16 @@ def read_archfile(i, f, filetype, row, colnames, archfiles, db):
     logger.info('Reading (%d / %d) %s' % (i, len(archfiles), filename))
     hdus = pyfits.open(f)
     hdu = hdus[1]
+
     try:
         dat = converters.convert(hdu.data, filetype['content'])
+
     except converters.NoValidDataError:
         # When creating files allow NoValidDataError
         hdus.close()
         logger.warning('WARNING: no valid data in data file {}'.format(filename))
-        if opt.create:
-            return None, None
-        else:
-            raise
+        return None, None
+
     except converters.DataShapeError as err:
         hdus.close()
         logger.warning('WARNING: skipping file {} with bad data shape: ASCDSVER={} {}'


### PR DESCRIPTION
There is a bug in CXCDS L0 SIM decom wherein the 3LDRTMEK MSID is
incorrectly assigned (TSC and FA are reversed).  The calibration
of 3LDRTPOS from steps to mm is then also wrong because it uses
the FA conversion instead of TSC.

This function fixes 3LDRTMEK, then backs out the (incorrect) 3LDRTPOS
steps to mm conversion and re-does it correctly using the TSC conversion.
Note that 3LDRTMEK is (by virtue of the way mission operations run)
always "TSC".
