### PR TITLE
Allow using kadi as a remote data server

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -27,6 +27,7 @@ from .units import Units
 from . import cache
 from . import remote_access
 from .version import __version__, __git_version__
+from .file_defs import ENG_ARCHIVE
 
 from Chandra.Time import DateTime
 
@@ -36,8 +37,6 @@ UNITS = Units(system='cxc')
 # Module-level control of whether MSID.fetch will cache the last 30 results
 CACHE = False
 
-SKA = os.getenv('SKA') or '/proj/sot/ska'
-ENG_ARCHIVE = os.getenv('ENG_ARCHIVE') or SKA + '/data/eng_archive'
 IGNORE_COLNAMES = ('TIME', 'MJF', 'MNF', 'TLM_FMT')
 DIR_PATH = os.path.dirname(os.path.abspath(__file__))
 

--- a/Ska/engarchive/file_defs.py
+++ b/Ska/engarchive/file_defs.py
@@ -13,6 +13,7 @@ all MSIDs in the same content-type group (e.g. ACIS2ENG).
 import os
 
 SKA = os.environ.get('SKA') or '/proj/sot/ska'
+ENG_ARCHIVE = os.getenv('ENG_ARCHIVE') or SKA + '/data/eng_archive'
 
 # Root directories for MSID files.  msid_root is prime, others are backups.
 # NOTE: msid_root(s) used ONLY in one-off or legacy code, not in update_archive.py or

--- a/Ska/engarchive/lazy_dict.py
+++ b/Ska/engarchive/lazy_dict.py
@@ -16,6 +16,7 @@ class LazyDict(OrderedDict):
 
             # update() calls methods like __contains__ so need to disable loading.
             self._loading = True
+            self.clear()
             self.update(vals)
             self._loading = False
 

--- a/Ska/engarchive/lazy_dict.py
+++ b/Ska/engarchive/lazy_dict.py
@@ -1,0 +1,46 @@
+from collections import OrderedDict
+
+
+class LazyDict(OrderedDict):
+    def __init__(self, load_func, *args, **kwargs):
+        self._load_func = load_func
+        self._args = args
+        self._kwargs = kwargs
+        self._loaded = False
+        self._loading = False
+        super(LazyDict, self).__init__()
+
+    def load(self):
+        if not self._loading and not self._loaded:
+            vals = OrderedDict(self._load_func(*self._args, **self._kwargs))
+
+            # update() calls methods like __contains__ so need to disable loading.
+            self._loading = True
+            self.update(vals)
+            self._loading = False
+
+            self._loaded = True
+
+    def __getitem__(self, item):
+        self.load()
+        return super(LazyDict, self).__getitem__(item)
+
+    def __contains__(self, item):
+        self.load()
+        return super(LazyDict, self).__contains__(item)
+
+    def keys(self):
+        self.load()
+        return super(LazyDict, self).keys()
+
+    def values(self):
+        self.load()
+        return super(LazyDict, self).values()
+
+    def items(self):
+        self.load()
+        return super(LazyDict, self).items()
+
+    def __len__(self):
+        self.load()
+        return super(LazyDict, self).__len__()

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -134,10 +134,11 @@ Function to close the connection to the remote server
 
 def local_or_remote_function(remote_print_output):
     """
-    Decorator maker so that a function gets run either locally or remotely
-    depending on the state of remote_access.access_remotely.  This decorator
-    maker takes an optional remote_print_output argument that will be
-    be printed (locally) if the function is executed remotely,
+    Decorator maker so that a function gets run either locally or remotely depending on
+    the state of ``access_remotely`` (IPython parallel via SSH) and
+    ``KADI_REMOTE_ENABLED`` (kadi web server).  This decorator maker takes an optional
+    remote_print_output argument that will be be printed (locally) if the function is
+    executed remotely,
 
     For functions that are decorated using this wrapper:
 
@@ -172,7 +173,7 @@ def local_or_remote_function(remote_print_output):
                 return execute_remotely(func, *args, **kwargs)
             else:
                 if KADI_REMOTE_ENABLED:
-                    # Let the user know
+                    # Let the user know that kadi web server being used for data access
                     warnings.warn('using {} for remote data access'.format(KADI_REMOTE_URL))
                     if show_print_output and remote_print_output is not None:
                         print(remote_print_output)
@@ -180,6 +181,7 @@ def local_or_remote_function(remote_print_output):
 
                     # Set up to use the kadi web server to run function remotely
                     import requests
+                    import zlib
                     from six.moves import cPickle as pickle
                     func_info = dict(func_name=func.__name__, args=args, kwargs=kwargs)
                     data = {'func_info': pickle.dumps(func_info, protocol=0)}
@@ -194,7 +196,7 @@ def local_or_remote_function(remote_print_output):
 
                     # Try unpickling the output
                     try:
-                        out = pickle.loads(r.content)
+                        out = pickle.loads(zlib.decompress(r.content))
                     except:
                         raise ValueError('kadi remote function {} returned content that '
                                          'failed unpickling'.format(func.__name__))

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -21,7 +21,7 @@ from .file_defs import ENG_ARCHIVE
 # (via fetch) will work on a single function call.  This effectively limits the remote
 # ingest size since read speed is of order 10^7 elements / second.
 KADI_REMOTE_ENABLED = not os.path.exists(ENG_ARCHIVE)
-KADI_REMOTE_URL = 'http://localhost:8000'
+KADI_REMOTE_URL = 'http://kadi.cfa.harvard.edu'
 KADI_REMOTE_TIMEOUT = 20  # seconds
 KADI_REMOTE_MAX_ROWS = 1e7  # max rows of data
 

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -12,10 +12,12 @@ except ImportError:
     from IPython import parallel
 from six.moves import input
 
+from .file_defs import ENG_ARCHIVE
+
 # To use remote access, this flag should be set True (it is true by default
 # on Windows systems, but can manually be set to true on Linux systems
 # if you don't have direct access to the archive)
-access_remotely = sys.platform.startswith('win')
+access_remotely = sys.platform.startswith('win') or not os.path.exists(ENG_ARCHIVE)
 
 # Hostname (IP), username, and password for remote access to the eng archive
 hostname = None

--- a/Ska/engarchive/tests/test_remote.py
+++ b/Ska/engarchive/tests/test_remote.py
@@ -17,6 +17,26 @@ else:
     HAS_KADI = True
 
 
+@pytest.mark.skipif(True)
+def test_remote_chimchim():
+    """
+    Manual testing of remote access to chimchim
+
+    In [1]: from Ska.engarchive import fetch
+
+    In [2]: dat = fetch.Msid('tephin', '2008:001', '2008:002')
+    Enter your login username [aldcroft]:SOT
+    Enter your password:
+    Establishing connection to chimchim...
+
+    In [3]: %matplotlib
+    Using matplotlib backend: MacOSX
+
+    In [4]: dat.plot()
+    """
+    pass
+
+
 @contextmanager
 def remote_access_enabled():
     remote_enabled = remote_access.access_remotely

--- a/Ska/engarchive/tests/test_remote_kadi.py
+++ b/Ska/engarchive/tests/test_remote_kadi.py
@@ -60,3 +60,17 @@ def test_kadi_remote_get_time_range():
         tstart, tstop = fetch.get_time_range('aopcadmd')
 
     assert abs(tstart - 63067297) < 2
+
+
+@pytest.mark.skipif('not HAS_KADI')
+def test_kadi_remote_max_rows():
+    max_rows = remote_access.KADI_REMOTE_MAX_ROWS
+    remote_access.KADI_REMOTE_MAX_ROWS = 10
+
+    # Make sure kadi web remote stops because max rows exceeded
+    with remote_access_enabled():
+        with pytest.raises(ValueError) as err:
+            fetch.Msid('aogyrct1', '2010:001', '2010:002')
+        assert 'max rows' in str(err)
+
+    remote_access.KADI_REMOTE_MAX_ROWS = max_rows

--- a/Ska/engarchive/tests/test_remote_kadi.py
+++ b/Ska/engarchive/tests/test_remote_kadi.py
@@ -19,16 +19,16 @@ else:
 
 @contextmanager
 def remote_access_enabled():
-    remote_enabled = remote_access.KADI_REMOTE_ENABLED
+    remote_enabled = remote_access.access_remotely
     show_print = remote_access.show_print_output
 
-    remote_access.KADI_REMOTE_ENABLED = True
+    remote_access.access_remotely = True
     remote_access.show_print_output = True
     fetch.content._loaded = False  # Force remote reload of content
 
     yield
 
-    remote_access.KADI_REMOTE_ENABLED = remote_enabled
+    remote_access.access_remotely = remote_enabled
     remote_access.show_print_output = show_print
     fetch.content._loaded = False  # Force remote reload of content
 
@@ -64,8 +64,8 @@ def test_kadi_remote_get_time_range():
 
 @pytest.mark.skipif('not HAS_KADI')
 def test_kadi_remote_max_rows():
-    max_rows = remote_access.KADI_REMOTE_MAX_ROWS
-    remote_access.KADI_REMOTE_MAX_ROWS = 10
+    max_rows = remote_access.remote_max_rows
+    remote_access.remote_max_rows = 10
 
     # Make sure kadi web remote stops because max rows exceeded
     with remote_access_enabled():
@@ -73,4 +73,4 @@ def test_kadi_remote_max_rows():
             fetch.Msid('aogyrct1', '2010:001', '2010:002')
         assert 'max rows' in str(err)
 
-    remote_access.KADI_REMOTE_MAX_ROWS = max_rows
+    remote_access.remote_max_rows = max_rows

--- a/Ska/engarchive/tests/test_remote_kadi.py
+++ b/Ska/engarchive/tests/test_remote_kadi.py
@@ -1,0 +1,62 @@
+from __future__ import print_function, division, absolute_import
+
+import pytest
+import requests
+import numpy as np
+from contextlib import contextmanager
+
+from .. import remote_access
+from .. import fetch
+
+try:
+    r = requests.get('http://kadi.cfa.harvard.edu/', timeout=10)
+    assert r.status_code == 200
+except:
+    HAS_KADI = False
+else:
+    HAS_KADI = True
+
+
+@contextmanager
+def remote_access_enabled():
+    remote_enabled = remote_access.KADI_REMOTE_ENABLED
+    show_print = remote_access.show_print_output
+
+    remote_access.KADI_REMOTE_ENABLED = True
+    remote_access.show_print_output = True
+    fetch.content._loaded = False  # Force remote reload of content
+
+    yield
+
+    remote_access.KADI_REMOTE_ENABLED = remote_enabled
+    remote_access.show_print_output = show_print
+    fetch.content._loaded = False  # Force remote reload of content
+
+
+@pytest.mark.skipif('not HAS_KADI')
+def test_kadi_remote_full():
+    with remote_access_enabled():
+        dat = fetch.Msid('aogyrct1', '2010:001:12:00:00', '2010:001:12:00:03')
+
+    assert len(dat) == 12
+    assert np.all(dat.vals == [16626, 16655, 16685, 16713, 16740, 16765, 16794, 16823, 16853,
+                               16881, 16909, 16935])
+
+
+@pytest.mark.skipif('not HAS_KADI')
+def test_kadi_remote_stat():
+    with remote_access_enabled():
+        dat = fetch.Msid('aogyrct1', '2010:001:12:00:00', '2010:001:13:00:00', stat='5min')
+
+    assert len(dat) == 11
+    assert np.allclose(dat.vals, [6007.67578125, -4243.63964844, 1857.47973633, 475.9296875,
+                                  -3084.60620117, 5720.10449219, -6835.83203125, 11247.36132812,
+                                  -12012.2109375, 13886.24902344, -13762.67480469])
+
+
+@pytest.mark.skipif('not HAS_KADI')
+def test_kadi_remote_get_time_range():
+    with remote_access_enabled():
+        tstart, tstop = fetch.get_time_range('aopcadmd')
+
+    assert abs(tstart - 63067297) < 2

--- a/Ska/engarchive/web.py
+++ b/Ska/engarchive/web.py
@@ -8,6 +8,9 @@ import zlib
 def remote_func(request):
     from . import remote_access
 
+    if 'func_info' not in request.POST:
+        return HttpResponse('ping')
+
     try:
         func_info = pickle.loads(str(request.POST['func_info']))
         func = getattr(remote_access, func_info['func_name'])

--- a/Ska/engarchive/web.py
+++ b/Ska/engarchive/web.py
@@ -8,11 +8,8 @@ def remote_func(request):
     from . import remote_access
 
     func_info = pickle.loads(str(request.POST['func_info']))
-    # print(func_info)
     func = getattr(remote_access, func_info['func_name'])
     out = func(*func_info['args'], **func_info['kwargs'])
-    print("HELLO2")
-    print(out)
 
     return HttpResponse(pickle.dumps(out, protocol=-1),
                         content_type="application/octet-stream")

--- a/Ska/engarchive/web.py
+++ b/Ska/engarchive/web.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 import pickle
+import zlib
 
 
 @csrf_exempt
@@ -11,5 +12,5 @@ def remote_func(request):
     func = getattr(remote_access, func_info['func_name'])
     out = func(*func_info['args'], **func_info['kwargs'])
 
-    return HttpResponse(pickle.dumps(out, protocol=-1),
-                        content_type="application/octet-stream")
+    stream = zlib.compress(pickle.dumps(out, protocol=-1))
+    return HttpResponse(stream, content_type="application/octet-stream")

--- a/Ska/engarchive/web.py
+++ b/Ska/engarchive/web.py
@@ -8,9 +8,14 @@ import zlib
 def remote_func(request):
     from . import remote_access
 
-    func_info = pickle.loads(str(request.POST['func_info']))
-    func = getattr(remote_access, func_info['func_name'])
-    out = func(*func_info['args'], **func_info['kwargs'])
+    try:
+        func_info = pickle.loads(str(request.POST['func_info']))
+        func = getattr(remote_access, func_info['func_name'])
+        out = func(*func_info['args'], **func_info['kwargs'])
+
+    except Exception as err:
+        # Pass back any exception
+        out = err
 
     stream = zlib.compress(pickle.dumps(out, protocol=-1))
     return HttpResponse(stream, content_type="application/octet-stream")

--- a/Ska/engarchive/web.py
+++ b/Ska/engarchive/web.py
@@ -1,0 +1,18 @@
+from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+import pickle
+
+
+@csrf_exempt
+def remote_func(request):
+    from . import remote_access
+
+    func_info = pickle.loads(str(request.POST['func_info']))
+    # print(func_info)
+    func = getattr(remote_access, func_info['func_name'])
+    out = func(*func_info['args'], **func_info['kwargs'])
+    print("HELLO2")
+    print(out)
+
+    return HttpResponse(pickle.dumps(out, protocol=-1),
+                        content_type="application/octet-stream")

--- a/doc/fetch_tutorial.rst
+++ b/doc/fetch_tutorial.rst
@@ -1036,7 +1036,7 @@ the `Remote access`_ section for ways of remotely accessing these CXC archives
 if you are running on a machine that is not on either of these networks
 (e.g. your laptop).
 
-In order to provide access to the most recently availalbe telemetry,
+In order to provide access to the most recently available telemetry,
 an interface to the `MAUDE telemetry server
 <http://occweb.cfa.harvard.edu/twiki/Software/MaudeSupport>`_ is also available.
 

--- a/doc/fetch_tutorial.rst
+++ b/doc/fetch_tutorial.rst
@@ -1030,7 +1030,9 @@ The ``fetch`` module provides the capability to choose the source of telemetry d
 in queries.  The historical (and current default) source of telemetry data consists of a
 collection of HDF5 files that are constructed and updated daily using CXC level-0
 engineering telemetry decom products.  This has the bulk of commonly used telemetry but
-typically has a latency of 2-3 days.
+typically has a latency of 2-3 days.  Two production copies of this large archive (few
+hundred Gb) are available, one on the HEAD network and one on GRETA (chimchim).  See
+the `Remote access`_ section for ways of remotely accessing these archives.
 
 In order to fill this gap an interface to the `MAUDE telemetry server
 <http://occweb.cfa.harvard.edu/twiki/Software/MaudeSupport>`_ is also available.
@@ -1382,7 +1384,7 @@ Argument       Description
 ============== ======================================================
 interpolate_dt Interpolate to uniform time steps (secs, default=None)
 ============== ======================================================
-
+G
 In general different MSIDs will come down in telemetry with different sampling and time
 stamps.  Interpolation allows you to put all the MSIDs onto a common time sequence so you
 can compare them, plot one against the other, and so forth.  You can see the
@@ -1534,19 +1536,66 @@ rates to those derived on the ground using raw gyro data.
 .. image:: fetchplots/obc_rates.png
 .. image:: fetchplots/gyro_sc_rates.png
 
-Remote Windows access
+Remote access
 =====================
+
+This section shows how to access the Ska telemetry archive on a remote machine that does
+not have a local copy of the archive data files.
+
+Windows GRETA
+-------------
 
 The telemetry archive can be accessed remotely from a Windows PC, if ssh access to
 chimchim is available.  The user will be queried for ssh credentials and
 Ska.engarchive.fetch will connect with a controller running on chimchim to retrieve the
 data.  Besides the initial query for credentials (and slower speeds when fetching data, of
 course), the use of Ska.engarchive.fetch is essentially the same whether the archive is
-local or remote.  The key file
+local or remote.
+
+The key file
 `<http://donut/svn/fot/Deployment/MATLAB_Tools/Python/python_Windows_64bit/ska_remote_access.json>`_
 needs to be in the user’s Python installation folder (the folder that contains python.exe,
-libs, Doc, etc.) for this to work.
+libs, Doc, etc.) for this to work.  This is normally bundled in the GRETA Windows
+installation of Ska Python.
 
+MacOS or Linux
+--------------
+
+On a remote MacOS or Linux systems there are two ways of accessing the Ska telemetry
+archive.
+
+kadi
+^^^^^
+
+On a machine without any Ska telemetry archive files directly accessible, the default is
+to attempt to use the kadi web server (http://kadi.cfa.harvard.edu) to perform
+telemetry queries.  Normally the code looks for telemetry files in the directory
+``/proj/sot/ska/data/eng_archive`` or ``${SKA}/data/eng_archive`` where ``${SKA}`` is the
+root of the Ska installation.
+
+To explicitly enable or disable using the kadi web server, do the following commands
+*before* importing ``Ska.engarchive.fetch``::
+
+  from Ska.engarchive import remote_access
+  remote_access.USE_KADI_SERVER = True  # or False
+
+One common reason to use this idiom is for testing remote access on a platform that does
+actually have access to the archive files.  For instance to force using a local django
+test kadi server do this::
+
+  from Ska.engarchive import remote_access
+  remote_access.USE_KADI_SERVER = True
+  remote_access.KADI_REMOTE_URL = 'http://localhost:8000'
+
+chimchim
+^^^^^^^^
+
+One can use the same remote chimchim access as for Windows, assuming ssh access to
+chimchim is available.  To do so, issue the following commands *before* importing
+``Ska.engarchive.fetch``::
+
+  from Ska.engarchive import remote_access
+  remote_access.access_remotely = True
 
 To do
 ======

--- a/doc/fetch_tutorial.rst
+++ b/doc/fetch_tutorial.rst
@@ -1577,14 +1577,15 @@ To explicitly enable or disable using the kadi web server, do the following comm
 *before* importing ``Ska.engarchive.fetch``::
 
   from Ska.engarchive import remote_access
-  remote_access.USE_KADI_SERVER = True  # or False
+  remote_access.KADI_REMOTE_ENABLED = True  # or False
+  remote_access.KADI_REMOTE_TIMEOUT = 30  # seconds (default=20)
 
 One common reason to use this idiom is for testing remote access on a platform that does
 actually have access to the archive files.  For instance to force using a local django
 test kadi server do this::
 
   from Ska.engarchive import remote_access
-  remote_access.USE_KADI_SERVER = True
+  remote_access.KADI_REMOTE_ENABLED = True
   remote_access.KADI_REMOTE_URL = 'http://localhost:8000'
 
 chimchim

--- a/doc/fetch_tutorial.rst
+++ b/doc/fetch_tutorial.rst
@@ -1571,6 +1571,16 @@ find one that is available to serve telemetry.  The default is
 ``['http://kadi.cfa.harvard.edu', '131.142.113.4']`` which means to try the
 production kadi web server and then chimchim.
 
+kadi
+----
+
+On a machine without any Ska telemetry archive files directly accessible, the default is
+to use the kadi web server (http://kadi.cfa.harvard.edu) to perform telemetry
+queries.  The only requirement is that the kadi web server be visible, which
+means being VPN'd to the HEAD or GRETA networks.
+
+This option works for both Python 2 and 3.
+
 chimchim
 --------
 
@@ -1590,16 +1600,3 @@ installation of Ska Python.
 
 Note also that this option is only available if you are locally running Python
 2.7.  It does not work if you are using Python 3 on your local client.
-
-kadi
-^^^^^
-
-On a machine without any Ska telemetry archive files directly accessible, the default is
-to use the kadi web server (http://kadi.cfa.harvard.edu) to perform telemetry
-queries.  The only requirement is that the kadi web server be visible, which
-means being VPN'd to the HEAD or GRETA networks.
-
-This option works for both Python 2 and 3.
-
-
-

--- a/doc/fetch_tutorial.rst
+++ b/doc/fetch_tutorial.rst
@@ -1384,7 +1384,7 @@ Argument       Description
 ============== ======================================================
 interpolate_dt Interpolate to uniform time steps (secs, default=None)
 ============== ======================================================
-G
+
 In general different MSIDs will come down in telemetry with different sampling and time
 stamps.  Interpolation allows you to put all the MSIDs onto a common time sequence so you
 can compare them, plot one against the other, and so forth.  You can see the
@@ -1568,8 +1568,8 @@ kadi
 ^^^^^
 
 On a machine without any Ska telemetry archive files directly accessible, the default is
-to attempt to use the kadi web server (http://kadi.cfa.harvard.edu) to perform
-telemetry queries.  Normally the code looks for telemetry files in the directory
+to use the kadi web server (http://kadi.cfa.harvard.edu) to perform telemetry queries.
+Normally the code looks for telemetry files in the directory
 ``/proj/sot/ska/data/eng_archive`` or ``${SKA}/data/eng_archive`` where ``${SKA}`` is the
 root of the Ska installation.
 


### PR DESCRIPTION
This goes along with https://github.com/sot/kadi/pull/100 and needs to be installed before that update goes live to the web.

To do:
- [x] Tests
- [x] Sanity checks that query is not too large (required or nice to have??)
