### PR TITLE
Skip sync tests on 32-bit platform (version 4.45.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ test/eng_archive
 test/*.tar.gz
 test/regr_vals.*
 build
-data
+/data*
 dist
 doc/_build
 www
@@ -21,3 +21,6 @@ dev_utils/event_filter_1.png
 dev_utils/event_filter_2.png
 dev_utils/l0_5icd.pdf
 dev_utils/memleak.py
+*.ipynb
+.ipynb_checkpoints
+.idea

--- a/Ska/engarchive/tests/test_sync.py
+++ b/Ska/engarchive/tests/test_sync.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import pickle
 import shutil
@@ -12,6 +13,8 @@ from Chandra.Time import DateTime
 from .. import fetch
 from .. import update_client_archive, update_server_sync
 from ..utils import STATS_DT, set_fetch_basedir
+
+pytestmark = pytest.mark.skipif(sys.maxsize <= 2 ** 32, reason="tests for 64-bit only")
 
 # Covers safe mode and IRU swap activities around 2018:283.  This is a time
 # with rarely-seen telemetry.

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -34,7 +34,7 @@ import os
 # SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (4, 45, None, False)
+VERSION = (4, 45, 1, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
This also updates the version to 4.45.1 and does an unrelated update to .gitignore that makes life easier in my development.

See the note here for inspiration: https://docs.python.org/3.6/library/platform.html#platform.architecture

## Testing

### Quango (32-bit)
```
quango% pytest Ska/engarchive/tests/ -k sync -v
======================================= test session starts ========================================
platform linux -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- /proj/sot/ska3/matlab32/bin/python
cachedir: .cache
rootdir: /data/baffin/tom/git/eng_archive, inifile:
plugins: arraydiff-0.2, doctestplus-0.1.3, openfiles-0.3.0, remotedata-0.3.0
collected 79 items                                                                                  

Ska/engarchive/tests/test_sync.py::test_sync[acis4eng] SKIPPED
Ska/engarchive/tests/test_sync.py::test_sync[dp_pcad32] SKIPPED
Ska/engarchive/tests/test_sync.py::test_sync[orbitephem0] SKIPPED
Ska/engarchive/tests/test_sync.py::test_sync[cpe1eng] SKIPPED
Ska/engarchive/tests/test_sync.py::test_sync[pcad13eng] SKIPPED
Ska/engarchive/tests/test_sync.py::test_sync[sim_mrg] SKIPPED
Ska/engarchive/tests/test_sync.py::test_sync[simcoor] SKIPPED

======================================= 72 tests deselected ========================================
============================ 7 skipped, 72 deselected in 127.56 seconds ============================
```
## kadi (64-bit)
```
ska3-kadi$ pytest Ska/engarchive/tests/ -v -k sync
======================================= test session starts ========================================
platform linux -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- /proj/sot/ska3/flight/bin/python
cachedir: .cache
rootdir: /data/baffin/tom/git/eng_archive, inifile:
plugins: remotedata-0.3.0, openfiles-0.3.0, doctestplus-0.1.3, arraydiff-0.2
collected 79 items                                                                                  

Ska/engarchive/tests/test_sync.py::test_sync[acis4eng] PASSED
Ska/engarchive/tests/test_sync.py::test_sync[dp_pcad32] PASSED
...
```

