### PR TITLE
Update times on maude regression test for MAUDE 1.0

### DIFF
--- a/Ska/engarchive/tests/test_data_source.py
+++ b/Ska/engarchive/tests/test_data_source.py
@@ -74,8 +74,8 @@ def test_maude_data_source():
         datm = fetch.Msid('aogyrct1', date1, date3)
         assert np.all(datm.vals == datc.vals)
         assert not np.all(datm.times == datc.times)
-        assert datm.data_source == {'maude': {'start': '2016:001:00:00:00.203',
-                                              'stop': '2016:001:00:00:04.815',
+        assert datm.data_source == {'maude': {'start': '2016:001:00:00:00.287',
+                                              'stop': '2016:001:00:00:04.900',
                                               'flags': {'tolerance': False, 'subset': False}}}
 
     with fetch.data_source('cxc', 'maude', 'test-drop-half'):
@@ -83,8 +83,8 @@ def test_maude_data_source():
         assert np.all(datcm.vals == datc.vals)
         assert datcm.data_source == {'cxc': {'start': '2016:001:00:00:00.287',
                                              'stop': '2016:001:00:00:02.337'},
-                                     'maude': {'start': '2016:001:00:00:02.509',
-                                               'stop': '2016:001:00:00:04.815',
+                                     'maude': {'start': '2016:001:00:00:02.593',
+                                               'stop': '2016:001:00:00:04.900',
                                                'flags': {'tolerance': False, 'subset': False}}}
 
 

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -34,7 +34,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (3, 43, 1, False)
+VERSION = (3, 43, 2, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
Update times in regression test corresponding to changes from MAUDE 0.7.4 to MAUDE 1.0.

These are tiny timestamp changes that 

Close #148 