### PR TITLE
Fix off by one errors in sync file generation and truncate

### DIFF
--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -786,7 +786,7 @@ def truncate_archive(filetype, date):
             logger.verbose('Removed rows from {0} for filetype {1}:{2}'.format(
                 rowstart, filetype['content'], colname))
         else:
-            logger.verbose('MSID file {} not found - skipping'.format(filename))
+            logger.debug('MSID file {} not found - skipping'.format(filename))
 
         if colname in fetch.IGNORE_COLNAMES:
             # Colnames like TIME, MNF etc that are not in stats
@@ -801,7 +801,7 @@ def truncate_archive(filetype, date):
                     del_stats(colname, time0, interval)
                 logger.verbose(f'Removed {interval} rows from {filename}')
             else:
-                logger.verbose(f'Stats file {filename} not found - skipping')
+                logger.debug(f'Stats file {filename} not found - skipping')
 
     # Remove the last_date_id file if it exists
     for interval in ('5min', 'daily'):

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -372,13 +372,17 @@ def del_stats(colname, time0, interval):
                              filters=tables.Filters(complevel=5, complib='zlib'))
     index0 = time0 // dt - 1
     indexes = stats.root.data.col('index')[:]
-    row0 = np.searchsorted(indexes, [index0])[0] - 1
-    if opt.dry_run:
-        n_del = len(stats.root.data) - row0
+    row0 = np.searchsorted(indexes, [index0])[0]
+    len_data = len(stats.root.data)
+    if row0 < len_data:
+        if opt.dry_run:
+            n_del = len_data - row0
+        else:
+            n_del = stats.root.data.remove_rows(row0, len_data)
+        logger.info('Deleted %d rows from row %s (%s) to end', n_del, row0,
+                    DateTime(indexes[row0] * dt).date)
     else:
-        n_del = stats.root.data.remove_rows(row0, len(stats.root.data))
-    logger.info('Deleted %d rows from row %s (%s) to end', n_del, row0,
-                DateTime(indexes[row0] * dt).date)
+        logger.info('No rows of stats data to delete - skipping')
     stats.close()
 
 

--- a/Ska/engarchive/version.py
+++ b/Ska/engarchive/version.py
@@ -34,7 +34,7 @@ import os
 # SET THESE VALUES
 ############################
 # Major, Minor, Bugfix, Dev
-VERSION = (4, 47, 2, False)
+VERSION = (4, 47, 3, False)
 
 
 class SemanticVersion(object):


### PR DESCRIPTION
Fixes #184.

Along the way I noticed there is also an off-by-one in truncating the stats archive.  Normally not really a problem but again these rarely-sampled MSIDs can have a problem where you lose a record and then the lookback time is not far enough to get it the next time around.

## Testing

### Server sync
- Regenerated sync files for AOSPASA2CV in pcad7eng covering 2019-09-20 to 2019-11-18 and confirmed that there is no longer a "misplaced row".

### Truncate
- Truncated pcad7eng (AOSPASA2CV only) at 2019-10-01 and confirmed that the last 5min record before then (which should be row 108206) is no longer dropped.
- Ran the same command after truncating and confirmed the expected behavior of saying that no rows are available to truncate.