### PR TITLE
Use os.pathsep instead of ':' for Windows compatibility

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -1905,8 +1905,8 @@ def _set_msid_files_basedir(datestart, msid_files=msid_files):
         if datestart < DATE2000_LO:
             # Note: don't use os.path.join because ENG_ARCHIVE and basedir must
             # use linux '/' convention but this might be running on Windows.
-            dirs = msid_files.basedir.split(':')
-            msid_files.basedir = ':'.join(dir_ + '/1999' for dir_ in dirs)
+            dirs = msid_files.basedir.split(os.pathsep)
+            msid_files.basedir = os.pathsep.join(dir_ + '/1999' for dir_ in dirs)
         yield
     finally:
         msid_files.basedir = cache_basedir


### PR DESCRIPTION
This requires https://github.com/sot/pyyaks/pull/6 to be installed to function on Windows.

I suspect that Windows was broken for queries before 2000:001 but not sure.