### PR TITLE
Allow archive file gaps after a specified number of days

### DIFF
--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -74,6 +74,10 @@ def get_options(args=None):
     parser.add_argument("--max-gap",
                         type=float,
                         help="Maximum time gap between archive files")
+    parser.add_argument("--allow-gap-after-days",
+                        type=float,
+                        default=4,
+                        help="Allow archive file gap when file is this old (days, default=4)")
     parser.add_argument("--max-arch-files",
                         type=int,
                         default=100,
@@ -955,6 +959,13 @@ def update_msid_files(filetype, archfiles):
                            time_gap, last_archfile['filename'], archfiles_row['filename'])
             if opt.create:
                 logger.warning('       Allowing gap because of opt.create=True')
+            elif DateTime() - DateTime(archfiles_row['tstart']) > opt.allow_gap_after_days:
+                # After 4 days (by default) just let it go through because this is
+                # likely a real gap and will not be fixed by subsequent processing.
+                # This can happen after normal sun mode to SIM products.
+                logger.warning('       Allowing gap because arch file '
+                               'start is more than {} days old'
+                               .format(opt.allow_gap_after_days))
             else:
                 break
         elif time_gap < 0:

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -80,7 +80,7 @@ def get_options(args=None):
                         help="Allow archive file gap when file is this old (days, default=4)")
     parser.add_argument("--max-arch-files",
                         type=int,
-                        default=100,
+                        default=500,
                         help="Maximum number of archive files to ingest at once")
     parser.add_argument("--data-root",
                         default=".",
@@ -1094,8 +1094,7 @@ def get_archive_files(filetype):
 
     # If running on the OCC GRETA network the cwd is a staging directory that
     # could already have files.  Also used in testing.
-    # Don't return more than opt.max_arch_files files at once because of memory
-    # issues on gretasot.  This only comes up when there has been some problem or stoppage.
+    # Don't allow arbitrary arch files at once because of memory issues.
     files = sorted(glob.glob(filetype['fileglob']))
     if opt.occ or files:
         return sorted(files)[:opt.max_arch_files]

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -33,7 +33,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (3, 41, 2, False)
+VERSION = (3, 41, 3, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
Sometimes CXCDS processing puts gaps into some files that then block eng archive ingest.  For example after the day 66 NSM:
```
kadi$ grep -i warning daily.0/eng_archive.log 
2017-03-12 05:30:19,180 WARNING: found gap of 951.20 secs between archfiles simf605224159N001_a_diag0.fits.gz and simf605247152N001_a_diag0.fits.gz
2017-03-12 05:30:44,762 WARNING: found gap of 65.60 secs between archfiles simf605244134N001_coor0a.fits.gz and simf605247185N001_coor0a.fits.gz
2017-03-12 05:30:49,288 WARNING: found gap of 65.60 secs between archfiles simf605244134N001_tlm0a.fits.gz and simf605247185N001_tlm0a.fits.gz
2017-03-12 05:31:11,821 WARNING: found gap of 328.00 secs between archfiles ephinf605224257N001_hkp0.fits.gz and ephinf605247152N001_hkp0.fits.gz
```

This PR introduces a new command line parameter that specifies the maximum age of a file (NOW - tstart) beyond which a gap will be allowed.

In addition, this PR increases the maximum number of archive files that can be processed at once.  The old limit of 100 was based on processing with 2 Gb memory, while now we have at least 16 Gb.