### PR TITLE
Check integrity fix post #117

### DIFF
--- a/Ska/engarchive/check_integrity.py
+++ b/Ska/engarchive/check_integrity.py
@@ -52,7 +52,7 @@ def get_options():
 
 
 def check_filetype(filetype):
-    ft['content'] = filetype['content'].lower()
+    ft['content'] = filetype.content.lower()
 
     if not os.path.exists(msid_files['archfiles'].abs):
         logger.info('No archfiles.db3 for %s - skipping' % ft['content'])

--- a/Ska/engarchive/check_integrity.py
+++ b/Ska/engarchive/check_integrity.py
@@ -14,8 +14,8 @@ import Ska.engarchive.file_defs as file_defs
 import Ska.DBI
 
 opt = None
-ft = None
-msid_files = None
+ft = fetch.ft
+msid_files = fetch.msid_files
 logger = None
 
 
@@ -52,7 +52,7 @@ def get_options():
 
 
 def check_filetype(filetype):
-    ft['content'] = filetype.content.lower()
+    ft['content'] = filetype['content'].lower()
 
     if not os.path.exists(msid_files['archfiles'].abs):
         logger.info('No archfiles.db3 for %s - skipping' % ft['content'])
@@ -134,12 +134,6 @@ def main():
     global logger
 
     opt, args = get_options()
-
-    ft = fetch.ft
-    msid_files = pyyaks.context.ContextDict('msid_files',
-                                            basedir=(opt.data_root or
-                                                     file_defs.msid_root))
-    msid_files.update(file_defs.msid_files)
 
     # Set up fetch so it will first try to read from opt.data_root if that is
     # provided as an option and exists, and if not fall back to the default of

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -33,7 +33,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (0, 41, 1, False)
+VERSION = (0, 41, 2, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
On GRETA there was a problem running check_integrity at the end of archive update.  This was due to `-data-root=/proj/sot/ska/data/eng_archive` while the fetch data root was `/proj/sot/ska/test/data/eng_archive`.  This might be related to the change in #117 in fetch of the internal basedir method, but I don't 100% understand how.

In any case the original code was done wrong and this fixes it.