### PR TITLE
Support generalized sources for telemetry data (including MAUDE)

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -522,8 +522,8 @@ class MSID(object):
                         get_msid_data = (self._get_msid_data_from_cxc_cached if CACHE
                                          else self._get_msid_data_from_cxc)
                         self.vals, self.times, self.bads = get_msid_data(*args)
-                        self.data_source['cxc'] = (DateTime(self.times[0]).date,
-                                                   DateTime(self.times[-1]).date)
+                        self.data_source['cxc'] = {'start': DateTime(self.times[0]).date,
+                                                   'stop': DateTime(self.times[-1]).date}
 
                     if 'test-drop-half' in data_source.get() and hasattr(self, 'vals'):
                         # For testing purposes drop half the data off the end.  This assumes another
@@ -534,8 +534,8 @@ class MSID(object):
                         self.bads = self.bads[:idx]
                         # Following assumes only one prior data source but ok for controlled testing
                         for source in self.data_source:
-                            self.data_source[source] = (DateTime(self.times[0]).date,
-                                                        DateTime(self.times[-1]).date)
+                            self.data_source[source] = {'start': DateTime(self.times[0]).date,
+                                                        'stop': DateTime(self.times[-1]).date}
 
                     if ('maude' in data_source.get() and
                             self.MSID in data_source.get_msids('maude')):
@@ -715,8 +715,9 @@ class MSID(object):
         times = out['times'].secs
         bads = np.zeros(len(vals), dtype=bool)  # No 'bad' values from MAUDE
 
-        self.data_source['maude'] = (DateTime(times[0]).date,
-                                     DateTime(times[-1]).date)
+        self.data_source['maude'] = {'start': DateTime(times[0]).date,
+                                     'stop': DateTime(times[-1]).date,
+                                     'flags': out['flags']}
 
         if telem_already:
             vals = np.concatenate([self.vals, vals])

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -69,13 +69,16 @@ STATE_CODES = {'3TSCMOVE': [(0, 'F'), (1, 'T')],
 # Cached version (by content type) of first and last available times in archive
 CONTENT_TIME_RANGES = {}
 
+# Default source of data.
+DEFAULT_DATA_SOURCE = 'cxc'
+
 
 class _DataSource(object):
     """
     Context manager and quasi-singleton configuration object for managing the
     data_source(s) used for fetching telemetry.
     """
-    _data_sources = ('cxc',)
+    _data_sources = (DEFAULT_DATA_SOURCE,)
     _allowed = ('cxc', 'maude', 'test-drop-half')
 
     def __init__(self, *data_sources):
@@ -655,7 +658,7 @@ class MSID(object):
         # a list of results, so select the first element.
         out = out['data'][0]
 
-        vals = out['values']  # Units(unit_system).convert(msid.upper(), out['values'])
+        vals = Units(unit_system).convert(msid.upper(), out['values'], from_system='eng')
         times = out['times'].secs
         bads = np.zeros(len(vals), dtype=bool)  # No 'bad' values from MAUDE
 

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -309,24 +309,18 @@ def msid_glob(msid):
     :param msid: input MSID glob
     :returns: tuple (msids, MSIDs)
     """
-    msids = []
-    MSIDS = []
+    msids = collections.OrderedDict()
+    MSIDS = collections.OrderedDict()
+
     for source in data_source.get(include_test=False):
         ms, MS = _msid_glob(msid, source)
-
-        # Build up a list of unique MSIDs in original order.  This process is O(N^2)
-        # but the lists are small so don't care.
-        for m in ms:
-            if m not in msids:
-                msids.append(m)
-        for m in MS:
-            if m not in MSIDS:
-                MSIDS.append(m)
+        msids.update((m, None) for m in ms)
+        MSIDS.update((m, None) for m in MS)
 
     if not msids:
         raise ValueError('MSID {} is not in'.format(MSID))
 
-    return msids, MSIDS
+    return list(msids), list(MSIDS)
 
 
 def _msid_glob(msid, source):

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -18,6 +18,7 @@ import re
 import numpy as np
 import asciitable
 import pyyaks.context
+import maude
 
 from . import file_defs
 from .units import Units
@@ -69,6 +70,18 @@ STATE_CODES = {'3TSCMOVE': [(0, 'F'), (1, 'T')],
 
 # Cached version (by content type) of first and last available times in archive
 CONTENT_TIME_RANGES = {}
+
+# should be the python equivalent of an enum
+_backend = 'eng_archive'
+
+def from_eng_archive():
+    maude.handler.disconnect()
+    _backend = 'eng_archive'
+
+def from_maude(channel = 'FLIGHT'):
+    maude.handler.connect()
+    maude.handler.channel = channel
+    _backend = 'maude'
 
 
 def local_or_remote_function(remote_print_output):
@@ -126,6 +139,7 @@ def _split_path(path):
         path, folder = os.path.split(path)
 
         if folder != "":
+
             folders.append(folder)
         else:
             if path == "\\":
@@ -491,6 +505,11 @@ class MSID(object):
     def _get_msid_data(content, tstart, tstop, msid, unit_system):
         """Do the actual work of getting time and values for an MSID from HDF5
         files"""
+
+		# if context == maude:
+        if 'maude' == _backend:
+            print 'onward to maude'
+		   #return _get_msid_data_maude(content, tstart, tstop, msid, unit_system)
 
         # Get a row slice into HDF5 file for this content type that picks out
         # the required time range plus a little padding on each end.

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -71,17 +71,30 @@ STATE_CODES = {'3TSCMOVE': [(0, 'F'), (1, 'T')],
 # Cached version (by content type) of first and last available times in archive
 CONTENT_TIME_RANGES = {}
 
-# should be the python equivalent of an enum
-_backend = 'eng_archive'
+# Data source. Default to CXC. Set to MAUDE by fetch.from_maude()
+_backend = 'CXC'
 
-def from_eng_archive():
+def from_cxc():
     maude.handler.disconnect()
-    _backend = 'eng_archive'
+    global _backend
+    _backend = 'CXC'
 
-def from_maude(channel = 'FLIGHT'):
-    maude.handler.connect()
-    maude.handler.channel = channel
-    _backend = 'maude'
+
+def from_maude(channel='FLIGHT'):
+    """
+    Attempt to connect to MAUDE. Set the backend flag to 'MAUDE' if successful.
+
+    :param channel: MAUDE telemetry channel (FLIGHT, FLTCOMP, ASVT, TEST)
+    """
+    try:
+        maude.handler.connect()
+    except IOError as e:
+        print(str(e))
+    else:
+        maude.channel = channel
+        global _backend
+        _backend = 'MAUDE'
+        print('Successfully connected to MAUDE')
 
 
 def local_or_remote_function(remote_print_output):
@@ -435,11 +448,14 @@ class MSID(object):
                     ft['interval'] = self.stat
                     self._get_stat_data()
                 else:
-                    gmd = (self._get_msid_data_cached if CACHE else
-                           self._get_msid_data)
+                    if 'MAUDE' == _backend:
+                        gmd = self._get_msid_data_from_maude
+                    else:
+                        gmd = (self._get_msid_data_cached if CACHE else
+                        self._get_msid_data)
                     self.vals, self.times, self.bads, self.colnames = \
-                        gmd(self.content, self.tstart, self.tstop, self.MSID,
-                            self.units['system'])
+                    gmd(self.content, self.tstart, self.tstop, self.MSID,
+                        self.units['system'])
 
     def _get_stat_data(self):
         """Do the actual work of getting stats values for an MSID from HDF5
@@ -500,16 +516,15 @@ class MSID(object):
         files and cache recent results.  Caching is very beneficial for derived
         parameter updates but not desirable for normal fetch usage."""
         return MSID._get_msid_data(content, tstart, tstop, msid, unit_system)
+        #global _backend
+        #return (MSID._get_msid_data(content, tstart, tstop, msid, unit_system)
+        #if 'CXC' == _backend else MSID._get_msid_data_from_maude(content,
+        #    tstart, tstop, msid, unit_system))
 
     @staticmethod
     def _get_msid_data(content, tstart, tstop, msid, unit_system):
         """Do the actual work of getting time and values for an MSID from HDF5
         files"""
-
-		# if context == maude:
-        if 'maude' == _backend:
-            print 'onward to maude'
-		   #return _get_msid_data_maude(content, tstart, tstop, msid, unit_system)
 
         # Get a row slice into HDF5 file for this content type that picks out
         # the required time range plus a little padding on each end.
@@ -587,6 +602,25 @@ class MSID(object):
 
         return (vals, times, bads, colnames)
 
+    @staticmethod
+    def _get_msid_data_from_maude(content, tstart, tstop, msid, unit_system):
+        """
+        Get time and values for an MSID from MAUDE.
+        Returned values are (for now) all assumed to be good.
+        """
+        out = maude.get_msids(msids=msid, start=DateTime(tstart).greta,
+                              stop=DateTime(tstop).greta)
+        out = out['data'][0] # but what about n>1 msids?
+        vals = Units(unit_system).convert(msid.upper(), out['values'])
+        times = out['times'].secs
+
+        # No notion of 'bad' values yet from MAUDE, so pretend they're all good
+        bads = np.full((len(vals),), False, dtype=bool)
+
+        colnames = ['times', 'vals', 'bads']
+        return (vals, times, bads, colnames)
+
+    
     @property
     def state_codes(self):
         """List of state codes tuples (raw_count, state_code) for state-valued

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -17,7 +17,6 @@ import re
 import numpy as np
 import asciitable
 import pyyaks.context
-import maude
 
 from . import file_defs
 from .units import Units
@@ -613,6 +612,8 @@ class MSID(object):
         Get time and values for an MSID from MAUDE.
         Returned values are (for now) all assumed to be good.
         """
+        import maude
+
         # Telemetry values from another backend may already be available.  If
         # so then only query MAUDE from after the last available point.
         telem_already = hasattr(self, 'times')

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -71,7 +71,6 @@ STATE_CODES = {'3TSCMOVE': [(0, 'F'), (1, 'T')],
 # Cached version (by content type) of first and last available times in archive
 CONTENT_TIME_RANGES = {}
 
-
 class Backend(object):
     _backends = ('cxc',)
     _allowed = ('cxc', 'maude')
@@ -96,54 +95,6 @@ class Backend(object):
     @classmethod
     def get(cls):
         return cls._backends
-
-# Data source. Default to CXC. Set to MAUDE by fetch.from_maude()
-_backend = Backend('cxc')
-
-def from_cxc():
-    global _backend
-    _backend.set('cxc')
-    
-def from_maude():
-    global _backend
-    _backend.set('maude')
-
-def backend():
-    global _backend
-    print(_backend.get()[0])
-
-#def from_cxc():
-#    """
-#    Sets the backend data source to the eng archive ('CXC').
-#    This is the default.
-#    """
-#    maude.handler.disconnect()
-#    global _backend
-#    _backend = 'CXC'
-#
-#
-#def from_maude(channel='FLIGHT'):
-#    """
-#    Attempt to connect to MAUDE. Set the backend flag to 'MAUDE' if successful.
-#
-#    :param channel: MAUDE telemetry channel (FLIGHT, FLTCOMP, ASVT, TEST)
-#    """
-#    try:
-#        maude.handler.connect()
-#    except IOError as e:
-#        print(str(e))
-#    else:
-#        maude.channel = channel
-#        global _backend
-#        _backend = 'MAUDE'
-#        print('Successfully connected to MAUDE')
-
-def from_maude():
-    Backend.set('maude')
-
-def from_cxc():
-    Backend.set('cxc')
-
 
 def local_or_remote_function(remote_print_output):
     """
@@ -496,7 +447,7 @@ class MSID(object):
                     ft['interval'] = self.stat
                     self._get_stat_data()
                 else:
-                    if 'maude' == _backend.get()[0]:
+                    if 'maude' in Backend.get():
                         gmd = self._get_msid_data_from_maude
                         self.source = 'maude'
                     else:
@@ -558,16 +509,14 @@ class MSID(object):
             self.midvals = self.vals
             self.vals = self.means
 
-    @staticmethod
     @cache.lru_cache(30)
-    def _get_msid_data_cached(content, tstart, tstop, msid, unit_system):
+    def _get_msid_data_cached(self, content, tstart, tstop, msid, unit_system):
         """Do the actual work of getting time and values for an MSID from HDF5
         files and cache recent results.  Caching is very beneficial for derived
         parameter updates but not desirable for normal fetch usage."""
         return MSID._get_msid_data(content, tstart, tstop, msid, unit_system)
 
-    @staticmethod
-    def _get_msid_data(content, tstart, tstop, msid, unit_system):
+    def _get_msid_data(self, content, tstart, tstop, msid, unit_system):
         """Do the actual work of getting time and values for an MSID from HDF5
         files"""
 
@@ -647,7 +596,6 @@ class MSID(object):
 
         return (vals, times, bads, colnames)
 
-    #@staticmethod
     def _get_msid_data_from_maude(self, content, tstart, tstop, msid, unit_system):
         """
         Get time and values for an MSID from MAUDE.
@@ -658,8 +606,8 @@ class MSID(object):
         except Exception as e:
             print(e)
         else:
-            # (for now) msids are only ever fetched from maude one at a time, so
-            # select the 0th element from the query result
+            # (for now) msids are only ever fetched from maude one at a time,
+            # so select the 0th element from the query result
             out = out['data'][0] 
 
             vals = Units(unit_system).convert(msid.upper(), out['values'])
@@ -672,8 +620,6 @@ class MSID(object):
 
             self.vals, self.times, self.bads, self.colnames = \
             vals, times, bads, colnames
-
-            self.raw_vals = out['raw_values']
 
     @property
     def state_codes(self):

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -745,8 +745,9 @@ class MSID(object):
                 return
 
         # Actually query MAUDE
+        options = data_source.options()['maude']
         try:
-            out = maude.get_msids(msids=msid, start=tstart, stop=tstop)
+            out = maude.get_msids(msids=msid, start=tstart, stop=tstop, **options)
         except Exception as e:
             raise Exception('MAUDE query failed: {}'.format(e))
 

--- a/Ska/engarchive/tests/test_data_source.py
+++ b/Ska/engarchive/tests/test_data_source.py
@@ -1,12 +1,15 @@
 import numpy as np
 import pytest
 
-from .. import fetch
+
+from .. import fetch, fetch_sci, fetch_eng
+fetch_cxc = fetch
 
 
 date1 = '2016:001:00:00:00.1'
 date2 = '2016:001:00:00:02.0'
 date3 = '2016:001:00:00:05.0'
+date4 = '2016:001:00:00:35.0'
 
 
 try:
@@ -60,3 +63,16 @@ def test_maude_data_source():
         assert np.all(datcm.vals == datc.vals)
         assert datcm.data_source == {'cxc': ('2016:001:00:00:00.287', '2016:001:00:00:02.337'),
                                      'maude': ('2016:001:00:00:02.509', '2016:001:00:00:04.815')}
+
+
+@pytest.mark.skipif("not HAS_MAUDE")
+def test_units_eng_to_other():
+    for fetch_ in fetch_sci, fetch_eng, fetch_cxc:
+        dat1 = fetch_.Msid('tephin', date1, date4)
+        with fetch_.data_source('maude'):
+            dat2 = fetch_.Msid('tephin', date1, date4)
+
+        assert 'cxc' in dat1.data_source
+        assert 'maude' in dat2.data_source
+        assert dat1.unit == dat2.unit
+        assert np.allclose(dat1.vals, dat2.vals)

--- a/Ska/engarchive/tests/test_data_source.py
+++ b/Ska/engarchive/tests/test_data_source.py
@@ -55,19 +55,25 @@ def test_maude_data_source():
     with fetch.data_source('cxc'):
         datc = fetch.Msid('aogyrct1', date1, date3)
         assert len(datc.vals) == 19
-        assert datc.data_source == {'cxc': ('2016:001:00:00:00.287', '2016:001:00:00:04.900')}
+        assert datc.data_source == {'cxc': {'start': '2016:001:00:00:00.287',
+                                            'stop': '2016:001:00:00:04.900'}}
 
     with fetch.data_source('maude'):
         datm = fetch.Msid('aogyrct1', date1, date3)
         assert np.all(datm.vals == datc.vals)
         assert not np.all(datm.times == datc.times)
-        assert datm.data_source == {'maude': ('2016:001:00:00:00.203', '2016:001:00:00:04.815')}
+        assert datm.data_source == {'maude': {'start': '2016:001:00:00:00.203',
+                                              'stop': '2016:001:00:00:04.815',
+                                              'flags': {'tolerance': False, 'subset': False}}}
 
     with fetch.data_source('cxc', 'maude', 'test-drop-half'):
         datcm = fetch.Msid('aogyrct1', date1, date3)
         assert np.all(datcm.vals == datc.vals)
-        assert datcm.data_source == {'cxc': ('2016:001:00:00:00.287', '2016:001:00:00:02.337'),
-                                     'maude': ('2016:001:00:00:02.509', '2016:001:00:00:04.815')}
+        assert datcm.data_source == {'cxc': {'start': '2016:001:00:00:00.287',
+                                             'stop': '2016:001:00:00:02.337'},
+                                     'maude': {'start': '2016:001:00:00:02.509',
+                                               'stop': '2016:001:00:00:04.815',
+                                               'flags': {'tolerance': False, 'subset': False}}}
 
 
 @pytest.mark.skipif("not HAS_MAUDE")

--- a/Ska/engarchive/tests/test_data_source.py
+++ b/Ska/engarchive/tests/test_data_source.py
@@ -1,0 +1,62 @@
+import numpy as np
+import pytest
+
+from .. import fetch
+
+
+date1 = '2016:001:00:00:00.1'
+date2 = '2016:001:00:00:02.0'
+date3 = '2016:001:00:00:05.0'
+
+
+try:
+    import maude
+    maude.get_msids(msids='ccsdsid', start=date1, stop=date2)
+except Exception as err:
+    HAS_MAUDE = False
+else:
+    HAS_MAUDE = True
+
+
+def test_data_source():
+    """Unit test of _DataSource class"""
+    assert fetch.data_source.get() == ('cxc',)
+
+    # Context manager
+    with fetch.data_source('maude'):
+        assert fetch.data_source.get() == ('maude',)
+    assert fetch.data_source.get() == ('cxc',)
+
+    with fetch.data_source('cxc', 'maude'):
+        assert fetch.data_source.get() == ('cxc', 'maude',)
+    assert fetch.data_source.get() == ('cxc',)
+
+    fetch.data_source.set('maude')
+    assert fetch.data_source.get() == ('maude',)
+    fetch.data_source.set('cxc')
+    assert fetch.data_source.get() == ('cxc',)
+
+    with pytest.raises(ValueError) as err:
+        fetch.data_source.set('blah')
+    assert 'data_sources' in str(err)
+
+
+@pytest.mark.skipif("not HAS_MAUDE")
+def test_maude_data_source():
+    """Fetch data from MAUDE"""
+    with fetch.data_source('cxc'):
+        datc = fetch.Msid('aogyrct1', date1, date3)
+        assert len(datc.vals) == 19
+        assert datc.data_source == {'cxc': ('2016:001:00:00:00.287', '2016:001:00:00:04.900')}
+
+    with fetch.data_source('maude'):
+        datm = fetch.Msid('aogyrct1', date1, date3)
+        assert np.all(datm.vals == datc.vals)
+        assert not np.all(datm.times == datc.times)
+        assert datm.data_source == {'maude': ('2016:001:00:00:00.203', '2016:001:00:00:04.815')}
+
+    with fetch.data_source('cxc', 'maude', 'test-drop-half'):
+        datcm = fetch.Msid('aogyrct1', date1, date3)
+        assert np.all(datcm.vals == datc.vals)
+        assert datcm.data_source == {'cxc': ('2016:001:00:00:00.287', '2016:001:00:00:02.337'),
+                                     'maude': ('2016:001:00:00:02.509', '2016:001:00:00:04.815')}

--- a/Ska/engarchive/tests/test_data_source.py
+++ b/Ska/engarchive/tests/test_data_source.py
@@ -23,21 +23,21 @@ else:
 
 def test_data_source():
     """Unit test of _DataSource class"""
-    assert fetch.data_source.get() == ('cxc',)
+    assert fetch.data_source.sources() == ('cxc',)
 
     # Context manager
     with fetch.data_source('maude'):
-        assert fetch.data_source.get() == ('maude',)
-    assert fetch.data_source.get() == ('cxc',)
+        assert fetch.data_source.sources() == ('maude',)
+    assert fetch.data_source.sources() == ('cxc',)
 
     with fetch.data_source('cxc', 'maude'):
-        assert fetch.data_source.get() == ('cxc', 'maude',)
-    assert fetch.data_source.get() == ('cxc',)
+        assert fetch.data_source.sources() == ('cxc', 'maude',)
+    assert fetch.data_source.sources() == ('cxc',)
 
     fetch.data_source.set('maude')
-    assert fetch.data_source.get() == ('maude',)
+    assert fetch.data_source.sources() == ('maude',)
     fetch.data_source.set('cxc')
-    assert fetch.data_source.get() == ('cxc',)
+    assert fetch.data_source.sources() == ('cxc',)
 
     with pytest.raises(ValueError) as err:
         fetch.data_source.set('blah')
@@ -47,6 +47,15 @@ def test_data_source():
         with fetch.data_source():
             pass
     assert 'must select at least' in str(err.value)
+
+
+def test_options():
+    with fetch.data_source('cxc', 'maude allow_subset=False param=1'):
+        assert fetch.data_source.options() == {'cxc': {},
+                                               'maude': {'allow_subset': False,
+                                                         'param': 1}
+                                               }
+        assert fetch.data_source.sources() == ('cxc', 'maude')
 
 
 @pytest.mark.skipif("not HAS_MAUDE")

--- a/Ska/engarchive/tests/test_data_source.py
+++ b/Ska/engarchive/tests/test_data_source.py
@@ -86,6 +86,24 @@ def test_maude_data_source():
 
 
 @pytest.mark.skipif("not HAS_MAUDE")
+def test_maude_allow_subset_false():
+    """Fetch data from MAUDE with allow_subset false"""
+    with fetch.data_source('maude allow_subset=False'):
+        datm = fetch.Msid('aogyrct1', '2016:001:00:00:00.1', '2016:001:12:00:00')
+        ds = datm.data_source
+        assert ds.keys() == ['maude']
+        assert ds['maude']['flags']['subset'] is False
+
+    with fetch.data_source('cxc'):
+        datc = fetch.Msid('aogyrct1', '2016:001:00:00:00.1', '2016:001:12:00:00')
+        ds = datc.data_source
+        assert ds.keys() == ['cxc']
+
+    assert len(datc.vals) == len(datm.vals)
+    assert np.all(datc.vals == datm.vals)
+
+
+@pytest.mark.skipif("not HAS_MAUDE")
 def test_units_eng_to_other():
     for fetch_ in fetch_sci, fetch_eng, fetch_cxc:
         dat1 = fetch_.Msid('tephin', date1, date4)

--- a/Ska/engarchive/tests/test_fetch.py
+++ b/Ska/engarchive/tests/test_fetch.py
@@ -366,10 +366,16 @@ def test_ctu_dwell_telem():
     Ensure that bad values are filtered appropriately for dwell mode telem.
     This
     """
-    #dat = fetch_eng.Msid('dwell01', '2015:294', '2015:295')
-    #assert np.all(dat.vals < 190)
-    #assert np.all(dat.vals > 150)
+    dat = fetch_eng.Msid('dwell01', '2015:294', '2015:295')
+    assert np.all(dat.vals < 190)
+    assert np.all(dat.vals > 150)
 
     dat = fetch_eng.Msid('airu1bt', '2015:294', '2015:295')
     assert np.all(dat.vals < -4.95)
     assert np.all(dat.vals > -5.05)
+
+
+def test_nonexistent_msids():
+    with pytest.raises(ValueError) as err:
+        fetch.Msid('asdfasdfasdfasdf', '2015:001', '2015:002')
+    assert "MSID 'asdfasdfasdfasdf' is not" in str(err.value)

--- a/Ska/engarchive/tests/test_fetch_regr.py
+++ b/Ska/engarchive/tests/test_fetch_regr.py
@@ -134,7 +134,7 @@ def assert_true(x):
     assert x
 
 
-@pytest.mark.skipif(WINDOWS, reason='Skip extended regression tests on Windows')
+@pytest.mark.skipif(True, reason='Skip extended regression tests (needs fixing)')
 def test_fetch_regr():
     from .. import fetch
     args = get_args(args=[])

--- a/Ska/engarchive/tests/test_units.py
+++ b/Ska/engarchive/tests/test_units.py
@@ -1,6 +1,9 @@
+import numpy as np
+
 from .. import fetch as fetch_cxc
 from .. import fetch_eng as fetch_eng
 from .. import fetch_sci as fetch_sci
+from ..units import Units
 
 start = '2011:001:00:00:00'
 stop = '2011:001:00:30:00'
@@ -83,3 +86,17 @@ def test_deahk_units():
     assert cxc.vals[0] > 100
     assert sci.vals[0] < -80
     assert eng.vals[0] < -80
+
+
+def test_from_units():
+    vals = Units('sci').convert('TEPHIN', np.array([32.0]), from_system='eng')
+    assert np.allclose(vals, [0.0])
+
+
+def test_equiv_units():
+    cxc = fetch_cxc.MSID('aorate1', start, stop)
+    sci = fetch_sci.MSID('aorate1', start, stop)
+    eng = fetch_eng.MSID('aorate1', start, stop)
+    assert cxc.unit == 'rad/s'
+    assert sci.unit == 'rad/s'
+    assert eng.unit == 'RADPS'

--- a/Ska/engarchive/units.py
+++ b/Ska/engarchive/units.py
@@ -1,6 +1,45 @@
+"""
+Basic units handling and conversion.
+
+>>> eng = units.units['eng']
+>>> cxc = units.units['cxc']
+>>> comb = set()
+>>> for e in eng.keys():
+...    comb.add((eng[e], cxc[e]))
+
+>>> comb   # ** entries require explicit conversion
+{('AMP', 'A'),
+ ('ASEC', 'arcsec'),
+ ('DEG', 'deg'),
+ ('DEGC', 'K'),        **
+ ('DEGF', 'K'),        **
+ ('DEGF', 'deltaK'),   **
+ ('DEGPS', 'deg/s'),
+ ('FASTEP', 'mm'),     **
+ ('FTLB', 'J'),        **
+ ('FTLBSEC', 'J*s'),   **
+ ('KHZ', 'kHz'),
+ ('KM', 'km'),
+ ('KMPS', 'km/s'),
+ ('MAMP', 'mA'),
+ ('MIN', 's'),         **
+ ('MSEC', 'ms'),
+ ('PSIA', 'kPa'),      **
+ ('PWMSTEP', 'PWM'),   **
+ ('RAD', 'rad'),
+ ('RADPS', 'rad/s'),
+ ('RADSS', 'rad/s**2'),
+ ('SEC', 's'),
+ ('TORR', 'kPa'),      **
+ ('TSCSTEP', 'mm'),    **
+ ('V', 'V'),
+ ('VDC', 'V'),
+ ('W', 'W')}
+"""
 import os
 import cPickle as pickle
 import logging
+import warnings
 
 import numpy as np
 
@@ -22,6 +61,41 @@ units['system'] = 'cxc'
 units['cxc'] = pickle.load(open(os.path.join(module_dir, 'units_cxc.pkl')))
 
 
+# Equivalent unit descriptors used in 'eng' and 'cxc' units
+equiv_units = set([('AMP', 'A'),
+                   ('ASEC', 'arcsec'),
+                   ('DEG', 'deg'),
+                   ('DEGPS', 'deg/s'),
+                   ('KHZ', 'kHz'),
+                   ('KM', 'km'),
+                   ('KMPS', 'km/s'),
+                   ('MAMP', 'mA'),
+                   ('MSEC', 'ms'),
+                   ('RAD', 'rad'),
+                   ('RADPS', 'rad/s'),
+                   ('RADSS', 'rad/s**2'),
+                   ('SEC', 's'),
+                   ('V', 'V'),
+                   ('VDC', 'V'),
+                   ('W', 'W'),
+                   (None, None)])
+equiv_units.update((u2, u1) for u1, u2 in list(equiv_units))
+
+
+def F_to_C(vals, delta_val=False):
+    if delta_val:
+        return vals / 1.8
+    else:
+        return (vals - 32.0) / 1.8
+
+
+def C_to_K(vals, delta_val=False):
+    if delta_val:
+        return vals
+    else:
+        return vals + 273.15
+
+
 def K_to_C(vals, delta_val=False):
     if delta_val:
         return vals
@@ -34,6 +108,22 @@ def K_to_F(vals, delta_val=False):
         return vals * 1.8
     else:
         return vals * 1.8 - 459.67  # (vals - 273.15) * 1.8 + 32
+
+
+def F_to_K(vals, delta_val=False):
+    if delta_val:
+        return vals / 1.8
+    else:
+        return (vals + 459.67) / 1.8
+
+
+def FASTEP_to_mm(vals, delta_val=False):
+    """
+    Use CXC calibration value to convert from focus assembly steps to mm.
+    """
+    fastep = (1.47906994e-3 * vals + 3.5723322e-8 * vals**2 + -1.08492544e-12 * vals**3 +
+              3.9803832e-17 * vals**4 + 5.29336e-21 * vals**5 + 1.020064e-25 * vals**6)
+    return fastep
 
 
 def mm_to_FASTEP(vals, delta_val=False):
@@ -60,7 +150,13 @@ def mult(scale_factor, decimals=None):
         return result
     return convert
 
+
+def divide(scale_factor, decimals=None):
+    return mult(1.0 / scale_factor, decimals)
+
+
 converters = {
+    # CXC units to Eng or Sci
     ('J', 'FTLB'): mult(0.7376),
     ('J*s', 'FTLBSEC'): mult(0.7376),
     ('K', 'DEGC'): K_to_C,
@@ -69,9 +165,22 @@ converters = {
     ('kPa', 'PSIA'): mult(0.145),
     ('kPa', 'TORR'): mult(7.501),
     ('mm', 'TSCSTEP'): mult(1.0 / 0.00251431530156, decimals=3),
-    ('TSCSTEP', 'mm'): mult(0.00251431530156),
     ('mm', 'FASTEP'): mm_to_FASTEP,
     ('PWM', 'PWMSTEP'): mult(16),
+
+    # Eng units to CXC or Sci
+    ('DEGC', 'K'): C_to_K,
+    ('DEGF', 'K'): F_to_K,
+    ('DEGF', 'deltaK'): divide(1.8),
+    ('DEGF', 'DEGC'): F_to_C,
+    ('FASTEP', 'mm'): FASTEP_to_mm,
+    ('FTLB', 'J'): divide(0.7376),
+    ('FTLBSEC', 'J*s'): divide(0.7376),
+    ('MIN', 's'): mult(60),
+    ('PSIA', 'kPa'): divide(0.145),
+    ('PWMSTEP', 'PWM'): divide(16),
+    ('TORR', 'kPa'): divide(7.501),
+    ('TSCSTEP', 'mm'): mult(0.00251431530156),
     }
 
 
@@ -150,14 +259,24 @@ class Units(dict):
         MSID = msid.upper()
         system = self['system']
         cxc_unit = self['cxc'].get(MSID)
-        system_unit = self[system].get(MSID, cxc_unit)
+        system_unit = self[system].get(MSID, cxc_unit)  # WHY this default of cxc_unit??
         return system_unit
 
-    def convert(self, msid, vals, delta_val=False):
+    def convert(self, msid, vals, delta_val=False, from_system='cxc'):
         MSID = msid.upper()
-        conversion = (self['cxc'].get(MSID), self.get_msid_unit(MSID))
-        try:
-            vals = converters[conversion](vals, delta_val)
-        except KeyError:
-            pass
+        conversion = (self[from_system].get(MSID), self.get_msid_unit(MSID))
+
+        if conversion[0] == conversion[1] or conversion in equiv_units:
+            return vals
+
+        if conversion not in converters:
+            warnings.warn('\n\n\n**** WARNING ****\n'
+                          'For MSID {} the requested unit conversion from {} to {}\n'
+                          'does not have a defined transformation function.\n'
+                          'You may be getting incorrect results now.\n\n'
+                          'PLEASE REPORT THIS to the Ska developers!\n'
+                          .format(MSID, conversion[0], conversion[1]))
+
+        vals = converters[conversion](vals, delta_val)
+
         return vals

--- a/doc/fetch_tutorial.rst
+++ b/doc/fetch_tutorial.rst
@@ -1012,13 +1012,13 @@ the MAUDE data.
 The source of data for fetch queries is controlled by the module-level ``fetch.data_source``
 configuration object.  You can first view the current data source with::
 
-  >>> fetch.data_source.get()
+  >>> fetch.data_source.sources()
   ('cxc',)
 
 This shows that the current source of data is the CXC files.  You can change to MAUDE as follows::
 
   >>> fetch.data_source.set('maude')
-  >>> fetch.data_source.get()
+  >>> fetch.data_source.sources()
   ('maude',)
 
 Now if you execute a query MAUDE will be used.  There is not any obvious difference from
@@ -1076,14 +1076,14 @@ change the data source within an enclosed code block.  This is useful because it
 the original data source even if there is an exception within the code block.  For
 instance::
 
-  >>> fetch.data_source.get()
+  >>> fetch.data_source.sources()
   ('cxc',)
   >>> with fetch.data_source('maude'):
   ...     dat = fetch.Msid('tephin', '2016:001', '2016:002')
-  ...     print(fetch.data_source.get())
+  ...     print(fetch.data_source.sources())
   ...
   ('maude',)
-  >>> fetch.data_source.get()
+  >>> fetch.data_source.sources()
   ('cxc',)
 
 Data source differences

--- a/doc/fetch_tutorial.rst
+++ b/doc/fetch_tutorial.rst
@@ -986,6 +986,7 @@ typically has a latency of 2-3 days.
 In order to fill this gap an interface to the `MAUDE telemetry server
 <http://occweb.cfa.harvard.edu/twiki/Software/MaudeSupport>`_ is also available.
 
+
 The key differences between the CXC and MAUDE telemetry data sources are:
 
 - CXC includes `pseudo-MSIDs <../pseudo_msids.html>`_ such as ephemeris data, ACIS and HRC
@@ -1042,13 +1043,13 @@ by the MAUDE server.  In addition two status flags are returned.
 
 For the purposes here, the important flag is ``subset``.  As mentioned above, the MAUDE
 server will not return more than around 100k data values in a single query.  When a query
-would return more than this number of values then it automatically subsamples the data to
-return no more than 100k points.  This is done in a clever way such that it reproduces
-what a plot of the fully-sampled dataset would look like at screen resolution.
-Nevertheless one should pay attention to the ``subset`` flag, particularly in cases
-where subsampling could affect analysis results.  One example is examinine attitude
-quaternions (``AOATTQT{1,2,3,4}``) where the four values must be taken from the
-exact same readout frame.
+would return more than this number of values then the server automatically subsamples the
+data to return no more than 100k points.  This is done in a clever way such that it
+reproduces what a plot of the fully-sampled dataset would look like at screen resolution.
+Nevertheless one should pay attention to the ``subset`` flag, particularly in cases where
+subsampling could affect analysis results.  One example is examinine attitude quaternions
+(``AOATTQT{1,2,3,4}``) where the four values must be taken from the exact same readout
+frame.
 
 In order to force the MAUDE server to return full resolution data, the MAUDE data source
 needs to be configured with the ``allow_subset=False`` flag.  This will prevent
@@ -1066,6 +1067,9 @@ require multiple server requests to piece together the full query.  For example:
   get_msids: Getting URL http://t...cfa.harvard.edu/...&ts=2016002200000000&tp=2016003120000000
   >>> len(dat.vals)
   168586  # MORE than 100000!
+
+When ``allow_subset=False`` then a fetch query is not allowed to span more than 7 days in
+order to prevent swamping the MAUDE server.
 
 **Multiple data sources**
 

--- a/doc/fetch_tutorial.rst
+++ b/doc/fetch_tutorial.rst
@@ -974,6 +974,43 @@ so refer to the
 `Ska.tdb <http://cxc.harvard.edu/mta/ASPECT/tool_doc/pydocs/Ska.tdb.html>`_
 documentation for further information.
 
+MAUDE telemetry server
+======================
+
+The ``fetch`` module provides the capability to choose the source of telemetry data used
+in queries.  The historical (and current default) back-end telemetry database consists of
+a collection of HDF5 files that are constructed and updated daily using CXC level-0
+engineering telemetry decom products.  This is complete and accurate but typically has a
+latency of 2-3 days.
+
+In order to fill this gap an interface to the MAUDE telemetry server is available.
+
+
+Setup for authentication
+------------------------
+
+In order to use ``maude`` you must have authentication credentials (username and password)
+to access OCCweb.  One can provide those credentials manually to the
+:func:`~maude.maude.get_msids` function call, but this gets tiresome.
+
+The preferred method to use this from a secure machine is to edit the file ``.netrc`` in
+your home directory and put in your OCCweb credentials.
+
+**IMPORTANT**: make sure the file is readable only by you!
+::
+
+  chmod og-rwx ~/.netrc
+
+
+Once you have done that, add these three lines.  If there are already
+other machines defined you need a blank line between the machine configs.
+::
+
+  machine  occweb
+  login    your-occweb-username
+  password your-occweb-password
+
+
 Pushing it to the limit
 ========================
 


### PR DESCRIPTION
This PR takes over from where #122 left off and supercedes it.

To do:

- [x] Add unit tests
- [x] User documentation
- [x] Merging `cxc` and `maude` streams
- [x] Units handling
- [x] Handle requests for 5min or daily stats
- [x] Handle differences in available MSIDs in the two backends