### PR TITLE
Add LICENSE and license comments

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, Smithsonian Astrophysical Observatory
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Ska/__init__.py
+++ b/Ska/__init__.py
@@ -1,2 +1,3 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pkgutil
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/Ska/engarchive/__init__.py
+++ b/Ska/engarchive/__init__.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .version import __version__, __git_version__
 
 

--- a/Ska/engarchive/cache.py
+++ b/Ska/engarchive/cache.py
@@ -1,4 +1,5 @@
 ## {{{ http://code.activestate.com/recipes/498245/ (r6)
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import collections
 import functools
 import six

--- a/Ska/engarchive/check_integrity.py
+++ b/Ska/engarchive/check_integrity.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import re
 import os

--- a/Ska/engarchive/converters.py
+++ b/Ska/engarchive/converters.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division, absolute_import
 
 import logging

--- a/Ska/engarchive/derived/__init__.py
+++ b/Ska/engarchive/derived/__init__.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Derived Parameters
 ------------------

--- a/Ska/engarchive/derived/acispow.py
+++ b/Ska/engarchive/derived/acispow.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Derived parameter MSIDs related to ACIS power.
 """

--- a/Ska/engarchive/derived/base.py
+++ b/Ska/engarchive/derived/base.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division, absolute_import
 
 from Chandra.Time import DateTime

--- a/Ska/engarchive/derived/eps.py
+++ b/Ska/engarchive/derived/eps.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Derived parameter MSIDs related to EPS subsystem.
 

--- a/Ska/engarchive/derived/orbit.py
+++ b/Ska/engarchive/derived/orbit.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division, absolute_import
 
 """

--- a/Ska/engarchive/derived/pcad.py
+++ b/Ska/engarchive/derived/pcad.py
@@ -1,4 +1,5 @@
-﻿"""
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
 Derived parameter MSIDs related to PCAD subsystem.
 
 Author: A. Arvai

--- a/Ska/engarchive/derived/test.py
+++ b/Ska/engarchive/derived/test.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from . import base
 
 class DerivedParameterTest(base.DerivedParameter):

--- a/Ska/engarchive/derived/thermal.py
+++ b/Ska/engarchive/derived/thermal.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Derived parameter MSIDs related to thermal subsystems.
 """

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Fetch values from the Ska engineering telemetry archive.
 """

--- a/Ska/engarchive/fetch_eng.py
+++ b/Ska/engarchive/fetch_eng.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .fetch import *
 from . import fetch
 from .version import version as __version__

--- a/Ska/engarchive/fetch_old.py
+++ b/Ska/engarchive/fetch_old.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Compatibility with ancient plotting scripts.
 """

--- a/Ska/engarchive/fetch_sci.py
+++ b/Ska/engarchive/fetch_sci.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .fetch import *
 from . import fetch
 from .version import version as __version__

--- a/Ska/engarchive/file_defs.py
+++ b/Ska/engarchive/file_defs.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Directory and file location definitions for telemetry archive applications.
 This is to be used to define corresponding ContextDict objects.

--- a/Ska/engarchive/get_telem.py
+++ b/Ska/engarchive/get_telem.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Fetch telemetry from the Ska engineering archive.
 

--- a/Ska/engarchive/plot.py
+++ b/Ska/engarchive/plot.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division, absolute_import
 
 import numpy as np

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Settings and functions for remotely accessing an engineering archive.
 """

--- a/Ska/engarchive/tests/test_data_source.py
+++ b/Ska/engarchive/tests/test_data_source.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division, absolute_import
 
 import numpy as np

--- a/Ska/engarchive/tests/test_fetch.py
+++ b/Ska/engarchive/tests/test_fetch.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division, absolute_import
 
 from copy import deepcopy

--- a/Ska/engarchive/tests/test_fetch_regr.py
+++ b/Ska/engarchive/tests/test_fetch_regr.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
 Regression test for fetching from the Ska engineering archive.

--- a/Ska/engarchive/tests/test_intervals.py
+++ b/Ska/engarchive/tests/test_intervals.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 import pytest
 

--- a/Ska/engarchive/tests/test_orbit.py
+++ b/Ska/engarchive/tests/test_orbit.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 
 from ..derived import orbit

--- a/Ska/engarchive/tests/test_units.py
+++ b/Ska/engarchive/tests/test_units.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 
 from .. import fetch as fetch_cxc

--- a/Ska/engarchive/tests/test_units_reversed.py
+++ b/Ska/engarchive/tests/test_units_reversed.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division, absolute_import
 
 # Import in reverse order from test_units.py

--- a/Ska/engarchive/tests/test_utils.py
+++ b/Ska/engarchive/tests/test_utils.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 
 from ..utils import get_fetch_size

--- a/Ska/engarchive/transfer_stage.py
+++ b/Ska/engarchive/transfer_stage.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
 Transfer stage files from HEAD network to OCC GRETA network via ftp server lucky.

--- a/Ska/engarchive/units.py
+++ b/Ska/engarchive/units.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Basic units handling and conversion.
 

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from __future__ import print_function, division, absolute_import
 

--- a/Ska/engarchive/utils.py
+++ b/Ska/engarchive/utils.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Utilities for the engineering archive.
 """

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Version numbering for Ska.engarchive.
 

--- a/add_derived.py
+++ b/add_derived.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import re, os, sys
 import cPickle as pickle

--- a/alias_rename_files.py
+++ b/alias_rename_files.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Rename MSID, 5min and daily h5 files based on a set of MSID aliases.
 Also updates colnames.pickle and colnames_all.pickle.

--- a/check_integrity.py
+++ b/check_integrity.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Check integrity of Ska archive
 

--- a/context_def.py
+++ b/context_def.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from pyyaks.context import ContextDict
 
 # datadir = '/data/baffin3/telem_archive/data'

--- a/context_files.py
+++ b/context_files.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from pyyaks.context import ContextDict
 
 basedir = 'test'

--- a/convert_headers.py
+++ b/convert_headers.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Convert dict of archive files and associated info from headers.pickle to
 sqlite3 'archfiles' table.  This is a one-off after ingest_h5_archive.py

--- a/correlate_units.py
+++ b/correlate_units.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pickle
 
 cxcunits = pickle.load(open('cxcunits.pkl'))

--- a/dev_utils/example_interpolate.py
+++ b/dev_utils/example_interpolate.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 
 from Ska.Matplotlib import plot_cxctime

--- a/dev_utils/find_colname_diffs.py
+++ b/dev_utils/find_colname_diffs.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 import os
 import pickle

--- a/dev_utils/find_tdb_diffs.py
+++ b/dev_utils/find_tdb_diffs.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 import Ska.tdb
 

--- a/dev_utils/fix_neg_dts.py
+++ b/dev_utils/fix_neg_dts.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Fix residual overlaps within the original archive and h5 ingest.  These
 are short overlaps that for some reason were not fixed by fix_h5_ingest.py

--- a/dev_utils/fix_oba_ave.py
+++ b/dev_utils/fix_oba_ave.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Apply a scale factor of 36.0/35.0 to account for a mistake in the original specification
 of the OBC_AVE thermal derived parameter.

--- a/dev_utils/plot_safes.py
+++ b/dev_utils/plot_safes.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 def plot_pitch(event, stat=None):
     figure()
     start = DateTime(event.start)

--- a/dev_utils/print_msidfile_times.py
+++ b/dev_utils/print_msidfile_times.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Print start or start/stop times for MSID content types.
 """

--- a/dev_utils/remote.py
+++ b/dev_utils/remote.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from IPython.parallel import Client
 client = Client()
 dview = client[0]  # direct view object

--- a/dev_utils/validate_tdb_updates.py
+++ b/dev_utils/validate_tdb_updates.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
 import pickle

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,6 +10,7 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import sys
 import os

--- a/doc/examples/cmp_obc_gyro.py
+++ b/doc/examples/cmp_obc_gyro.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import Ska.engarchive.fetch as fetch
 from Ska.Matplotlib import plot_cxctime
 import Ska.Numpy

--- a/doc/fetchplots/make_interpolate.py
+++ b/doc/fetchplots/make_interpolate.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Make plots illustrating MSIDset.interpolate()
 

--- a/fetch_tutorial.py
+++ b/fetch_tutorial.py
@@ -1,5 +1,6 @@
 ## The basic process of fetching data always starts with importing the module
 ## into the python session::
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 print "Welcome to the fetch module!"
 import Ska.engarchive.fetch as fetch

--- a/find_rel_temps.py
+++ b/find_rel_temps.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pickle
 from Ska.engarchive import fetch
 

--- a/fix_bad_values.py
+++ b/fix_bad_values.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
 Fix bad values that are in the engineering archive.

--- a/fix_ingest_h5.py
+++ b/fix_ingest_h5.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Fix overlaps within the original archive and h5 ingest.  These are due to
 problems with different versioned files that cover same time range being

--- a/get_products.py
+++ b/get_products.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import tables
 import numpy as np
 import Ska.Table

--- a/ingest_fits_archive.py
+++ b/ingest_fits_archive.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import time
 import os
 import sys

--- a/ingest_h5_archive.py
+++ b/ingest_h5_archive.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import time
 import tables
 import pyfits

--- a/make_h5.py
+++ b/make_h5.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import tables
 import numpy as np
 import Ska.Table

--- a/make_qual.py
+++ b/make_qual.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Convert boolean quality vectors within each content/MSID.h5 file to an int8
 content/MSID_qual.h5 file.  This is a one-off for Matt to be able to use files

--- a/make_regr_data.py
+++ b/make_regr_data.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pdb
 
 import re, os , sys

--- a/make_resync_stage.py
+++ b/make_resync_stage.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """Create stage directory structure resync the OCC eng archive with the
 HEAD archive.

--- a/make_units_cxc.py
+++ b/make_units_cxc.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Create the default unit system as found in the CXC telemetry FITS files.
 """

--- a/make_units_eng.py
+++ b/make_units_eng.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Make a unit_system consistent with usual OCC/FOT engineering units via P009.
 """

--- a/make_units_sci.py
+++ b/make_units_sci.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Make a unit_system consistent with usual CXC Science units where all temperatures
 are in degC instead of Kelvins.  Otherwise leave the CXC units untouched.

--- a/move_fits_archive.py
+++ b/move_fits_archive.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 One-off tool to move archive files from original flat structure (everything in
 one directory per content-type) to <content>/arch/<year>/<doy>/[files] structure.

--- a/rebuild_stats/move_stats.py
+++ b/rebuild_stats/move_stats.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import sys
 import os
 import shutil

--- a/rebuild_stats/validate_stats.py
+++ b/rebuild_stats/validate_stats.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Check that the 5min and daily stats are consistent between two different
 builds of the stats archive.
 """

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand

--- a/test/compare_regr_vals.py
+++ b/test/compare_regr_vals.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import sys
 import os

--- a/test/get_regr_vals.py
+++ b/test/get_regr_vals.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import sys
 import os

--- a/test/make_plots.py
+++ b/test/make_plots.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # Make a few plots for a sanity check of test archive correctness
 # run in pylab

--- a/transfer_stage.py
+++ b/transfer_stage.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Perform file transfer functions to get files over to GRETA network.
 

--- a/update_archive.py
+++ b/update_archive.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Update the engineering archive database.  Normally this
 includes new telemetry from the CXC archive and updating

--- a/update_fits_archive.py
+++ b/update_fits_archive.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import time
 import re, os , sys
 import glob

--- a/update_h5_archive.py
+++ b/update_h5_archive.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import time
 import tables
 import numpy as np

--- a/update_h5_archive2.py
+++ b/update_h5_archive2.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import time
 import tables
 import numpy as np

--- a/update_h5_archive3.py
+++ b/update_h5_archive3.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pyfits
 import time
 import tables

--- a/validate.py
+++ b/validate.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Find gaps (positive and negative) in telemetry times.  Positive gaps are missing data
 while negative gaps are duplicate data.  The latter need to be excised (via bad quality).


### PR DESCRIPTION
@jeanconn - I'm planning to do this kind of change for all the Ska packages in skare/cfg/python_modules.cfg.  Add LICENSE.rst and put the license text in every `.py` file.  The text is always after existing comment lines starting with `#` in the file.  Do you see any problems?

```
tables3_api
ska_path
parse_cm
Chandra.Time
Chandra.ECF
Ska.arc5gl
Ska.astro
Ska.engarchive
Ska.File
Ska.ftp
Ska.Shell
Ska.Numpy
Ska.CIAO
Ska.DBI
Ska.Table
Ska.ParseCM
Ska.Matplotlib
Ska.tdb
Ska.TelemArchive
cosmocalc
Quaternion
Ska.quatutil
Ska.Sun
Chandra.Maneuver
Chandra.cmd_states
kadi
agasc
pyyaks
asciitable
pyger
Chandra.taco
Ska.report_ranges
xija
chandra_aca
chandra_models
find_attitude
mica
hopper
maude
cxotime
starcheck
testr
```

