### PR TITLE
More robust and faster sync

### DIFF
--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -233,43 +233,6 @@ def get_full_data_sets(ft, index_tbl, logger, opt):
     return dats
 
 
-def concat_full_data_sets(dats):
-    """
-    Concatenate the list of ``dat`` dicts into a single such dict
-
-    Each dat dict has keys {msid}.{key} for key in data, quality, row0, row1.
-    The ``.data`` and ``.quality`` elements are numpy arrays, while row0 and
-    row1 are integers.
-
-    :param dats: list of dict
-    :return:
-    """
-    msids = {key[:-5] for key in dats[0] if key.endswith('.data')}
-
-    # Check on consistency of dats
-    for dat0, dat1 in zip(dats[:-1], dats[1:]):
-        # Same MSIDs
-        msids1 = {key[:-5] for key in dat1 if key.endswith('.data')}
-        if msids != msids1:
-            raise ValueError('unexpected inconsistency in full data files')
-
-        # Continuity of rows
-        for msid in msids:
-            if dat0[f'{msid}.row1'] != dat1[f'{msid}.row0']:
-                raise ValueError('unexpected discontinuity in rows of full data files')
-
-    dat = {}
-    for msid in msids:
-        for key in ('data', 'quality'):
-            dat[f'{msid}.{key}'] = np.concatenate([dat[f'{msid}.{key}'] for dat in dats])
-        dat[f'{msid}.row0'] = dats[0][f'{msid}.row0']
-        dat[f'{msid}.row1'] = dats[-1][f'{msid}.row1']
-
-    dat['archfiles'] = list(itertools.chain.from_iterable(dat['archfiles'] for dat in dats))
-
-    return dat, msids
-
-
 def sync_stat_archive(opt, msid_files, logger, content, stat):
     """
     Sync the archive for ``content``.

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -448,8 +448,9 @@ def append_stat_col(dat, stat_file, msid, date_id, opt, logger):
             vals['row0'] += idx0
 
         if vals['row0'] != len(h5.root.data):
-            raise ValueError(f'ERROR: unexpected discontinuity '
-                             f'row0 {vals["row0"]} != len {len(h5.root.data)}')
+            raise ValueError(f'ERROR: unexpected discontinuity\n'
+                             f'  First row0 in new data {vals["row0"]} != '
+                             f'length of existing data {len(h5.root.data)}')
 
         logger.debug(f'Appending {len(vals["data"])} rows to {stat_file}')
         if not opt.dry_run:
@@ -519,8 +520,9 @@ def append_h5_col(opt, msid, vals, logger, msid_files):
         logger.verbose(f'Appending {n_vals} rows to {msid_file}')
 
         if vals['row0'] != len(h5.root.data):
-            raise ValueError(f'ERROR: unexpected discontinuity '
-                             f'row0 {vals["row0"]} != len {len(h5.root.data)}')
+            raise ValueError(f'ERROR: unexpected discontinuity\n'
+                             f'  First row0 in new data {vals["row0"]} != '
+                             f'length of existing data {len(h5.root.data)}')
 
         # For the TIME column include special processing to effectively remove
         # existing rows that are superceded by new rows in time.  This is done by

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -37,7 +37,7 @@ from Ska.DBI import DBI
 from astropy.table import Table
 from astropy.utils.data import download_file
 
-from . import file_defs
+from . import file_defs, __version__
 from .utils import get_date_id, STATS_DT
 
 sync_files = pyyaks.context.ContextDict('update_client_archive.sync_files')
@@ -574,6 +574,9 @@ def main(args=None):
         os.environ['ENG_ARCHIVE'] = opt.data_root
 
     fetch = importlib.import_module('.fetch', __package__)
+    logger.info(f'Running cheta_update_client_archive version {__version__}')
+    logger.info(f'  {__file__}')
+    logger.info('')
     logger.info(f'Updating client archive at {fetch.msid_files.basedir}')
 
     if opt.content:

--- a/Ska/engarchive/update_server_sync.py
+++ b/Ska/engarchive/update_server_sync.py
@@ -33,6 +33,7 @@ sync repository to capture newly-available data since the last bundle.
 import argparse
 import gzip
 import pickle
+import re
 import shutil
 from itertools import count
 from pathlib import Path
@@ -134,6 +135,12 @@ def remove_outdated_sync_files(opt, logger, index_tbl):
     :return: mask of rows that were removed
     """
     min_time = (DateTime(opt.date_stop) - opt.max_lookback).secs
+
+    # Ephemeris files are time stamped around a month before current date,
+    # so leave them around for couple months longer.
+    if re.search(r'ephem\d$', str(fetch.ft['content'])):
+        min_time -= 60 * 86400
+
     remove_mask = np.zeros(len(index_tbl), dtype=bool)
 
     for idx, row in enumerate(index_tbl):

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -34,7 +34,7 @@ import os
 # SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (4, 45, 1, False)
+VERSION = (4, 46, None, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
Key changes:

1.  Change flow so all available data updates are downloaded in one step, then concatenated into a single update, and then applied to the local files.  Previously it was doing all processing (fetch and apply) for each available daily update in sequence.  This was simpler but it turns out that most of the processing time is actually in updating the HDF5 files (largely independent of update size), not in downloading data.  So if you are syncing your archive after a month then this change makes the update nearly 30 times faster.

2. Add a context manager to prevent user hitting keyboard interrupt (ctrl-c) during critical file update operations where the archive can get corrupted.  This doesn't prevent other problems (force quit etc), but at least helps the common case.