### PR TITLE
Add support for CTU dwell mode from TDB P013

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -1650,7 +1650,6 @@ def _fix_ctu_dwell_mode_bads(msid, bads):
         # Find transitions from good value to bad value.  Turn that
         # good value to bad to extend the badness by one sample.
         ok = (bads[:-1] == False) & (bads[1:] == True)
-        print(bads.dtype)
         bads[:-1][ok] = True
 
     return bads

--- a/Ska/engarchive/filetypes.dat
+++ b/Ska/engarchive/filetypes.dat
@@ -21,6 +21,8 @@ L0   CCDM      CCDM10ENG       CCDM_ENG_0{CCDM10ENG}        *.fits.gz
 L0   CCDM      CCDM11ENG       CCDM_ENG_0{CCDM11ENG}        *.fits.gz
 L0   CCDM      CCDM12ENG       CCDM_ENG_0{CCDM12ENG}        *.fits.gz
 L0   CCDM      CCDM13ENG       CCDM_ENG_0{CCDM13ENG}        *.fits.gz
+L0   CCDM      CCDM14ENG       CCDM_ENG_0{CCDM14ENG}        *.fits.gz
+L0   CCDM      CCDM15ENG       CCDM_ENG_0{CCDM15ENG}        *.fits.gz
 L0   EPHIN     EPHIN1ENG       EPHIN_ENG_0{EPHIN1ENG}       *.fits.gz
 L0   EPHIN     EPHIN2ENG       EPHIN_ENG_0{EPHIN2ENG}       *.fits.gz
 L0   EPS       EPS1ENG         EPS_ENG_0{EPS1ENG}           *.fits.gz

--- a/Ska/engarchive/tests/test_fetch.py
+++ b/Ska/engarchive/tests/test_fetch.py
@@ -359,3 +359,17 @@ def test_intervals_fetch_unit():
 
     dat = fetch_eng.Msid('tephin', '1999:350', '2000:010')
     assert np.allclose(np.mean(dat.vals), 41.646729)
+
+
+def test_ctu_dwell_telem():
+    """
+    Ensure that bad values are filtered appropriately for dwell mode telem.
+    This
+    """
+    #dat = fetch_eng.Msid('dwell01', '2015:294', '2015:295')
+    #assert np.all(dat.vals < 190)
+    #assert np.all(dat.vals > 150)
+
+    dat = fetch_eng.Msid('airu1bt', '2015:294', '2015:295')
+    assert np.all(dat.vals < -4.95)
+    assert np.all(dat.vals > -5.05)

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -33,7 +33,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (0, 36, 5, False)
+VERSION = (0, 37, None, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
During dwell mode the following MSIDs are stepped on:

4PRT5BT
4RT585T
AFLCA3BI
AIRU1BT
CSITB5V
CUSOAOVN
ECNV3V
PLAED4ET
PR1TV01T
TCYLFMZM
TOXTSUPN
ES1P5CV
ES2P5CV

Because of an issue related to the placement of the dwell mode flag, these msids get a bad value at the beginning of a dwell mode, while the dwell mode values (DWELLnn) get a bad value at the end.