### PR TITLE
Set fetched bads array to be writeable, needed for remote access

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -762,6 +762,7 @@ class MSID(object):
             return(vals, bads)
 
         vals, bads = get_msid_data_from_server(h5_slice, _split_path(filename))
+        bads.flags['WRITEABLE'] = True  # Remote access can return a readonly bads
 
         # Filter bad times rows if needed
         if not times_all_ok:


### PR DESCRIPTION
## Rationale
Fixes #145.

I do not understand why the `bads` array is set with `WRITEABLE=False` for remote access, while the `vals` array fetched in the same context is not.  Nevertheless, this does fix the problem in my testing.

## Testing
### Functional (using Mac laptop)
- Get onto OCC VPN
- Get into the `ska` environment in the `~/anaconda` installation (not my current default `~/anaconda3`).
- Do the following for functional test (this fails without the patch):
```
>>> import Ska.engarchive.remote_access
>>> Ska.engarchive.remote_access.access_remotely = True
>>> import Ska.engarchive.fetch_eng as fetch
   ...: 
Enter hostname (or IP) of Ska server (enter to cancel):131.142.---.---
Enter your login username [aldcroft]: <user>
Enter your password: <pass>
Establishing connection to 131.142.---.---...

>>> from Ska.engarchive.tests.test_fetch import test_ctu_dwell_telem
Ska/engarchive/fetch.py
>>> test_ctu_dwell_telem()
>>> # pass
```
For reference this relies on having the remote key file `ska_remote_access.json` in `~/anaconda/envs/ska`.  One can also do the following prior to importing `fetch`:
```
>>> Ska.engarchive.remote_access.client_key_file = '<path>/ska_remote_access.json'
```

### Regression testing
Passed unit regression tests on HEAD Ska and Ska3

### Interface impact
None

### Review

- [x] Mark Baski

### Installation
Install to HEAD Ska flight, Ska3 flight and GRETA test after approval and when convenient (maybe along with another more impacting patch).  Mark B has indicated that this is not required for the pending Matlab tools release so no need for immediate install to GRETA dev.

### Back-out
Reverting to 3.43.1 is straightforward.