### PR TITLE
Fix remote data access for Ska3

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -763,16 +763,14 @@ class MSID(object):
 
         vals, bads = get_msid_data_from_server(h5_slice, _split_path(filename))
 
-        # Remote access can return arrays that don't own their data, see #150.
-        # In lieu of understanding the root cause of that, just make a fresh
-        # copy if that is the case.
+        # Remote access will return arrays that don't own their data, see #150.
+        # For an explanation see:
+        # https://ipyparallel.readthedocs.io/en/latest/details.html#non-copying-sends-and-numpy-arrays
         try:
-            bads.flags['WRITEABLE'] = True
+            bads.flags.writeable = True
+            vals.flags.writeable = True
         except ValueError:
             bads = bads.copy()
-        try:
-            vals.flags['WRITEABLE'] = True
-        except ValueError:
             vals = vals.copy()
 
         # Filter bad times rows if needed

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -762,7 +762,18 @@ class MSID(object):
             return(vals, bads)
 
         vals, bads = get_msid_data_from_server(h5_slice, _split_path(filename))
-        bads.flags['WRITEABLE'] = True  # Remote access can return a readonly bads
+
+        # Remote access can return arrays that don't own their data, see #150.
+        # In lieu of understanding the root cause of that, just make a fresh
+        # copy if that is the case.
+        try:
+            bads.flags['WRITEABLE'] = True
+        except ValueError:
+            bads = bads.copy()
+        try:
+            vals.flags['WRITEABLE'] = True
+        except ValueError:
+            vals = vals.copy()
 
         # Filter bad times rows if needed
         if not times_all_ok:

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -34,7 +34,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (4, 44, None, False)
+VERSION = (4, 44, 1, False)
 
 class SemanticVersion(object):
     def __init__(self, major=0, minor=None, bugfix=None, dev=False):


### PR DESCRIPTION
Fixes #150 

As a reminder, the appropriate ska_remote_access.json file needs to be in place.

## Testing (from git repo)
```
(ska3) neptune$ ska_version
2018.12.18-f55b6df
(ska3) neptune$ export ENG_ARCHIVE=/proj/sot/ska/data/eng_archive
(ska3) neptune$ ipython
Python 3.6.2 |Continuum Analytics, Inc.| (default, Jul 20 2017, 13:14:59) 
Type 'copyright', 'credits' or 'license' for more information
IPython 6.1.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: >>> import Ska.engarchive.remote_access
   ...: >>> Ska.engarchive.remote_access.access_remotely = True
   ...: >>> import Ska.engarchive.fetch_eng as fetch
   ...: 
Enter hostname (or IP) of Ska server (enter to cancel):131.142.xxx
Enter your login username [aldcroft]:SOT
Enter your password:
Establishing connection to 131.142.xxx...
fetch: using ENG_ARCHIVE=/proj/sot/ska/data/eng_archive for archive path

In [2]: from Ska.engarchive.tests.test_fetch import test_ctu_dwell_telem
/Users/aldcroft/git/eng_archive/Ska/engarchive/fetch.py

In [3]: test_ctu_dwell_telem()

In [4]: import Ska.engarchive

In [5]: Ska.engarchive.test()
========================================================================= test session starts =========================================================================
platform darwin -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0
rootdir: /Users/aldcroft/git/eng_archive, inifile:
plugins: remotedata-0.3.0, openfiles-0.3.0, doctestplus-0.1.3, arraydiff-0.2
collected 66 items                                                                                                                                                     

Ska/engarchive/tests/test_data_source.py .........
Ska/engarchive/tests/test_fetch.py .....................
Ska/engarchive/tests/test_fetch_regr.py s
Ska/engarchive/tests/test_intervals.py ..........
Ska/engarchive/tests/test_orbit.py .
Ska/engarchive/tests/test_units.py ...........
Ska/engarchive/tests/test_units_reversed.py ...........
Ska/engarchive/tests/test_utils.py ..

================================================================ 65 passed, 1 skipped in 84.00 seconds ================================================================
```

