### PR TITLE
Fix missing import for remote use

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -290,6 +290,7 @@ for filetype in filetypes:
 # Function to load MSID names from the files (executed remotely, if necessary)
 @local_or_remote_function("Loading MSID names from Ska eng archive server...")
 def load_msid_names(all_msid_names_files):
+    import six
     from six.moves import cPickle as pickle
     all_colnames = dict()
     for k, msid_names_file in six.iteritems(all_msid_names_files):

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -34,7 +34,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (3, 43, None, False)
+VERSION = (3, 43, 1, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
**Rationale**

From M. Baski: The 3.43 version of fetch in Ska.engarchive needs a minor fix to work via remote access (from Windows PCs).  Specifically, “import six” (or similar) needs to be added to the load_msid_names function (it reports “NameError: global name 'six' is not defined” since six has not been imported when this function runs on the server).  This will be needed for this large MATLAB release that is being tested.

**Interface impact**

None.

**Testing**

Passes unit tests for Ska and Ska3.  M. Baski did functional testing on Windows.

**Review**

Reviewed by M. Baski.

**Deployment**

This will be installed to HEAD Ska / Ska3 flight and GRETA Ska test / Ska3 flight and GRETA Ska dev after being approved.

**Backout**

The previous version can be re-installed with no trouble if a problem arises.
 