### PR TITLE
Improve remote access and fix sync to work on FOT Windows

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -27,6 +27,7 @@ from . import file_defs
 from .units import Units
 from . import cache
 from . import remote_access
+from .remote_access import ENG_ARCHIVE
 from .version import __version__, __git_version__
 
 from Chandra.Time import DateTime
@@ -37,8 +38,6 @@ UNITS = Units(system='cxc')
 # Module-level control of whether MSID.fetch will cache the last 30 results
 CACHE = False
 
-SKA = os.getenv('SKA')
-ENG_ARCHIVE = os.getenv('ENG_ARCHIVE') or os.path.join(SKA, 'data', 'eng_archive')
 IGNORE_COLNAMES = ('TIME', 'MJF', 'MNF', 'TLM_FMT')
 DIR_PATH = os.path.dirname(os.path.abspath(__file__))
 

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -316,14 +316,10 @@ class NullHandler(logging.Handler):
     def emit(self, record):
         pass
 
+
 logger = logging.getLogger('Ska.engarchive.fetch')
 logger.addHandler(NullHandler())
 logger.propagate = False
-
-# Warn the user if ENG_ARCHIVE is set such that the data path is non-standard
-if os.getenv('ENG_ARCHIVE'):
-    print('fetch: using ENG_ARCHIVE={} for archive path'
-          .format(os.getenv('ENG_ARCHIVE')))
 
 
 def get_units():

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -15,8 +15,13 @@ from six.moves import input
 
 # To use remote access, this flag should be set True (it is true by default
 # on Windows systems, but can manually be set to true on Linux systems
-# if you don't have direct access to the archive)
-access_remotely = sys.platform.startswith('win')
+# if you don't have direct access to the archive).  The environment variable
+# SKA_ACCESS_REMOTELY can be set to always disable remote access.
+if 'SKA_ACCESS_REMOTELY' in os.environ:
+    import ast
+    access_remotely = ast.literal_eval(os.environ['SKA_ACCESS_REMOTELY'])
+else:
+    access_remotely = sys.platform.startswith('win')
 
 # Hostname (IP), username, and password for remote access to the eng archive
 hostname = None

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -16,7 +16,7 @@ except ImportError:
 from six.moves import input
 
 
-def get_data_access_info():
+def get_data_access_info(is_windows=sys.platform.startswith('win')):
     """
     Determine path to eng archive data and whether to access data remotely.
 
@@ -38,8 +38,9 @@ def get_data_access_info():
     # - Remote access defaults to False on non-Windows systems.
 
     # First check if there is a local data archive
-    if eng_archive:
+    if eng_archive is not None:
         eng_data_dir = Path(eng_archive) / 'data'
+        eng_archive = str(Path(eng_archive).absolute())
         has_ska_data = eng_data_dir.exists()
     else:
         has_ska_data = False
@@ -49,7 +50,7 @@ def get_data_access_info():
         import ast
         ska_access_remotely = ast.literal_eval(os.environ['SKA_ACCESS_REMOTELY'])
     else:
-        ska_access_remotely = False if has_ska_data else sys.platform.startswith('win')
+        ska_access_remotely = False if has_ska_data else is_windows
 
     if not ska_access_remotely and not has_ska_data:
         if eng_archive is None:

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -34,9 +34,10 @@ def get_data_access_info(is_windows=sys.platform.startswith('win')):
     # moot (and SKA is not required to be defined), so just make sure this bit runs without
     # failing.
     ska = os.getenv('SKA')
+    ska_eng_path = None if (ska is None) else os.path.join(ska, 'data', 'eng_archive')
     eng_archive = os.getenv('ENG_ARCHIVE')
-    if eng_archive is None and ska is not None:
-        eng_archive = os.path.join(ska, 'data', 'eng_archive')
+    if eng_archive is None and ska_eng_path is not None:
+        eng_archive = ska_eng_path
 
     # Remote access is controlled as follows:
     # - The environment variable SKA_ACCESS_REMOTELY can be set to "False" or "True"
@@ -69,7 +70,13 @@ def get_data_access_info(is_windows=sys.platform.startswith('win')):
         # If accessing remotely, then hardwire eng_archive to the linux path where
         # the data are stored on the server.  This prevents a local SKA repository
         # from getting used on the remote server.
-        eng_archive = '/proj/sot/ska/data/eng_archive'
+        ska_eng_path = '/proj/sot/ska/data/eng_archive'
+        eng_archive = ska_eng_path
+
+    # Warn the user if eng data path is non-standard.  Note: if no SKA then
+    # any path is non-standard.
+    if eng_archive != ska_eng_path:
+        print(f'fetch: using ENG_ARCHIVE={eng_archive} for archive path')
 
     return eng_archive, ska_access_remotely
 

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -16,7 +16,8 @@ from six.moves import input
 # To use remote access, this flag should be set True (it is true by default
 # on Windows systems, but can manually be set to true on Linux systems
 # if you don't have direct access to the archive).  The environment variable
-# SKA_ACCESS_REMOTELY can be set to always disable remote access.
+# SKA_ACCESS_REMOTELY can be set to "False" or "True"  to control remote
+# access explicitly.
 if 'SKA_ACCESS_REMOTELY' in os.environ:
     import ast
     access_remotely = ast.literal_eval(os.environ['SKA_ACCESS_REMOTELY'])

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -130,7 +130,7 @@ def establish_connection():
         try:
             _remote_client = parallel.Client(client_key_file,
                                              sshserver=f'{username}@{hostname}',
-                                             password=password, timeout=30, debug=True)
+                                             password=password)
         except Exception:
             raise
             print('Error connecting to server ', hostname, ': ', sys.exc_info()[0])

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -15,42 +15,55 @@ except ImportError:
     from IPython import parallel
 from six.moves import input
 
-# Define the path to eng archive data (if possible), using either the ENG_ARCHIVE env var or
-# looking in the standard SKA place.  In the case that accessing data remotely this is all moot (
-# and SKA is not required to be defined), so just make sure this bit runs without failing.
-# These two values get exported to the ``fetch`` module.
-SKA = os.getenv('SKA')
-ENG_ARCHIVE = os.getenv('ENG_ARCHIVE')
-if ENG_ARCHIVE is None and SKA is not None:
-    ENG_ARCHIVE = os.path.join(SKA, 'data', 'eng_archive')
 
-# Remote access is controlled as follows:
-# - The environment variable SKA_ACCESS_REMOTELY can be set to "False" or "True"
-# - Remote access defaults to True on Windows systems unless the SKA environment
-#   variable is set and data on $SKA\data\eng_archive are found.
-# - Remote access defaults to False on non-Windows systems.
+def get_data_access_info():
+    """
+    Determine path to eng archive data and whether to access data remotely.
 
-# First check if there is a local data archive
-if ENG_ARCHIVE:
-    eng_data_dir = Path(ENG_ARCHIVE) / 'data'
-    has_ska_data = eng_data_dir.exists()
-else:
-    has_ska_data = False
+    :return: eng_archive, access_remotely
+    """
+    # Define the path to eng archive data (if possible), using either the ENG_ARCHIVE env var or
+    # looking in the standard SKA place.  In the case that accessing data remotely this is all
+    # moot ( and SKA is not required to be defined), so just make sure this bit runs without
+    # failing. These two values get exported to the ``fetch`` module.
+    ska = os.getenv('SKA')
+    eng_archive = os.getenv('ENG_ARCHIVE')
+    if eng_archive is None and ska is not None:
+        eng_archive = os.path.join(ska, 'data', 'eng_archive')
 
-if 'SKA_ACCESS_REMOTELY' in os.environ:
-    # User explicitly specified, so that is the end of the story.
-    import ast
-    access_remotely = ast.literal_eval(os.environ['SKA_ACCESS_REMOTELY'])
-else:
-    access_remotely = False if has_ska_data else sys.platform.startswith('win')
+    # Remote access is controlled as follows:
+    # - The environment variable SKA_ACCESS_REMOTELY can be set to "False" or "True"
+    # - Remote access defaults to True on Windows systems unless the SKA environment
+    #   variable is set and data on $SKA\data\eng_archive are found.
+    # - Remote access defaults to False on non-Windows systems.
 
-if not access_remotely and not has_ska_data:
-    if ENG_ARCHIVE is None:
-        msg = 'need to define SKA or ENG_ARCHIVE environment variable'
+    # First check if there is a local data archive
+    if eng_archive:
+        eng_data_dir = Path(eng_archive) / 'data'
+        has_ska_data = eng_data_dir.exists()
     else:
-        msg = f'no {eng_data_dir.absolute()} directory'
-    raise RuntimeError(f'no local Ska data found and remote access is not selected: {msg}')
+        has_ska_data = False
 
+    if 'SKA_ACCESS_REMOTELY' in os.environ:
+        # User explicitly specified, so that is the end of the story.
+        import ast
+        ska_access_remotely = ast.literal_eval(os.environ['SKA_ACCESS_REMOTELY'])
+    else:
+        ska_access_remotely = False if has_ska_data else sys.platform.startswith('win')
+
+    if not ska_access_remotely and not has_ska_data:
+        if eng_archive is None:
+            msg = 'need to define SKA or ENG_ARCHIVE environment variable'
+        else:
+            msg = f'no {eng_data_dir.absolute()} directory'
+        raise RuntimeError(f'no local Ska data found and remote access is not selected: {msg}')
+
+    return eng_archive, ska_access_remotely
+
+
+# Module globals with eng archive data root path and whether or not to access
+# data remotely.
+ENG_ARCHIVE, access_remotely = get_data_access_info()
 
 # Hostname (IP), username, and password for remote access to the eng archive
 hostname = None
@@ -69,14 +82,16 @@ client_key_file = os.path.join(sys.prefix,"ska_remote_access.json")
 # IPython parallel client for accessing the remote python engine
 _remote_client = None
 
+
 class RemoteConnectionError(Exception):
     pass
 
+
 def establish_connection():
     """
-Function to establish a connection to the remote server
-Return success status (True/False)
-"""
+    Function to establish a connection to the remote server
+    Return success status (True/False)
+    """
     global _remote_client
     global hostname
     global username
@@ -89,7 +104,7 @@ Return success status (True/False)
         # Get the username and password if not already set
         hostname = hostname or input('Enter hostname (or IP) of Ska ' +
                                          'server (enter to cancel):')
-        if hostname=="":
+        if hostname == "":
             break
         default_username = getpass.getuser()
         username = username or input('Enter your login username [' +
@@ -101,10 +116,11 @@ Return success status (True/False)
         sys.stdout.flush()
         try:
             _remote_client = parallel.Client(client_key_file,
-                                             sshserver=username+'@'+hostname,
-                                             password=password)
-        except:
-            print('Error connecting to server ',hostname,': ',sys.exc_info()[0])
+                                             sshserver=f'{username}@{hostname}',
+                                             password=password, timeout=30, debug=True)
+        except Exception:
+            raise
+            print('Error connecting to server ', hostname, ': ', sys.exc_info()[0])
             sys.stdout.flush()
             _remote_client = None
             # Clear out information so the user can try again
@@ -114,45 +130,43 @@ Return success status (True/False)
             if not ask_again_if_connect_fails:
                 break
 
-    return(connection_is_established())
+    return connection_is_established()
 
 
 def connection_is_established():
     """
-Function to check if a connection to the remote server has been established
-"""
-    return (not _remote_client is None)
+    Function to check if a connection to the remote server has been established
+    """
+    return _remote_client is not None
 
 
 def execute_remotely(fcn, *args, **kwargs):
     """
-Function for executing a function remotely
-"""
+    Function for executing a function remotely
+    """
     if not connection_is_established():
-        raise parallel.ConnectionError(
-                "Connection not established to remote server")
-    dview = _remote_client[0]; # Use the first (and should be only) engine
+        raise parallel.ConnectionError("Connection not established to remote server")
+    dview = _remote_client[0]  # Use the first (and should be only) engine
     dview.block = True
     return dview.apply_sync(fcn, *args, **kwargs)
 
 
 def test_connection():
     """
-Function to perform a quick test of the connection to the
-remote server
-"""
+    Function to perform a quick test of the connection to the
+    remote server
+    """
     def remote_fcn():
         import os
         return os.sys.version
-    return (execute_remotely(remote_fcn))
+    return execute_remotely(remote_fcn)
 
 
 def close_connection():
     """
-Function to close the connection to the remote server
-"""
+    Function to close the connection to the remote server
+    """
     global _remote_client
 
     _remote_client.close()
     _remote_client = None
-

--- a/Ska/engarchive/tests/test_data_source.py
+++ b/Ska/engarchive/tests/test_data_source.py
@@ -1,11 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division, absolute_import
 
+import os
+from pathlib import Path
+
 import numpy as np
 import pytest
 
 
-from .. import fetch, fetch_sci, fetch_eng
+from .. import fetch, fetch_sci, fetch_eng, remote_access
 fetch_cxc = fetch
 
 

--- a/Ska/engarchive/tests/test_data_source.py
+++ b/Ska/engarchive/tests/test_data_source.py
@@ -1,14 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division, absolute_import
 
-import os
-from pathlib import Path
-
 import numpy as np
 import pytest
 
 
-from .. import fetch, fetch_sci, fetch_eng, remote_access
+from .. import fetch, fetch_sci, fetch_eng
 fetch_cxc = fetch
 
 

--- a/Ska/engarchive/tests/test_remote_access.py
+++ b/Ska/engarchive/tests/test_remote_access.py
@@ -1,5 +1,54 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Test getting data archive path information for eng archive and possible
+access via a remote server.
+
+In addition, do manual tests below.  For tests that require remote access,
+one must be VPN'd to the OCC network and enter an IP address and credentials
+for chimchim.  In addition, the file ska_remote_access.json must be
+installed at the Ska3 root (sys.prefix).  Search email around Jan 3, 2019 for
+"ska_remote_access.json" to find a path to this file.
+
+- Nominal remote access on Windows:
+  No env vars set (SKA, ENG_ARCHIVE, SKA_ACCESS_REMOTELY).
+  Confirm that remote access is enabled and works by fetching an MSID::
+
+    import os
+    os.environ.pop('SKA')
+    os.environ.pop('ENG_ARCHIVE')
+    os.environ.pop('SKA_ACCESS_REMOTELY')
+    from Ska.engarchive import fetch, remote_access
+    fetch.add_logging_handler()
+    assert remote_access.access_remotely is True
+    dat = fetch.Msid('tephin', '2018:001', '2018:010')
+    print(dat.vals)
+
+- Override remote access on Windows by setting SKA to a valid path
+  so eng archive data will be found. Confirm that remote access is
+  disabled and fetch uses local access::
+
+    import os
+    os.environ['SKA'] = <path_to_ska_root>
+    os.environ.pop('ENG_ARCHIVE')
+    os.environ.pop('SKA_ACCESS_REMOTELY')
+    from Ska.engarchive import fetch, remote_access
+    fetch.add_logging_handler()
+    assert remote_access.access_remotely is True
+    dat = fetch.Msid('tephin', '2018:001', '2018:010')
+    print(dat.vals)
+
+- Override remote access on non-Windows by setting SKA_ACCESS_REMOTELY to 'True'::
+
+    import os
+    os.environ['SKA_ACCESS_REMOTELY'] = 'True'
+    from Ska.engarchive import fetch, remote_access
+    fetch.add_logging_handler()
+    assert remote_access.access_remotely is False
+    dat = fetch.Msid('tephin', '2018:001', '2018:010')
+    print(dat.vals)
+
+"""
 import os
-import sys
 from pathlib import Path
 
 import pytest
@@ -49,7 +98,7 @@ def test_remote_access_get_data_access_info1(remote_setup_dirs):
     # Not windows
     with pytest.raises(RuntimeError) as err:
         get_data_access_info(is_windows=False)
-    assert 'need to define SKA or ENG_ARCHIVE environment variable' in str(err)
+    assert 'need to define SKA or ENG_ARCHIVE environment variable' in str(err.value)
 
 
 def test_remote_access_get_data_access_info2(remote_setup_dirs):
@@ -116,7 +165,7 @@ def test_remote_access_get_data_access_info5(remote_setup_dirs):
     for is_windows in True, False:
         with pytest.raises(RuntimeError) as err:
             get_data_access_info(is_windows)
-        assert 'need to define SKA or ENG_ARCHIVE environment variable' in str(err)
+        assert 'need to define SKA or ENG_ARCHIVE environment variable' in str(err.value)
 
 
 def test_remote_access_get_data_access_info6(remote_setup_dirs):
@@ -132,4 +181,3 @@ def test_remote_access_get_data_access_info6(remote_setup_dirs):
         eng_archive, ska_access_remotely = get_data_access_info(is_windows)
         assert eng_archive == '/proj/sot/ska/data/eng_archive'
         assert ska_access_remotely is True
-

--- a/Ska/engarchive/tests/test_remote_access.py
+++ b/Ska/engarchive/tests/test_remote_access.py
@@ -1,0 +1,89 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from Ska.engarchive.remote_access import get_data_access_info
+
+INVALID_DIR = str(Path(__file__).parent / '__non_existent_invalid_directory____')
+
+ORIG_ENV = {name: os.getenv(name)
+            for name in ('SKA', 'ENG_ARCHIVE', 'SKA_ACCESS_REMOTELY')}
+
+
+def setenv(name, val):
+    if val is not None:
+        os.environ[name] = str(val)
+    else:
+        os.environ.pop(name, None)
+
+
+def test_remote_access_get_data_access_info(tmpdir):
+    """
+    Unit test of the get_data_access_info() function.
+    """
+    # Make a fake Ska data installation
+    ska_dir = Path(tmpdir)
+    eng_archive_dir = ska_dir / 'data' / 'eng_archive'
+    (eng_archive_dir / 'data').mkdir(parents=True)
+
+    # Check some possible use cases:
+
+    # No env vars set
+    setenv('SKA', None)
+    setenv('ENG_ARCHIVE', None)  # I.e. not set
+    setenv('SKA_ACCESS_REMOTELY', None)
+
+    # Windows
+    eng_archive, ska_access_remotely = get_data_access_info(is_windows=True)
+    assert eng_archive is None
+    assert ska_access_remotely is True
+
+    # Not windows
+    with pytest.raises(RuntimeError) as err:
+        get_data_access_info(is_windows=False)
+    assert 'need to define SKA or ENG_ARCHIVE environment variable' in str(err)
+
+    # Just SKA set to a valid directory (typical case on linux/mac)
+    setenv('SKA', ska_dir)
+    setenv('ENG_ARCHIVE', None)  # I.e. not set
+    setenv('SKA_ACCESS_REMOTELY', None)
+    for is_windows in True, False:
+        eng_archive, ska_access_remotely = get_data_access_info(is_windows)
+        assert eng_archive == str(eng_archive_dir.absolute())
+        assert ska_access_remotely is False
+
+    # Just ENG_ARCHIVE set to a valid directory (typical for testing)
+    # SKA either unset or set to a bad directory
+    for ska_env in None, INVALID_DIR:
+        setenv('SKA', ska_env)
+        setenv('ENG_ARCHIVE', eng_archive_dir)
+        setenv('SKA_ACCESS_REMOTELY', None)
+        for is_windows in True, False:
+            eng_archive, ska_access_remotely = get_data_access_info(is_windows)
+            assert eng_archive == str(eng_archive_dir.absolute())
+            assert ska_access_remotely is False
+
+    # ENG_ARCHIVE set to a bad directory
+    setenv('SKA', ska_dir)
+    setenv('ENG_ARCHIVE', INVALID_DIR)
+    setenv('SKA_ACCESS_REMOTELY', None)
+    # Windows
+    eng_archive, ska_access_remotely = get_data_access_info(is_windows=True)
+    assert eng_archive == INVALID_DIR
+    assert ska_access_remotely is True
+
+    # No SKA or ENG_ARCHIVE and SKA_ACCESS_REMOTELY=False
+    setenv('SKA', None)
+    setenv('ENG_ARCHIVE', None)  # I.e. not set
+    setenv('SKA_ACCESS_REMOTELY', False)
+
+    for is_windows in True, False:
+        with pytest.raises(RuntimeError) as err:
+            get_data_access_info(is_windows)
+        assert 'need to define SKA or ENG_ARCHIVE environment variable' in str(err)
+
+    # Teardown
+    for name in 'SKA', 'ENG_ARCHIVE', 'SKA_ACCESS_REMOTELY':
+        setenv(name, ORIG_ENV[name])

--- a/Ska/engarchive/tests/test_sync.py
+++ b/Ska/engarchive/tests/test_sync.py
@@ -89,7 +89,7 @@ def make_sync_repo(outdir, content):
     date_stop = (DateTime(STOP) + 2).date
 
     print(f'Updating server sync for {content}')
-    args = [f'--data-root={outdir}',
+    args = [f'--sync-root={outdir}',
             f'--date-start={date_start}',
             f'--date-stop={date_stop}',
             f'--log-level={LOG_LEVEL}',
@@ -315,12 +315,13 @@ def check_content(outdir, content, msids=None):
 
     date_stop = (DateTime(STOP) + 2).date
 
+    print(f'Updating client archive {content}')
     with set_fetch_basedir(basedir_test):
-        print(f'Updating client archive {content}')
         update_client_archive.main([f'--content={content}',
                                     f'--log-level={LOG_LEVEL}',
                                     f'--date-stop={date_stop}',
-                                    f'--data-root={basedir_test}'])
+                                    f'--data-root={basedir_test}',
+                                    f'--sync-root={basedir_test}'])
 
     print(f'Checking {content} {msids}')
     for stat in None, '5min', 'daily':

--- a/Ska/engarchive/tests/test_sync.py
+++ b/Ska/engarchive/tests/test_sync.py
@@ -9,9 +9,9 @@ import Ska.DBI
 import tables
 from Chandra.Time import DateTime
 
-from cheta import fetch
-from cheta import update_client_archive, update_server_sync
-from cheta.utils import STATS_DT, set_fetch_basedir
+from .. import fetch
+from .. import update_client_archive, update_server_sync
+from ..utils import STATS_DT, set_fetch_basedir
 
 # Covers safe mode and IRU swap activities around 2018:283.  This is a time
 # with rarely-seen telemetry.
@@ -19,12 +19,12 @@ START, STOP = '2018:281', '2018:293'
 
 # Content types and associated MSIDs that will be tested
 CONTENTS = {'acis4eng': ['1WRAT'],  # [float]
-            'dp_pcad32': ['DP_SYS_MOM_TOT'],  # Derived parameter [float]
-            'orbitephem0': ['ORBITEPHEM0_X'],  # Heavily overlapped [float]
-            'cpe1eng': ['6GYRCT1', '6RATE1'],  # Safe mode, [int, float]
-            'pcad13eng': ['ASPAGYC2A'],  # PCAD subformat and rarely sampled [int]
-            'sim_mrg': ['3TSCMOVE', '3TSCPOS'],  # [str, float]
-            'simcoor': ['SIM_Z_MOVED'],  # [bool]
+            #'dp_pcad32': ['DP_SYS_MOM_TOT'],  # Derived parameter [float]
+            #'orbitephem0': ['ORBITEPHEM0_X'],  # Heavily overlapped [float]
+            #'cpe1eng': ['6GYRCT1', '6RATE1'],  # Safe mode, [int, float]
+            #'pcad13eng': ['ASPAGYC2A'],  # PCAD subformat and rarely sampled [int]
+            #'sim_mrg': ['3TSCMOVE', '3TSCPOS'],  # [str, float]
+            #'simcoor': ['SIM_Z_MOVED'],  # [bool]
             }
 
 LOG_LEVEL = 50  # quiet
@@ -99,7 +99,7 @@ def make_sync_repo(outdir, content):
 
 
 def make_stub_archfiles(date, basedir_ref, basedir_stub):
-    archfiles_def = open('cheta/archfiles_def.sql').read()
+    archfiles_def = (Path(fetch.__file__).parent / 'archfiles_def.sql').read_text()
 
     with set_fetch_basedir(basedir_ref):
         filename = fetch.msid_files['archfiles'].abs

--- a/Ska/engarchive/tests/test_sync.py
+++ b/Ska/engarchive/tests/test_sync.py
@@ -110,7 +110,7 @@ def make_stub_archfiles(date, basedir_ref, basedir_stub):
         last_row = db.fetchone(f'select * from archfiles '
                                f'where filetime < {filetime} '
                                f'order by filetime desc'
-                              )
+                               )
 
     with set_fetch_basedir(basedir_stub):
         filename = fetch.msid_files['archfiles'].abs

--- a/Ska/engarchive/tests/test_sync.py
+++ b/Ska/engarchive/tests/test_sync.py
@@ -19,12 +19,12 @@ START, STOP = '2018:281', '2018:293'
 
 # Content types and associated MSIDs that will be tested
 CONTENTS = {'acis4eng': ['1WRAT'],  # [float]
-            #'dp_pcad32': ['DP_SYS_MOM_TOT'],  # Derived parameter [float]
-            #'orbitephem0': ['ORBITEPHEM0_X'],  # Heavily overlapped [float]
-            #'cpe1eng': ['6GYRCT1', '6RATE1'],  # Safe mode, [int, float]
-            #'pcad13eng': ['ASPAGYC2A'],  # PCAD subformat and rarely sampled [int]
-            #'sim_mrg': ['3TSCMOVE', '3TSCPOS'],  # [str, float]
-            #'simcoor': ['SIM_Z_MOVED'],  # [bool]
+            'dp_pcad32': ['DP_SYS_MOM_TOT'],  # Derived parameter [float]
+            'orbitephem0': ['ORBITEPHEM0_X'],  # Heavily overlapped [float]
+            'cpe1eng': ['6GYRCT1', '6RATE1'],  # Safe mode, [int, float]
+            'pcad13eng': ['ASPAGYC2A'],  # PCAD subformat and rarely sampled [int]
+            'sim_mrg': ['3TSCMOVE', '3TSCPOS'],  # [str, float]
+            'simcoor': ['SIM_Z_MOVED'],  # [bool]
             }
 
 LOG_LEVEL = 50  # quiet

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -221,7 +221,7 @@ def sync_stat_archive(opt, msid_files, logger, content, stat):
     ft['content'] = content
     ft['interval'] = stat
 
-    stats_dir = Path(msid_files['statsdir'].rel)
+    stats_dir = Path(msid_files['statsdir'].abs)
     if not stats_dir.exists():
         logger.debug(f'Skipping {stat} data for {content}: no directory')
         return
@@ -279,7 +279,7 @@ def sync_stat_archive(opt, msid_files, logger, content, stat):
 
         for msid in msids:
             fetch.ft['msid'] = msid
-            stat_file = msid_files['stats'].rel
+            stat_file = msid_files['stats'].abs
             if os.path.exists(stat_file):
                 append_stat_col(dat, stat_file, msid, date_id, opt, logger)
 
@@ -343,7 +343,7 @@ def get_last_date_id(msid_files, msids, stat, logger):
     :param logger:
     :return:
     """
-    last_date_id_file = msid_files['last_date_id'].rel
+    last_date_id_file = msid_files['last_date_id'].abs
 
     if Path(last_date_id_file).exists():
         logger.verbose(f'Reading {last_date_id_file} to get last update time')

--- a/Ska/engarchive/update_server_sync.py
+++ b/Ska/engarchive/update_server_sync.py
@@ -265,7 +265,8 @@ def update_index_file(index_file, opt, logger):
             if len(archfiles) > 0:
                 rows.append(get_row_from_archfiles(archfiles))
                 filedates = DateTime(archfiles['filetime']).fits
-                logger.verbose(f'Got {len(archfiles)} rows {filedates}')
+                logger.verbose(f'Got {len(archfiles)} archfiles rows from '
+                               f'{filedates[0]} to {filedates[-1]}')
 
             filetime0 = filetime1
 

--- a/Ska/engarchive/update_server_sync.py
+++ b/Ska/engarchive/update_server_sync.py
@@ -55,7 +55,7 @@ sync_files.update(file_defs.sync_files)
 
 def get_options(args=None):
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-root",
+    parser.add_argument("--sync-root",
                         default=".",
                         help="Root directory for sync files (default='.')")
     parser.add_argument("--content",
@@ -103,7 +103,7 @@ def update_msid_contents_pkl(logger):
 def main(args=None):
     # Setup for updating the sync repository
     opt = get_options(args)
-    sync_files.basedir = opt.data_root
+    sync_files.basedir = opt.sync_root
 
     # Set up logging
     loglevel = int(opt.log_level)

--- a/doc/fetch_tutorial.rst
+++ b/doc/fetch_tutorial.rst
@@ -1534,25 +1534,28 @@ rates to those derived on the ground using raw gyro data.
 .. image:: fetchplots/obc_rates.png
 .. image:: fetchplots/gyro_sc_rates.png
 
-Remote Windows access
-=====================
+Remote data access
+==================
 
-The telemetry archive can be accessed remotely from a Windows PC, if ssh access to
-chimchim is available.  The user will be queried for ssh credentials and
-Ska.engarchive.fetch will connect with a controller running on chimchim to retrieve the
-data.  Besides the initial query for credentials (and slower speeds when fetching data, of
-course), the use of Ska.engarchive.fetch is essentially the same whether the archive is
-local or remote.  The key file
-`<http://donut/svn/fot/Deployment/MATLAB_Tools/Python/python_Windows_64bit/ska_remote_access.json>`_
-needs to be in the user’s Python installation folder (the folder that contains python.exe,
-libs, Doc, etc.) for this to work.
+The telemetry archive can be accessed remotely if ssh access to
+``chimchim`` is available.  The user will be queried for ssh credentials and
+``fetch`` will connect with a controller running on ``chimchim`` to retrieve the
+data.  Besides the initial query for credentials (and slower speeds when fetching data over
+the network), the use of ``fetch`` is essentially the same whether the archive is
+local or remote.
 
+In order to use this option, the user must have a special key file
+``ska_remote_access.json``placed at the root of the local Python installation folder.  This is
+placed in the directory shown with ``import sys; print(sys.prefix)``.  To get a copy of this file
+ contact Mark Baski or Tom Aldcroft.
 
-To do
-======
+Remote access is controlled as follows:
 
-* Add telemetry:
-
-  - ACA header-3
-
-* Add MSID method to determine exact time of mins or maxes
+- The environment variable ``SKA_ACCESS_REMOTELY`` can be set to "False" or "True"
+  to force either disabling or enabling remote access, respectively.
+- If ``SKA_ACCESS_REMOTELY`` is not defined on a linux or Mac system, remote access
+  is always *disabled*.
+- If ``SKA_ACCESS_REMOTELY`` is not defined on a Windows system, remote access
+  is *enabled* unless the system finds a local engineering data archive.  It looks
+  for data in either ``$SKA/data/eng_archive`` or ``$ENG_ARCHIVE``, where those
+  refer to user-defined environment variables.


### PR DESCRIPTION
This does two somewhat independent things:

- Improve remote access control by allowing for a `SKA_ACCESS_REMOTELY` user environment variable to explicitly control whether the remote server is used.  Along the way the logic and implementation were refined as noted in the improved user documentation.
- Adds unit tests of remote access (to the extent possible) and describes manually-run tests.
- Fix some path issues in the sync mechanism that only showed up on a FOT Windows laptop.

Testing using an installed version of the package.  "Limited" unit tests done with:
```
>>> import Ska.engarchive
>>> Ska.engarchive.test('-k test_sync', '-s', '-v')
>>> Ska.engarchive.test('-k test_remote_access', '-v')
```

Testing status

- [x] TA runs limited unit tests on Windows VM
- [x] TA runs manual tests on Windows VM
- [x] TA runs limited unit tests on Mac
- [x] TA runs manual test on Mac
- [x] TA runs all unit tests on linux
- [x] MB runs limited unit tests on FOT Windows laptop
- [x] MB runs manual tests on FOT Windows laptop
- [x] MB tests in https://github.com/sot/eng_archive/pull/170#issuecomment-524032307

Manual test:
- Nominal remote access on Windows:
  No env vars set (SKA, ENG_ARCHIVE, SKA_ACCESS_REMOTELY).
  Confirm that remote access is enabled and works by fetching an MSID::
```
    import os
    os.environ.pop('SKA', None)
    os.environ.pop('ENG_ARCHIVE', None)
    os.environ.pop('SKA_ACCESS_REMOTELY', None)
    from Ska.engarchive import fetch, remote_access
    fetch.add_logging_handler()
    assert remote_access.access_remotely is True
    dat = fetch.Msid('tephin', '2018:001', '2018:010')
    print(dat.vals)
```
- Override remote access on Windows by setting SKA to a valid path
  so eng archive data will be found. Confirm that remote access is
  disabled and fetch uses local access::
```
    import os
    os.environ['SKA'] = <path_to_ska_root>
    os.environ.pop('ENG_ARCHIVE', None)
    os.environ.pop('SKA_ACCESS_REMOTELY', None)
    from Ska.engarchive import fetch, remote_access
    fetch.add_logging_handler()
    assert remote_access.access_remotely is False
    dat = fetch.Msid('1wrat', '2018:001', '2018:010')
    print(dat.vals)
```
- Override remote access on non-Windows by setting SKA_ACCESS_REMOTELY to 'True'::
```
    import os
    os.environ['SKA_ACCESS_REMOTELY'] = 'True'
    from Ska.engarchive import fetch, remote_access
    fetch.add_logging_handler()
    assert remote_access.access_remotely is True
    dat = fetch.Msid('tephin', '2018:001', '2018:010')
    print(dat.vals)
```