### PR TITLE
State codes only fix

### DIFF
--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -240,11 +240,13 @@ def main_loop():
         if opt.update_stats:
             for colname in colnames:
                 if opt.state_codes_only:
+                    # Check if colname has a state code in the TDB or if it is in the
+                    # special-case fetch.STATE_CODES dict (e.g. simdiag or simmrg telem).
                     try:
                         Ska.tdb.msids[colname].Tsc['STATE_CODE']
-                    except:
-                        # Either not in TDB or does not have Tsc defined
-                        continue
+                    except Exception:
+                        if not colname.upper() in fetch.STATE_CODES:
+                            continue
 
                 msid = update_stats(colname, 'daily')
                 update_stats(colname, '5min', msid)

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -33,7 +33,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (0, 41, None, False)
+VERSION = (0, 41, 1, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
Using --state-codes-only was missing the `simdiag` and `sim_mrg` MSIDs that have custom STATE_CODES defined in fetch.py.

No need to make a release for now, this only affects one-time processing that was done related to #117.