### PR TITLE
Make update_archive.py module py3-compatible

### DIFF
--- a/Ska/engarchive/check_integrity.py
+++ b/Ska/engarchive/check_integrity.py
@@ -84,7 +84,7 @@ def check_filetype(filetype):
     for colname in colnames:
         ft['msid'] = colname
 
-        h5 = tables.openFile(msid_files['msid'].abs, mode='r')
+        h5 = tables.open_file(msid_files['msid'].abs, mode='r')
         length = len(h5.root.data)
         h5.root.data[length - 1]
         h5.close()
@@ -109,7 +109,7 @@ def check_filetype(filetype):
 
 def find_glitch():
     ft['msid'] = 'TIME'
-    h5 = tables.openFile(msid_files['msid'].abs, mode='r')
+    h5 = tables.open_file(msid_files['msid'].abs, mode='r')
     times = h5.root.data
 
     db = Ska.DBI.DBI(dbi='sqlite', server=msid_files['archfiles'].abs)

--- a/Ska/engarchive/converters.py
+++ b/Ska/engarchive/converters.py
@@ -97,6 +97,8 @@ def get_bit_array(dat, in_name, out_name, bit_index):
         mult = 1
         out_array = np.zeros(len(dat), dtype=np.uint32)  # no more than 32 bit indexes
         for bit_index in reversed(bit_indexes):
+            # Note: require casting mult and 0 to uint32 because recent versions of numpy
+            # disallow in-place adding of int64 to uint32.
             out_array += np.where(dat[in_name][:, bit_index], np.uint32(mult), np.uint32(0))
             mult *= 2
     else:

--- a/Ska/engarchive/converters.py
+++ b/Ska/engarchive/converters.py
@@ -97,7 +97,7 @@ def get_bit_array(dat, in_name, out_name, bit_index):
         mult = 1
         out_array = np.zeros(len(dat), dtype=np.uint32)  # no more than 32 bit indexes
         for bit_index in reversed(bit_indexes):
-            out_array += np.where(dat[in_name][:, bit_index], mult, 0)
+            out_array += np.where(dat[in_name][:, bit_index], np.uint32(mult), np.uint32(0))
             mult *= 2
     else:
         try:

--- a/Ska/engarchive/derived/base.py
+++ b/Ska/engarchive/derived/base.py
@@ -40,7 +40,7 @@ class DerivedParameter(object):
 
         # Translate state codes "ON" and "OFF" to 1 and 0, respectively.
         for data in dataset.values():
-            if (data.vals.dtype.name == 'string24'
+            if (data.vals.dtype.name == 'str96'
                 and set(data.vals).issubset(set(['ON ', 'OFF']))):
                 data.vals = np.where(data.vals == 'OFF', np.int8(0), np.int8(1))
                     

--- a/Ska/engarchive/transfer_stage.py
+++ b/Ska/engarchive/transfer_stage.py
@@ -92,7 +92,7 @@ def transfer_lucky_to_stage():
         logger.info('mkdir {}'.format(opt.ftp_dir))
         ftp.mkdir(opt.ftp_dir)
     ftp.cd(opt.ftp_dir)
-    for _ in range(opt.timeout / opt.sleep_time):
+    for _ in range(opt.timeout // opt.sleep_time):
         logger.info('Directory: {}'.format(ftp.ftp.getcwd()))
         logger.info('Files: {}'.format(ftp.ls()))
         files = [x for x in ftp.ls() if re.match('stage_\d+\.tar', x)]

--- a/Ska/engarchive/transfer_stage.py
+++ b/Ska/engarchive/transfer_stage.py
@@ -5,7 +5,9 @@
 Transfer stage files from HEAD network to OCC GRETA network via ftp server lucky.
 """
 
-import re, os, sys
+import re
+import os
+import sys
 import time
 import optparse
 import tarfile
@@ -26,6 +28,7 @@ logger = None
 def get_options():
     parser = optparse.OptionParser()
     parser.add_option("--data-root",
+                      default=".",
                       help="Engineering archive root directory for MSID and arch files")
     parser.add_option("--ftp-dir",
                       default='eng_archive',

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -395,6 +395,11 @@ def calc_stats_vals(msid, rows, indexes, interval):
     msid_dtype = msid.vals.dtype
     msid_is_numeric = issubclass(msid_dtype.type, (np.number, np.bool_))
 
+    # If MSID data is unicode, then for stats purposes cast back to bytes
+    # by creating the output array as a like-sized S-type array.
+    if msid_dtype.kind == 'U':
+        msid_dtype = re.sub(r'U', 'S', msid.vals.dtype.str)
+
     # Predeclare numpy arrays of correct type and sufficient size for accumulating results.
     out = OrderedDict()
     out['index'] = np.ndarray((n_out,), dtype=np.int32)

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -155,10 +155,10 @@ def create_content_dir():
     empty = set()
     if not os.path.exists(msid_files['colnames'].abs):
         with open(msid_files['colnames'].abs, 'wb') as f:
-            pickle.dump(empty, f)
+            pickle.dump(empty, f, protocol=0)
     if not os.path.exists(msid_files['colnames_all'].abs):
         with open(msid_files['colnames_all'].abs, 'wb') as f:
-            pickle.dump(empty, f)
+            pickle.dump(empty, f, protocol=0)
 
     if not os.path.exists(msid_files['archfiles'].abs):
         archfiles_def = open('archfiles_def.sql').read()
@@ -1053,12 +1053,12 @@ def update_msid_files(filetype, archfiles):
         logger.warning('WARNING: updating %s because colnames changed: %s'
                        % (msid_files['colnames'].abs, old_colnames ^ colnames))
         if not opt.dry_run:
-            pickle.dump(colnames, open(msid_files['colnames'].abs, 'wb'))
+            pickle.dump(colnames, open(msid_files['colnames'].abs, 'wb'), protocol=0)
     if colnames_all != old_colnames_all:
         logger.warning('WARNING: updating %s because colnames_all changed: %s'
                        % (msid_files['colnames_all'].abs, colnames_all ^ old_colnames_all))
         if not opt.dry_run:
-            pickle.dump(colnames_all, open(msid_files['colnames_all'].abs, 'wb'))
+            pickle.dump(colnames_all, open(msid_files['colnames_all'].abs, 'wb'), protocol=0)
 
     return archfiles_processed
 

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -798,7 +798,7 @@ def read_archfile(i, f, filetype, row, colnames, archfiles, db):
 
     # Read FITS archive file and accumulate data into dats list and header into headers dict
     logger.info('Reading (%d / %d) %s' % (i, len(archfiles), filename))
-    hdus = pyfits.open(f)
+    hdus = pyfits.open(f, character_as_bytes=True)
     hdu = hdus[1]
 
     try:

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -22,7 +22,6 @@ import pyyaks.logger
 import pyyaks.context
 import astropy.io.fits as pyfits
 import tables
-import tables3_api
 import numpy as np
 import scipy.stats.mstats
 

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -650,10 +650,10 @@ def make_h5_col_file(dats, colname):
     col = dats[-1][colname]
     h5shape = (0,) + col.shape[1:]
     h5type = tables.Atom.from_dtype(col.dtype)
-    h5.createEArray(h5.root, 'data', h5type, h5shape, title=colname,
-                    expectedrows=n_rows)
-    h5.createEArray(h5.root, 'quality', tables.BoolAtom(), (0,), title='Quality',
-                    expectedrows=n_rows)
+    h5.create_earray(h5.root, 'data', h5type, h5shape, title=colname,
+                     expectedrows=n_rows)
+    h5.create_earray(h5.root, 'quality', tables.BoolAtom(), (0,), title='Quality',
+                     expectedrows=n_rows)
     logger.verbose('WARNING: made new file {} for column {!r} shape={} with n_rows(1e6)={}'
                    .format(filename, colname, h5shape, n_rows / 1.0e6))
     h5.close()
@@ -1111,7 +1111,7 @@ def get_archive_files(filetype):
     # do not look back further than --max-lookback-time
     db = Ska.DBI.DBI(dbi='sqlite', server=msid_files['archfiles'].abs)
     vals = db.fetchone("select max(filetime) from archfiles")
-    datestart = DateTime(max(vals['max(filetime)'],
+    datestart = DateTime(max(vals['max(filetime)'] or 0.0,
                              datestop.secs - opt.max_lookback_time * 86400))
 
     # For *ephem0 the query needs to extend well into the future

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -533,8 +533,8 @@ def update_stats(colname, interval, msid=None):
                         logger.info('  Adding %d records', len(vals_stats))
                     except tables.NoSuchNodeError:
                         logger.info('  Creating table with %d records ...', len(vals_stats))
-                        stats.createTable(stats.root, 'data', vals_stats,
-                                          "{} sampling".format(interval), expectedrows=2e7)
+                        stats.create_table(stats.root, 'data', vals_stats,
+                                           "{} sampling".format(interval), expectedrows=2e7)
                     stats.root.data.flush()
             else:
                 logger.info('  No stat records within available fetched values')

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -1073,23 +1073,10 @@ def move_archive_files(filetype, archfiles):
     for f in archfiles:
         if not os.path.exists(f):
             continue
-        ft['basename'] = os.path.basename(f)
-        tstart = re.search(r'(\d+)', str(ft['basename'])).group(1)
-        datestart = DateTime(tstart).date
-        ft['year'], ft['doy'] = re.search(r'(\d\d\d\d):(\d\d\d)', datestart).groups()
 
-        archdir = arch_files['archdir'].abs
-        archfile = arch_files['archfile'].abs
-
-        if not os.path.exists(archdir):
-            os.makedirs(archdir)
-
-        if not os.path.exists(archfile):
-            logger.info('mv %s %s' % (os.path.abspath(f), archfile))
-            if not opt.dry_run:
-                if not opt.occ:
-                    shutil.copy2(f, stagedir)
-                shutil.move(f, archfile)
+        if not opt.dry_run and not opt.occ:
+            logger.info('mv %s %s' % (os.path.abspath(f), stagedir))
+            shutil.move(f, stagedir)
 
         if os.path.exists(f):
             logger.verbose('Unlinking %s' % os.path.abspath(f))

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -34,8 +34,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (3, 43, 2, False)
-
+VERSION = (3, 44, None, False)
 
 class SemanticVersion(object):
     def __init__(self, major=0, minor=None, bugfix=None, dev=False):

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -34,7 +34,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (3, 44, None, False)
+VERSION = (4, 44, None, False)
 
 class SemanticVersion(object):
     def __init__(self, major=0, minor=None, bugfix=None, dev=False):

--- a/add_derived.py
+++ b/add_derived.py
@@ -75,7 +75,7 @@ def add_colname(filename, colname):
         with open(filename, 'wb') as f:
             pickle.dump(set(), f)
 
-    colnames = pickle.load(open(filename, 'r'))
+    colnames = pickle.load(open(filename, 'rb'))
     if colname not in colnames:
         logger.info('Adding colname {} to colnames pickle {}'.format(colname, filename))
         colnames.add(colname)
@@ -102,15 +102,15 @@ def make_msid_file(colname, content, content_def):
 
     # Finally make the actual MSID data file
     filters = tables.Filters(complevel=5, complib='zlib')
-    h5 = tables.openFile(filename, mode='w', filters=filters)
+    h5 = tables.open_file(filename, mode='w', filters=filters)
 
     n_rows = int(20 * 3e7 / content_def['time_step'])
     h5shape = (0,)
     h5type = tables.Atom.from_dtype(dp_vals.dtype)
-    h5.createEArray(h5.root, 'data', h5type, h5shape, title=colname,
-                    expectedrows=n_rows)
-    h5.createEArray(h5.root, 'quality', tables.BoolAtom(), (0,), title='Quality',
-                    expectedrows=n_rows)
+    h5.create_earray(h5.root, 'data', h5type, h5shape, title=colname,
+                     expectedrows=n_rows)
+    h5.create_earray(h5.root, 'quality', tables.BoolAtom(), (0,), title='Quality',
+                     expectedrows=n_rows)
 
     logger.info('Made {} shape={} with n_rows(1e6)={}'.format(colname, h5shape, n_rows / 1.0e6))
     h5.close()

--- a/add_derived.py
+++ b/add_derived.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import re, os, sys
-import cPickle as pickle
+import re
+import os
+from six.moves import cPickle as pickle
 import optparse
 
 import tables
+import tables3_api
 from Chandra.Time import DateTime
 
 import Ska.DBI
@@ -13,9 +15,10 @@ import pyyaks.logger
 import pyyaks.context
 import numpy as np
 
-import Ska.engarchive.fetch as fetch 
+import Ska.engarchive.fetch as fetch
 import Ska.engarchive.file_defs as file_defs
 import Ska.engarchive.derived as derived
+
 
 def get_options():
     parser = optparse.OptionParser()
@@ -32,6 +35,7 @@ def get_options():
                       action='append',
                       help="Content type to process [match regex] (default = all)")
     return parser.parse_args()
+
 
 def make_archfiles_db(filename, content_def):
     # Do nothing if it is already there
@@ -56,10 +60,11 @@ def make_archfiles_db(filename, content_def):
                          tstop=tstop,
                          rowstart=0,
                          rowstop=0,
-                         startmjf=indexes[0], # really index0
+                         startmjf=indexes[0],  # really index0
                          stopmjf=indexes[-1],  # really index1
                          date=datestart.date)
     db.insert(archfiles_row, 'archfiles')
+
 
 def add_colname(filename, colname):
     """Add ``colname`` to the pickled set() in ``filename``.  Create the pickle
@@ -67,16 +72,17 @@ def add_colname(filename, colname):
     """
     if not os.path.exists(filename):
         logger.info('Creating colnames pickle {}'.format(filename))
-        with open(filename, 'w') as f:
+        with open(filename, 'wb') as f:
             pickle.dump(set(), f)
 
     colnames = pickle.load(open(filename, 'r'))
     if colname not in colnames:
         logger.info('Adding colname {} to colnames pickle {}'.format(colname, filename))
         colnames.add(colname)
-        with open(filename, 'w') as f:
+        with open(filename, 'wb') as f:
             pickle.dump(colnames, f)
-    
+
+
 def make_msid_file(colname, content, content_def):
     ft['content'] = content
     ft['msid'] = colname
@@ -97,9 +103,9 @@ def make_msid_file(colname, content, content_def):
     # Finally make the actual MSID data file
     filters = tables.Filters(complevel=5, complib='zlib')
     h5 = tables.openFile(filename, mode='w', filters=filters)
-    
+
     n_rows = int(20 * 3e7 / content_def['time_step'])
-    h5shape = (0,) 
+    h5shape = (0,)
     h5type = tables.Atom.from_dtype(dp_vals.dtype)
     h5.createEArray(h5.root, 'data', h5type, h5shape, title=colname,
                     expectedrows=n_rows)
@@ -109,6 +115,7 @@ def make_msid_file(colname, content, content_def):
     logger.info('Made {} shape={} with n_rows(1e6)={}'.format(colname, h5shape, n_rows / 1.0e6))
     h5.close()
 
+
 def main():
     global opt, ft, msid_files, logger
 
@@ -116,13 +123,13 @@ def main():
     ft = fetch.ft
     msid_files = pyyaks.context.ContextDict('add_derived.msid_files', basedir=opt.data_root)
     msid_files.update(file_defs.msid_files)
-    logger = pyyaks.logger.get_logger(name='engarchive', level=pyyaks.logger.VERBOSE, 
+    logger = pyyaks.logger.get_logger(name='engarchive', level=pyyaks.logger.VERBOSE,
                                       format="%(asctime)s %(message)s")
 
     # Get the derived parameter classes
     dp_classes = (getattr(derived, x) for x in dir(derived) if x.startswith('DP_'))
-    dp_classes = [x for x in dp_classes if hasattr(x, '__base__') and
-                                           issubclass(x, derived.DerivedParameter)]
+    dp_classes = [x for x in dp_classes
+                  if hasattr(x, '__base__') and issubclass(x, derived.DerivedParameter)]
     content_defs = {}
     for dp_class in dp_classes:
         colname = dp_class.__name__.upper()
@@ -161,4 +168,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-    

--- a/add_derived.py
+++ b/add_derived.py
@@ -7,7 +7,6 @@ from six.moves import cPickle as pickle
 import optparse
 
 import tables
-import tables3_api
 from Chandra.Time import DateTime
 
 import Ska.DBI

--- a/add_derived.py
+++ b/add_derived.py
@@ -73,14 +73,14 @@ def add_colname(filename, colname):
     if not os.path.exists(filename):
         logger.info('Creating colnames pickle {}'.format(filename))
         with open(filename, 'wb') as f:
-            pickle.dump(set(), f)
+            pickle.dump(set(), f, protocol=0)
 
     colnames = pickle.load(open(filename, 'rb'))
     if colname not in colnames:
         logger.info('Adding colname {} to colnames pickle {}'.format(colname, filename))
         colnames.add(colname)
         with open(filename, 'wb') as f:
-            pickle.dump(colnames, f)
+            pickle.dump(colnames, f, protocol=0)
 
 
 def make_msid_file(colname, content, content_def):


### PR DESCRIPTION
This updates the `update_archive.py` module so it runs on Py3 (Ska3).

Promotion plan:

- [x] Make a "ska-legacy" branch from current master to allow for cherry-picked updates going forward as needed.
- [x] Note that ska2 flight currently has 3.43.1 not 3.42.2, but that doesn't really matter.
- [x] End-to-end testing that `transfer_stage.py` and `check_integrity.py` both function as expected (run manually from git repo on HEAD and GRETA with local data dir for one content type).
- [ ] Merge PR #143, tag new version.
- [ ] Build new ska3 package for Ska.engarchive 4.44
- [ ] Update ska3-flight for Ska.engarchive 4.44
- [ ] Install on HEAD, GRETA
- [ ] Pass tests using 4.44 (`Ska.engarchive.test()`).
- [ ] Update cron job to use ska3

Testing was done with `ska_testr` using the `eng-archive-fix` branch and no diffs from flight output were found. Relevant output of the `test_make_regr_long.sh` script is:
```
Bash-10:14:47> cd eng_archive
Bash-10:14:47> 
Bash-10:14:47> # Checkout test branch, either ENG_ARCHIVE_BRANCH env var or master.
Bash-10:14:47> # Google "bash parameter expansion" for this syntax.
Bash-10:14:47> git checkout ${ENG_ARCHIVE_BRANCH:-master}
Branch py3-update set up to track remote branch py3-update from origin.
Switched to a new branch 'py3-update'
Bash-10:14:47> 
Bash-10:14:47> mkdir data
Bash-10:14:47> 
Bash-10:14:47> CONTENTS="--content=acis2eng --content=acis3eng --content=acisdeahk --content=simcoor --content=orbitephem0"
Bash-10:14:47> START="2016:100"
Bash-10:14:47> STOP="2016:105"
Bash-10:14:47> 
Bash-10:14:47> export ENG_ARCHIVE=$PWD
Bash-10:14:47> 
Bash-10:14:47> # Create full resolution data
Bash-10:14:47> echo "Creating archive for normal full resolution MSIDs..."
Creating archive for normal full resolution MSIDs...
Bash-10:14:47> ./update_archive.py --date-start $START --date-now $STOP --max-lookback-time=2 \
Bash-10:14:47-    --create --data-root=$PWD $CONTENTS
fetch: using ENG_ARCHIVE=/data/baffin/tom/git/ska_testr/outputs/2.18-r782-a39ed41_x86_64_kadi/Ska.engarchive/eng_archive for archive path
2018-05-06 10:14:52,101 Run time options: 
Namespace(allow_gap_after_days=4, content=['acis2eng', 'acis3eng', 'acisdeahk', 'simcoor', 'orbitephem0'], create=True, data_root='/data/baffin/tom/git/ska_testr/outputs/2.18-r782-a39ed41_x86_64_kadi/Ska.engarchive/eng_archive', date_now='2016:102:12:00:00.000', date_start='2016:100', dry_run=False, fix_misorders=False, log_level=None, max_arch_files=500, max_gap=None, max_lookback_time=4.0, occ=False, state_codes_only=False, truncate=None, update_full=True, update_stats=False)
2018-05-06 10:14:52,101 Update_archive file: /data/baffin/tom/git/ska_testr/outputs/2.18-r782-a39ed41_x86_64_kadi/Ska.engarchive/eng_archive/Ska/engarchive/update_archive.py
2018-05-06 10:14:52,101 Fetch module file: /data/baffin/tom/git/ska_testr/outputs/2.18-r782-a39ed41_x86_64_kadi/Ska.engarchive/eng_archive/Ska/engarchive/fetch.py
2018-05-06 10:14:52,101 
```
