### PR TITLE
Fix SIM_MRG comparison bug introduced in Py3 transition

### DIFF
--- a/Ska/engarchive/converters.py
+++ b/Ska/engarchive/converters.py
@@ -373,9 +373,9 @@ def sim_mrg(dat):
 
     # Now do the fixes.  FOT mech has stated that 3LDRTMEK is always 'FA'
     # in practice.
-    bad = out['3LDRTMEK'] == 'FA '
+    bad = out['3LDRTMEK'] == b'FA '
     if np.count_nonzero(bad):
-        out['3LDRTMEK'][bad] = 'TSC'
+        out['3LDRTMEK'][bad] = b'TSC'
         pos_tsc_steps = units.converters['mm', 'FASTEP'](out['3LDRTPOS'][bad])
         out['3LDRTPOS'][bad] = units.converters['TSCSTEP', 'mm'](pos_tsc_steps)
 

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -34,7 +34,7 @@ import os
 ### SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (4, 44, 1, False)
+VERSION = (4, 44, 2, False)
 
 class SemanticVersion(object):
     def __init__(self, major=0, minor=None, bugfix=None, dev=False):


### PR DESCRIPTION
The data array values at this point in the code are bytestrings, not unicode so the equality test was failing.  The MSIDs 3LDRTMEK and 3LDRTPOS after around 2018:336 were incorrect.  This fix restores the correct functionality in this function which was introduced in #121.

Testing:
- Truncated a local copy of the archive from 2018:280.  The data reprocessing to catch up after the safe mode was done using this code and was also impacted.  See also #154.
- Updated the local copy using the new code.
- Confirmed expected values by comparing with MAUDE queries (notice the red entirely overlaps blue)
```
In [1]: impska
In [2]: dat = fetch.Msid('3ldrtpos', '2018:334', '2018:339')
In [3]: fetch.data_source.set('maude')
In [4]: datm = fetch.Msid('3ldrtpos', '2018:334', '2018:339')
In [5]: dat.plot()
In [6]: datm.plot(color='r')
```
![image](https://user-images.githubusercontent.com/348089/52301199-e3aa6780-2957-11e9-9049-4f5b971ebeeb.png)
