### PR TITLE
Fixes and test improvements for Windows

### DIFF
--- a/Ska/engarchive/tests/test_sync.py
+++ b/Ska/engarchive/tests/test_sync.py
@@ -9,9 +9,9 @@ import Ska.DBI
 import tables
 from Chandra.Time import DateTime
 
-from cheta import fetch
-from cheta import update_client_archive, update_server_sync
-from cheta.utils import STATS_DT, set_fetch_basedir
+from .. import fetch
+from .. import update_client_archive, update_server_sync
+from ..utils import STATS_DT, set_fetch_basedir
 
 # Covers safe mode and IRU swap activities around 2018:283.  This is a time
 # with rarely-seen telemetry.
@@ -99,7 +99,7 @@ def make_sync_repo(outdir, content):
 
 
 def make_stub_archfiles(date, basedir_ref, basedir_stub):
-    archfiles_def = open('cheta/archfiles_def.sql').read()
+    archfiles_def = (Path(fetch.__file__).parent / 'archfiles_def.sql').read_text()
 
     with set_fetch_basedir(basedir_ref):
         filename = fetch.msid_files['archfiles'].abs
@@ -339,6 +339,7 @@ def check_content(outdir, content, msids=None):
 
 @pytest.mark.parametrize('content', list(CONTENTS))
 def test_sync(tmpdir, content):
+    print(f'CWD = {os.getcwd()}')
     check_content(tmpdir, content)
 
     # Clean up if test successful (otherwise check_content raises)

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -119,7 +119,7 @@ def sync_full_archive(opt, msid_files, logger, content):
     logger.info(f'Processing full data for {content}')
 
     # Read the index file to know what is available for new data
-    index_file = sync_files['index'].rel
+    index_file = sync_files['index'].abs
     with get_readable(opt.data_root, opt.is_url, index_file) as (index_input, uri):
         if index_input is None:
             # If index_file is not found then get_readable returns None
@@ -152,7 +152,7 @@ def sync_full_archive(opt, msid_files, logger, content):
 
         # File names like sync/acis4eng/2019-07-08T1150z/full.npz
         ft['date_id'] = date_id
-        datafile = sync_files['data'].rel
+        datafile = sync_files['data'].abs
 
         # Read the file with all the MSID data as a hash with keys like {msid}.data
         # {msid}.quality etc, plus an `archive` key with the table of corresponding
@@ -220,7 +220,7 @@ def sync_stat_archive(opt, msid_files, logger, content, stat):
     ft['content'] = content
     ft['interval'] = stat
 
-    stats_dir = Path(msid_files['statsdir'].rel)
+    stats_dir = Path(msid_files['statsdir'].abs)
     if not stats_dir.exists():
         logger.debug(f'Skipping {stat} data for {content}: no directory')
         return
@@ -230,7 +230,7 @@ def sync_stat_archive(opt, msid_files, logger, content, stat):
 
     # Read the index file to know what is available for new data
     # TODO: factor this out
-    index_file = sync_files['index'].rel
+    index_file = sync_files['index'].abs
     with get_readable(opt.data_root, opt.is_url, index_file) as (index_input, uri):
         if index_input is None:
             # If index_file is not found then get_readable returns None
@@ -266,7 +266,7 @@ def sync_stat_archive(opt, msid_files, logger, content, stat):
 
         # File names like sync/acis4eng/2019-07-08T1150z/5min.npz
         ft['date_id'] = date_id
-        datafile = sync_files['data'].rel
+        datafile = sync_files['data'].abs
 
         # Read the file with all the MSID data as a hash with keys {msid}.data
         # {msid}.row0, {msid}.row1
@@ -280,7 +280,7 @@ def sync_stat_archive(opt, msid_files, logger, content, stat):
 
         for msid in msids:
             fetch.ft['msid'] = msid
-            stat_file = msid_files['stats'].rel
+            stat_file = msid_files['stats'].abs
             if os.path.exists(stat_file):
                 append_stat_col(dat, stat_file, msid, date_id, opt, logger)
 
@@ -344,7 +344,7 @@ def get_last_date_id(msid_files, msids, stat, logger):
     :param logger:
     :return:
     """
-    last_date_id_file = msid_files['last_date_id'].rel
+    last_date_id_file = msid_files['last_date_id'].abs
 
     if Path(last_date_id_file).exists():
         logger.verbose(f'Reading {last_date_id_file} to get last update time')


### PR DESCRIPTION
This makes some fixes that will hopefully help tests to pass on Windows, in part by making all ContextValue filepaths be absolute, not relative.

It also ensures that intra-package imports in sync-related modules are all relative imports instead of absolute.