### PR TITLE
Functionality to add content to local archive by MSID

### DIFF
--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -292,7 +292,8 @@ def get_copy_files(logger, msids, msids_content):
             if not pth.exists():
                 copy_files.add(str(pth.relative_to(basedir)))
 
-    logger.info(f'Found {len(copy_files)} local archive files that missing and need to be copied')
+    logger.info(f'Found {len(copy_files)} local archive files that are '
+                f'missing and need to be copied')
 
     return sorted(copy_files)
 
@@ -303,7 +304,8 @@ def get_msids_for_add_msids(opt, logger):
 
     This implements support for a MSID spec file like::
 
-        # MSIDs that match the name or pattern are included:
+        # MSIDs that match the name or pattern are included, where * matches
+        # anything (0 or more characters) while ? matches exactly one character:
         #
         aopcadm?
         aacccd*
@@ -738,7 +740,7 @@ def append_h5_col(opt, msid, vals, logger, msid_files):
 
     mode = 'r' if opt.dry_run else 'a'
     with tables.open_file(str(msid_file), mode=mode) as h5:
-        # If the vals[] data begins before then end of current data then chop the
+        # If the vals[] data begins before the end of current data then chop the
         # beginning of data for this row.
         last_row_idx = len(h5.root.data) - 1
         if vals['row0'] <= last_row_idx:

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -65,7 +65,7 @@ def get_options(args=None):
     parser.add_argument("--dry-run",
                         action="store_true",
                         help="Dry run (no actual file or database updates)")
-    parser.add_argument('--add-msids-from-file',
+    parser.add_argument('--add-msids',
                         help='Add MSIDs specified in <file> to eng archive data files"')
     parser.add_argument('--server-data-root',
                         help=('Add MSID data from root (/path/to/data, user@remote, '
@@ -150,7 +150,7 @@ class DelayedKeyboardInterrupt(object):
             sys.exit(1)
 
 
-def add_msids_from_file(opt, logger):
+def add_msids(opt, logger):
     """
     Main function for adding MSIDs to the local archive from a remote server or disk.
 
@@ -158,10 +158,10 @@ def add_msids_from_file(opt, logger):
     :param logger: logger
     :return: None
     """
-    msids, msids_content = get_msids_for_add_msids_from_file(opt, logger)
+    msids, msids_content = get_msids_for_add_msids(opt, logger)
     copy_files = get_copy_files(logger, msids, msids_content)
     if not copy_files:
-        logger.info(f'Local cheta archive is complete for MSIDs in {opt.add_msids_from_file}')
+        logger.info(f'Local cheta archive is complete for MSIDs in {opt.add_msids}')
         return
 
     if '@' in opt.server_data_root:
@@ -279,9 +279,9 @@ def get_copy_files(logger, msids, msids_content):
     return sorted(copy_files)
 
 
-def get_msids_for_add_msids_from_file(opt, logger):
+def get_msids_for_add_msids(opt, logger):
     """
-    Parse MSIDs spec file (opt.add_msids_from_file) and return corresponding list of MSIDs.
+    Parse MSIDs spec file (opt.add_msids) and return corresponding list of MSIDs.
 
     This implements support for a MSID spec file like::
 
@@ -315,8 +315,8 @@ def get_msids_for_add_msids_from_file(opt, logger):
     for msid, content in msids_content.items():
         content_msids[content].append(msid)
 
-    logger.info(f'Reading MSID specs from {opt.add_msids_from_file}')
-    with open(opt.add_msids_from_file) as fh:
+    logger.info(f'Reading MSID specs from {opt.add_msids}')
+    with open(opt.add_msids) as fh:
         lines = [line.strip() for line in fh.readlines()]
     msid_specs = [line.upper() for line in lines if (line and not line.startswith('#'))]
 
@@ -813,8 +813,8 @@ def main(args=None):
     logger.info('')
     logger.info(f'Updating client archive at {fetch.msid_files.basedir}')
 
-    if opt.add_msids_from_file:
-        add_msids_from_file(opt, logger)
+    if opt.add_msids:
+        add_msids(opt, logger)
         return
 
     if opt.content:

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -553,8 +553,9 @@ def sync_stat_archive(opt, msid_files, logger, content, stat, index_tbl):
                     append_stat_col(dat, stat_file, msid, date_id, opt, logger)
 
             logger.debug(f'Updating {last_date_id_file} with {date_id}')
-            with open(last_date_id_file, 'w') as fh:
-                fh.write(f'{date_id}')
+            if not opt.dry_run:
+                with open(last_date_id_file, 'w') as fh:
+                    fh.write(f'{date_id}')
 
 
 def get_stat_data_sets(ft, index_tbl, last_date_id, logger, opt):

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -17,6 +17,7 @@ import contextlib
 import gzip
 import itertools
 import os
+import subprocess
 import sys
 import pickle
 import re
@@ -144,9 +145,26 @@ class DelayedKeyboardInterrupt(object):
             sys.exit(1)
 
 
+def find_rsync():
+    from subprocess import PIPE
+    for rsync in ('rsync', Path('C:/FOT_Tools', 'local', 'tools', 'rsync.exe')):
+        try:
+            out = subprocess.run([str(rsync), '--help'], stdout=PIPE, stderr=PIPE)
+            assert out.returncode == 0
+            assert len(out.stderr) == 0
+            assert len(out.stdout) > 100
+        except (FileNotFoundError, AssertionError):
+            pass
+        else:
+            return rsync
+
+    raise FileNotFoundError('cannot find rsync executable')
+
+
 def add_from_file(opt, logger):
     msids = get_msids_for_add_from_file(opt, logger)
-    return msids
+    rsync = find_rsync()
+    return msids, rsync
 
 
 def get_msids_for_add_from_file(opt, logger):

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -170,7 +170,7 @@ def add_msids_from_file(opt, logger):
         copy_server_files(opt, logger, copy_files, opt.server_data_root, copy_func=shutil.copyfile)
 
 
-def copy_server_files(opt, logger, copy_files, server_path, copy_func):
+def copy_server_files(opt, logger, copy_files, server_path, copy_func, as_posix=False):
     """
     Copy list of files from server to local, making directories as needed.
 
@@ -195,9 +195,13 @@ def copy_server_files(opt, logger, copy_files, server_path, copy_func):
             progress_bar.update()
             local_file = Path(opt.data_root, copy_file)
             server_file = Path(server_path, copy_file)
+            if as_posix:
+                server_file = server_file.as_posix()
             local_file.parent.mkdir(parents=True, exist_ok=True)
             if not opt.dry_run:
                 with DelayedKeyboardInterrupt(logger):
+                    logger.verbose('\ncopy server:{} local:{}'
+                                   .format(str(server_file), str(local_file)))
                     copy_func(str(server_file), str(local_file))
 
 
@@ -231,7 +235,8 @@ def copy_server_files_ssh(opt, logger, copy_files):
                        username=username,
                        password=password)
     ftp_client = ssh_client.open_sftp()
-    copy_server_files(opt, logger, copy_files, server_path, copy_func=ftp_client.get)
+    copy_server_files(opt, logger, copy_files, server_path, copy_func=ftp_client.get,
+                      as_posix=True)
     ftp_client.close()
     ssh_client.close()
 

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -192,6 +192,8 @@ def copy_server_files(opt, logger, copy_files, server_path, copy_func, as_posix=
         logger.info('DRY RUN')
 
     with ProgressBar(len(copy_files)) as progress_bar:
+        total_size = 0
+        tstart = time.time()
         for copy_file in copy_files:
             local_file = Path(opt.data_root, copy_file)
             server_file = Path(server_path, copy_file)
@@ -205,6 +207,11 @@ def copy_server_files(opt, logger, copy_files, server_path, copy_func, as_posix=
             if not opt.dry_run:
                 with DelayedKeyboardInterrupt(logger):
                     copy_func(str(server_file), str(local_file))
+                total_size += local_file.stat().st_size / 1e6
+    total_time = time.time() - tstart
+    xfer_rate = total_size / total_time
+    logger.info(f'Data transfer rate = {xfer_rate:.2f} Mb/s : '
+                f'{total_size:.2f} Mb in {total_time:.2f} s')
 
 
 def copy_server_files_ssh(opt, logger, copy_files):

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -246,10 +246,10 @@ def copy_server_files_ssh(opt, logger, copy_files):
         else:
             break
 
-    ftp_client = ssh_client.open_sftp()
-    copy_server_files(opt, logger, copy_files, server_path, copy_func=ftp_client.get,
+    sftp_client = ssh_client.open_sftp()
+    copy_server_files(opt, logger, copy_files, server_path, copy_func=sftp_client.get,
                       as_posix=True)
-    ftp_client.close()
+    sftp_client.close()
     ssh_client.close()
 
 

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -109,7 +109,8 @@ def get_readable(sync_root, is_url, filename, timeout=30):
         try:
             filename = download_file(uri, show_progress=False, cache=False, timeout=timeout)
         except urllib.error.URLError as err:
-            raise urllib.error.URLError('Are you on a network with icxc access?') from err
+            raise urllib.error.URLError(
+                f'unable to load {uri}. Are you on a network with icxc access?') from err
 
     else:
         uri = Path(sync_root, filename)

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -192,16 +192,17 @@ def copy_server_files(opt, logger, copy_files, server_path, copy_func, as_posix=
 
     with ProgressBar(len(copy_files)) as progress_bar:
         for copy_file in copy_files:
-            progress_bar.update()
             local_file = Path(opt.data_root, copy_file)
             server_file = Path(server_path, copy_file)
             if as_posix:
                 server_file = server_file.as_posix()
             local_file.parent.mkdir(parents=True, exist_ok=True)
             if not opt.dry_run:
+                progress_bar.update()
+            else:
+                logger.info(f'copy {copy_file}')
+            if not opt.dry_run:
                 with DelayedKeyboardInterrupt(logger):
-                    logger.verbose('\ncopy server:{} local:{}'
-                                   .format(str(server_file), str(local_file)))
                     copy_func(str(server_file), str(local_file))
 
 

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -34,7 +34,7 @@ import os
 # SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (4, 47, None, False)
+VERSION = (4, 47, 1, False)
 
 
 class SemanticVersion(object):

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -34,7 +34,7 @@ import os
 # SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (4, 46, None, False)
+VERSION = (4, 47, None, False)
 
 
 class SemanticVersion(object):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 package_version.write_git_version_file()
 
 console_scripts = ['ska_fetch = cheta.get_telem:main',
-                   'cheta_update_client_archive = cheta.update_client_archive:main',
+                   'cheta_sync = cheta.update_client_archive:main',
                    'cheta_update_server_sync = cheta.update_server_sync:main',
                    'cheta_update_server_archive = cheta.update_archive:main',
                    'cheta_check_integrity = cheta.check_integrity:main',

--- a/task_schedule_sync.cfg
+++ b/task_schedule_sync.cfg
@@ -41,7 +41,7 @@ alert       taldcroft@cfa.harvard.edu
 <task eng_archive>
       cron       * * * * *
       check_cron * * * * *
-      exec cheta_update_server_sync --data-root /proj/sot/ska/data/eng_archive
+      exec cheta_update_server_sync --sync-root /proj/sot/ska/data/eng_archive
       <check>
         <error>
           #    File           Expression


### PR DESCRIPTION
This copies content from a remote server or separate directory (normally an external drive) with a full copy of the archive.  The MSIDs to copy are defined in a simple flat file, for example the following file named `msid_specs` (used in examples below):
```
# MSIDs that match the name or pattern are included:
aopcadmd
aacccd*

# MSIDs with the same subsystem and sampling rate as given MSIDs are included.
# Example: */1wrat gives all acis4eng engineering telemetry.
*/1wrat

# MSIDs with the same subsystem regardless of sampling rate.
# Example: **/3tscpos gives all engineering SIM telemetry
**/3tscpos
```
Example usage.  In all cases you can provide a `--dry-run` option to avoid actually doing any copies.
```
# Copy into a test area
$ mkdir test
$ python -m cheta.update_client_archive --add-msids-from-file=msid_specs \
  --server-data-root=aldcroft@ccosmos --data-root=test [--dry-run]

# On HEAD or chimchim
$ python -m cheta.update_client_archive --add-msids-from-file=msid_specs \
  --server-data-root=/proj/sot/ska/data/eng_archive --data-root=test

# TEST the test
$ ipython
import os
os.environ['ENG_ARCHIVE'] = 'test'
from cheta import fetch
fetch.msid_files.basedir  # Should be your `test` directory
%matplotlib
dat = fetch.Msid('1wrat', '2019:290')
dat.plot()

# Copy into official Ska cheta data archive $SKA/data/eng_archive
$ python -m cheta.update_client_archive --add-msids-from-file=msid_specs \
  --server-data-root=aldcroft@ccosmos
```
