### PR TITLE
Make remote access default if no ENG_ARCHIVE dir found

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -27,6 +27,7 @@ from .units import Units
 from . import cache
 from . import remote_access
 from .version import __version__, __git_version__
+from .file_defs import ENG_ARCHIVE
 
 from Chandra.Time import DateTime
 
@@ -36,8 +37,6 @@ UNITS = Units(system='cxc')
 # Module-level control of whether MSID.fetch will cache the last 30 results
 CACHE = False
 
-SKA = os.getenv('SKA') or '/proj/sot/ska'
-ENG_ARCHIVE = os.getenv('ENG_ARCHIVE') or SKA + '/data/eng_archive'
 IGNORE_COLNAMES = ('TIME', 'MJF', 'MNF', 'TLM_FMT')
 DIR_PATH = os.path.dirname(os.path.abspath(__file__))
 

--- a/Ska/engarchive/file_defs.py
+++ b/Ska/engarchive/file_defs.py
@@ -13,6 +13,7 @@ all MSIDs in the same content-type group (e.g. ACIS2ENG).
 import os
 
 SKA = os.environ.get('SKA') or '/proj/sot/ska'
+ENG_ARCHIVE = os.getenv('ENG_ARCHIVE') or SKA + '/data/eng_archive'
 
 # Root directories for MSID files.  msid_root is prime, others are backups.
 # NOTE: msid_root(s) used ONLY in one-off or legacy code, not in update_archive.py or

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -12,10 +12,12 @@ except ImportError:
     from IPython import parallel
 from six.moves import input
 
+from .file_defs import ENG_ARCHIVE
+
 # To use remote access, this flag should be set True (it is true by default
 # on Windows systems, but can manually be set to true on Linux systems
 # if you don't have direct access to the archive)
-access_remotely = sys.platform.startswith('win')
+access_remotely = sys.platform.startswith('win') or not os.path.exists(ENG_ARCHIVE)
 
 # Hostname (IP), username, and password for remote access to the eng archive
 hostname = None


### PR DESCRIPTION
With this PR and chimchim accessibility through VPN (and of course login credentials), it is straightforward to have eng_archive access on remote clients like Mac laptops.

Most of the changes are just a refactor of where the ENG_ARCHIVE global gets defined.