### PR TITLE
Add code to support and test computed MSIDs

### DIFF
--- a/Ska/engarchive/derived/base.py
+++ b/Ska/engarchive/derived/base.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from Chandra.Time import DateTime
-from .. import fetch, fetch_eng
 import Ska.Numpy
 import numpy as np
 from .. import cache
@@ -35,6 +34,8 @@ class DerivedParameter(object):
         raise NotImplementedError
 
     def fetch(self, start, stop):
+        from .. import fetch
+
         unit_system = fetch.get_units()  # cache current units and restore after fetch
         fetch.set_units(self.unit_system)
         dataset = fetch.MSIDset(self.rootparams, start, stop)
@@ -89,6 +90,7 @@ class DerivedParameter(object):
         return dataset
 
     def __call__(self, start, stop):
+        from .. import fetch_eng
         dataset = fetch_eng.MSIDset(self.rootparams, start, stop, filter_bad=True)
 
         # Translate state codes "ON" and "OFF" to 1 and 0, respectively.

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -73,7 +73,7 @@ class ComputedMsid:
 
 
 class Comp_MUPS_Valve_Temp_Clean(ComputedMsid):
-    msid_match = r'comp_(pm2thv1t|pm1thv2t)'
+    msid_match = r'(pm2thv1t|pm1thv2t)_clean'
     extra_msid_attrs = ('vals_raw', 'vals_nan', 'vals_corr', 'vals_model', 'source')
 
     def get_msid_attrs(self, start, stop, msid, msid_args):

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -1,4 +1,15 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Support computed MSIDs in the cheta archive.
+
+- Base class ComputedMsid for user-generated comps.
+- Cleaned MUPS valve temperatures MSIDs: '(pm2thv1t|pm1thv2t)_clean'.
+- Commanded states 'cmd_state_<key>_<dt>' for any kadi commanded state value.
+"""
+
 import re
+
+import numpy as np
 
 
 class ComputedMsid:
@@ -66,17 +77,85 @@ class ComputedMsid:
 
 
 class Comp_MUPS_Valve_Temp_Clean(ComputedMsid):
+    """Computed MSID for cleaned MUPS valve temps PM2THV1T, PM1THV2T
+
+    This uses the cleaning method demonstrated in the following notebook
+    to return a version of the MUPS valve temperature comprised of
+    telemetry values that are consistent with a thermal model.
+
+    https://nbviewer.jupyter.org/urls/cxc.cfa.harvard.edu/mta/ASPECT/ipynb/misc/mups-valve-xija-filtering.ipynb
+
+    Allowed MSIDs are 'pm2thv1t_clean' and 'pm1thv2t_clean' (as always case is
+    not important).
+    """
     msid_match = r'(pm2thv1t|pm1thv2t)_clean'
     extra_msid_attrs = ('vals_raw', 'vals_nan', 'vals_corr', 'vals_model', 'source')
 
-    def get_msid_attrs(self, start, stop, msid, msid_args):
+    def get_msid_attrs(self, tstart, tstop, msid, msid_args):
+        """Get attributes for computed MSID: ``vals``, ``bads``, ``times``
+
+        :param tstart: start time (CXC secs)
+        :param tstop: stop time (CXC secs)
+        :param msid: full MSID name e.g. pm2thv1t_clean
+        :param msid_args: tuple of regex match groups (msid_name,)
+
+        :returns: dict of MSID attributes
+        """
         from .mups_valve import fetch_clean_msid
 
         # Get cleaned MUPS valve temperature data as an MSID object
-        dat = fetch_clean_msid(msid_args[0], start, stop,
+        dat = fetch_clean_msid(msid_args[0], tstart, tstop,
                                dt_thresh=5.0, median=7, model_spec=None)
 
         # Convert to dict as required by the get_msids_attrs API
         msid_attrs = {attr: getattr(dat, attr) for attr in self.msid_attrs}
 
         return msid_attrs
+
+
+class Comp_KadiCommandState(ComputedMsid):
+    """Computed MSID for kadi dynamic commanded states.
+
+    The MSID here takes the form ``cmd_state_<state_key>_<dt>`` where:
+    - ``state_key`` is a valid commanded state key such as ``pitch`` or
+      ``pcad_mode`` or ``acisfp_temp``.
+    - ``dt`` is the sampling time expressed as a multiple of 1.025 sec
+      frames.
+
+    Example MSID names::
+
+      'cmd_state_pcad_mode_1': sample ``pcad_mode`` every 1.025 secs
+      'cmd_state_acisfp_temp_32': sample ``acisfp_temp`` every 32.8 secs
+    """
+    msid_match = r'cmd_state_(\w+)_(\d+)'
+
+    def get_msid_attrs(self, start, stop, msid, msid_args):
+        """Get attributes for computed MSID: ``vals``, ``bads``, ``times``
+
+        :param tstart: start time (CXC secs)
+        :param tstop: stop time (CXC secs)
+        :param msid: full MSID name e.g. cmd_state_pitch_clean
+        :param msid_args: tuple of regex match groups: (state_key, dt)
+
+        :returns: dict of MSID attributes
+        """
+        from kadi.commands.states import get_states
+        from Chandra.Time import date2secs
+
+        state_key = msid_args[0]
+        dt = 1.025 * int(msid_args[1])
+        states = get_states(start, stop, state_keys=[state_key])
+
+        tstart = date2secs(states['datestart'][0])
+        tstops = date2secs(states['datestop'])
+
+        times = np.arange(tstart, tstops[-1], dt)
+        vals = states[state_key].view(np.ndarray)
+
+        indexes = np.searchsorted(tstops, times)
+
+        out = {'vals': vals[indexes],
+               'times': times,
+               'bads': np.zeros(len(times), dtype=bool)}
+
+        return out

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -1,0 +1,51 @@
+class ComputedMsid:
+    # Global dict of registered computed MSIDs
+    msid_classes = {}
+
+    # Default MSID attributes that are provided
+    msid_attrs = ('times', 'vals', 'bads')
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if not cls.__name__.startswith('Comp_'):
+            raise ValueError(f'comp class name {cls.__name__} must start with Comp_')
+        cls.msid_classes[cls.__name__.upper()] = cls
+
+    @property
+    def fetch_eng(self):
+        from .. import fetch_eng
+        return fetch_eng
+
+    @property
+    def fetch_sci(self):
+        from .. import fetch_sci
+        return fetch_sci
+
+    @property
+    def fetch_cxc(self):
+        from .. import fetch_cxc
+        return fetch_cxc
+
+    def __call__(self, start, stop):
+        dat = self.get_MSID(start, stop)
+        out = {attr: getattr(dat, attr) for attr in self.msid_attrs}
+        return out
+
+
+class Comp_MUPS_Clean:
+    msid_attrs = ComputedMsid.msid_attrs + ('vals_raw', 'vals_nan', 'vals_corr',
+                                            'vals_model', 'source')
+
+    def get_MSID(self, start, stop):
+        from .mups_valve import fetch_clean_msid
+        dat = fetch_clean_msid(self.msid.lower(), start, stop,
+                               dt_thresh=5.0, median=7, model_spec=None)
+        return dat
+
+
+class Comp_PM2THV1T(Comp_MUPS_Clean, ComputedMsid):
+    msid = 'pm2thv1t'
+
+
+class Comp_PM1THV2T(Comp_MUPS_Clean, ComputedMsid):
+    msid = 'pm1thv2t'

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -7,7 +7,7 @@ Support computed MSIDs in the cheta archive.
 - Commanded states 'cmd_state_<key>_<dt>' for any kadi commanded state value.
 
 See: https://nbviewer.jupyter.org/urls/cxc.harvard.edu/mta/ASPECT/ipynb/misc/DAWG-mups-valve-xija-filtering.ipynb
-"""
+""" # noqa
 
 import re
 
@@ -378,7 +378,7 @@ class Comp_KadiCommandState(ComputedMsid):
     """Computed MSID for kadi dynamic commanded states.
 
     The MSID here takes the form ``cmd_state_<state_key>_<dt>`` where:
-    
+
     * ``state_key`` is a valid commanded state key such as ``pitch`` or
       ``pcad_mode`` or ``acisfp_temp``.
     * ``dt`` is the sampling time expressed as a multiple of 1.025 sec

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -248,7 +248,7 @@ class Comp_MUPS_Valve_Temp_Clean(ComputedMsid):
 
         # Get cleaned MUPS valve temperature data as an MSID object
         dat = fetch_clean_msid(msid_args[0], tstart, tstop,
-                               dt_thresh=5.0, median=7, model_spec=None)
+                               dt_thresh=5.0, median=7, model_spec=None, unit='degc')
 
         # Convert to dict as required by the get_msids_attrs API
         msid_attrs = {attr: getattr(dat, attr) for attr in self.msid_attrs}

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -180,12 +180,6 @@ class ComputedMsid:
     def get_stats_attrs(self, tstart, tstop, msid, match_args, interval):
         from ..fetch import _plural
 
-        class MsidStub:
-            def __init__(self, kwargs):
-                self.state_codes = None
-                for key, val in kwargs.items():
-                    setattr(self, key, val)
-
         # Replicate a stripped-down version of processing in update_archive.
         # This produces a recarray with columns that correspond to the raw
         # stats HDF5 files.

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -129,7 +129,7 @@ class Comp_KadiCommandState(ComputedMsid):
     """
     msid_match = r'cmd_state_(\w+)_(\d+)'
 
-    def get_msid_attrs(self, start, stop, msid, msid_args):
+    def get_msid_attrs(self, tstart, tstop, msid, msid_args):
         """Get attributes for computed MSID: ``vals``, ``bads``, ``times``
 
         :param tstart: start time (CXC secs)
@@ -144,7 +144,7 @@ class Comp_KadiCommandState(ComputedMsid):
 
         state_key = msid_args[0]
         dt = 1.025 * int(msid_args[1])
-        states = get_states(start, stop, state_keys=[state_key])
+        states = get_states(tstart, tstop, state_keys=[state_key])
 
         tstart = date2secs(states['datestart'][0])
         tstops = date2secs(states['datestop'])

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -14,17 +14,10 @@ class ComputedMsid:
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
 
-        # Validate class name, msid_attrs, msid_match
-        if not cls.__name__.startswith('Comp_'):
-            raise ValueError(f'comp class name {cls.__name__} must start with Comp_')
-
         cls.msid_attrs = ComputedMsid.msid_attrs + cls.extra_msid_attrs
 
         if not hasattr(cls, 'msid_match'):
             raise ValueError(f'comp {cls.__name__} must define msid_match')
-
-        # Force match to include entire line
-        cls.msid_match = cls.msid_match + '$'
 
         cls.msid_classes.append(cls)
 

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -5,6 +5,8 @@ Support computed MSIDs in the cheta archive.
 - Base class ComputedMsid for user-generated comps.
 - Cleaned MUPS valve temperatures MSIDs: '(pm2thv1t|pm1thv2t)_clean'.
 - Commanded states 'cmd_state_<key>_<dt>' for any kadi commanded state value.
+
+See: https://nbviewer.jupyter.org/urls/cxc.harvard.edu/mta/ASPECT/ipynb/misc/DAWG-mups-valve-xija-filtering.ipynb
 """
 
 import re
@@ -208,9 +210,16 @@ class ComputedMsid:
     def get_msid_attrs(self, tstart, tstop, msid, msid_args):
         """Get the attributes required for this MSID.
 
-        TODO: detailed docs here since this is the main user-defined method
+        Get attributes for computed MSID, which must include at least
+        ``vals``, ``bads``, ``times``, and may include additional attributes.
+
+        :param tstart: start time (CXC secs)
+        :param tstop: stop time (CXC secs)
+        :param msid: full MSID name e.g. tephin_plus_5
+        :param msid_args: tuple of regex match groups (msid_name,)
+        :returns: dict of MSID attributes
         """
-        raise NotImplementedError()
+        raise NotImplementedError('sub-class must implement get_msid_attrs()')
 
     def get_stats_attrs(self, tstart, tstop, msid, match_args, interval):
         from ..fetch import _plural
@@ -256,6 +265,7 @@ class Comp_MUPS_Valve_Temp_Clean(ComputedMsid):
     telemetry values that are consistent with a thermal model.
 
     https://nbviewer.jupyter.org/urls/cxc.cfa.harvard.edu/mta/ASPECT/ipynb/misc/mups-valve-xija-filtering.ipynb
+    https://nbviewer.jupyter.org/urls/cxc.harvard.edu/mta/ASPECT/ipynb/misc/DAWG-mups-valve-xija-filtering.ipynb
 
     Allowed MSIDs are 'pm2thv1t_clean' and 'pm1thv2t_clean' (as always case is
     not important).

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -133,7 +133,7 @@ class ComputedMsid:
             MSID format is "comp_<MSID>_plus_<offset>".
             '''
             # Regex to match including arguments <MSID> and <offset>
-            msid_match = r'comp_(\w+)_plus_(\d+)'
+            msid_match = r'comp_(\w+)_plus_(\d+)'  # noqa
 
             def get_msid_attrs(self, tstart, tstop, msid, msid_args):
                 offset = int(msid_args[1])

--- a/Ska/engarchive/derived/mups_valve.py
+++ b/Ska/engarchive/derived/mups_valve.py
@@ -112,14 +112,8 @@ volt_with_resistor = [4.153325779, 3.676396578, 3.175100371, 2.587948965, 2.435,
                       1.538506813, 1.148359251, 0.63128179, 0.354868907, 0.208375569]
 volt_without_resistor = [28.223, 15, 9.1231, 5.5228, 4.87, 3.467, 2.249,
                          1.5027, 0.7253, 0.38276, 0.21769]
-temp_without_resistor = [50, 77, 100, 125, 130, 150, 175, 200, 250, 300, 350]
-
-volt_without_resistor_to_temp_without_resistor = interp1d(volt_without_resistor,
-                                                          temp_without_resistor)
-temp_without_resistor_to_volt_without_resistor = interp1d(temp_without_resistor,
-                                                          volt_without_resistor)
-volt_with_resistor_to_volt_without_resistor = interp1d(volt_with_resistor, volt_without_resistor)
-volt_without_resistor_to_volt_with_resistor = interp1d(volt_without_resistor, volt_with_resistor)
+volt_without_resistor_to_volt_with_resistor = interp1d(volt_without_resistor,
+                                                       volt_with_resistor)
 
 
 def get_corr_mups_temp(temp):

--- a/Ska/engarchive/derived/mups_valve.py
+++ b/Ska/engarchive/derived/mups_valve.py
@@ -1,0 +1,250 @@
+# coding: utf-8
+
+"""
+ Fetch clean MUPS valve temperature telemetry
+
+ This makes use of the temperature correction code provided by Scott Blanchard (to correct
+ for a resistor dropout in the thermistor data) and xija thermal model developed by
+ Matt Dahmer.
+
+ The basic cleaning algorithm is very simple:
+
+ - Fetch raw telemetry from the cheta archive.
+ - Compute a xija thermal model prediction for the same timespan (actually starting a few
+   days in advance to burn out uncertainty in the pseudo-node value).
+ - Accept either raw telemetry or corrected data which are within a tolerance (5 degF) of
+   the model.
+ - In the gaps where the model diverges from both raw and corrected temperatures,
+   "repropagate" the model starting from the last accepted temperature value.
+   This effectively takes out much of the systematic model error, which can be up to
+   15 degF after a transition to a new attitude.
+ - In some cases this allows recovery of additional data, while in others the data are
+   not recoverable: either due to partial disconnect of the parallel resistor or full
+   disconnects where the output voltage exceeds 5.12 V.
+
+ The output of this function is a `fetch.Msid` object with some bonus attributes,
+ documented below.  In particular the output cleaned data are labeled so one knows
+ exactly where each data point came from.
+
+ The function is fast, and one can get 5 years of cleaned telemetry in a few seconds
+ on a modern laptop with SSD drive.
+
+ This cleaning technique recovers on average about 90% of data for PM2THV1T.  Since
+ 2015, about 60% of telemetry is good (no dropout) while 30% is in a recoverable
+ fully-dropped state (and 10% is not recoverable).
+
+ ```
+ def fetch_clean_msid(msid, start, stop=None, dt_thresh=5.0, median=7, model_spec=None):
+
+     Fetch a cleaned version of telemetry for ``msid``.
+
+     If not supplied the model spec will be downloaded from github using this URL:
+       https://raw.githubusercontent.com/sot/chandra_models/master/chandra_models/xija/
+               mups_valve/{msid}_spec.json
+
+     This function returns a `fetch.Msid` object like a normal fetch but with extra attributes:
+
+     - vals: cleaned telemetry (either original or corrected telemetry, or xija model prediction)
+     - source: label for each vals data point
+       - 0: unrecoverable, so use xija model value
+       - 1: original telemetry
+       - 2: corrected telemetry
+     - vals_raw: raw (uncleaned) telemetry
+     - vals_nan: cleaned telem but with np.nan at points where data are unrecoverable (this is
+                 for plotting)
+     - vals_corr: telemetry with the MUPS correction applied
+     - vals_model: xija model prediction
+
+     :param start: start time
+     :param stop: stop time (default=NOW)
+     :param dt_thresh: tolerance for matching model to data in degF (default=5 degF)
+     :param median: length of median filter (default=7, use 0 to disable)
+     :param model_spec: file name or URL containing relevant xija model spec
+
+     :returns: fetch.Msid object
+ ```
+"""
+
+import os
+
+import numpy as np
+import numba
+from astropy.utils.data import download_file
+from scipy.interpolate import interp1d
+from scipy.ndimage import median_filter
+
+from cheta import fetch_eng
+from xija import XijaModel
+
+
+def c2f(degc):
+    degf = 32 + degc * 1.8
+    return degf
+
+
+# Define MUPS valve thermistor point pair calibration table (from TDB).
+pp_counts = np.array([0, 27, 36, 44, 55, 70, 90, 118, 175, 195, 210, 219, 226, 231, 235, 255])
+pp_temps = np.array([369.5305, 263.32577, 239.03652, 222.30608, 203.6944, 183.2642, 161.0796,
+                     134.93818, 85.65725, 65.6537, 47.3176, 33.50622, 19.9373, 7.42435, -5.79635,
+                     -111.77265])
+
+count_to_degf = interp1d(pp_counts, pp_temps)
+degf_to_counts = interp1d(pp_temps, pp_counts)
+
+# Define MUPS valve thermistor voltage point pair calibration table.
+count_to_volts = lambda counts: counts / 256 * 5.12
+volts_to_counts = lambda volts: volts / 5.12 * 256
+
+# Voltage and Temperature, with and without resistor (see flight note 447 for
+# the source of these numbers).
+
+volt_with_resistor = [4.153325779, 3.676396578, 3.175100371, 2.587948965, 2.435, 2.025223702,
+                      1.538506813, 1.148359251, 0.63128179, 0.354868907, 0.208375569]
+volt_without_resistor = [28.223, 15, 9.1231, 5.5228, 4.87, 3.467, 2.249,
+                         1.5027, 0.7253, 0.38276, 0.21769]
+temp_without_resistor = [50, 77, 100, 125, 130, 150, 175, 200, 250, 300, 350]
+
+volt_without_resistor_to_temp_without_resistor = interp1d(volt_without_resistor,
+                                                          temp_without_resistor)
+temp_without_resistor_to_volt_without_resistor = interp1d(temp_without_resistor,
+                                                          volt_without_resistor)
+volt_with_resistor_to_volt_without_resistor = interp1d(volt_with_resistor, volt_without_resistor)
+volt_without_resistor_to_volt_with_resistor = interp1d(volt_without_resistor, volt_with_resistor)
+
+
+def get_corr_mups_temp(temp):
+    """ Calculate a MUPS valve thermistor corrected temperature.
+    Args:
+        temp (float, int): Temperature in Fahrenheit to which a correction will be applied.
+
+    Returns:
+        (float): Corrected temperaure
+
+    """
+    # Convert observed temperature to voltage
+    count = degf_to_counts(temp)
+    volt = count_to_volts(count)
+
+    # Convert voltage as read, assuming no resistor, to what it would be with the resistor
+    new_volt = volt_without_resistor_to_volt_with_resistor(volt)
+
+    # Convert this new voltage to counts and, in turn, to a new temperature
+    new_count = volts_to_counts(new_volt)
+    new_temp = count_to_degf(new_count)
+
+    return new_temp
+
+
+@numba.autojit()
+def select_using_model(data1, data2, model, dt_thresh, out, source):
+    """Select from either ``data1`` or ``data2`` using ``model`` to get clean data.
+
+    This does a 2-step process:
+
+    1. Select either `data1` or `data2` where either is within `dt_thresh` of `model`.
+    2. Fill in gaps where possible by propagating the model from previous good data,
+       thus reducing the impact of model errors.
+
+    :param data1: ndarray of data (e.g. observed temperature telemetry)
+    :param data2: ndarray of data (e.g. corrected temperature telemetry)
+    :param model: ndarray with model prediction for data
+    :param dt_thresh: model error tolerance for selecting data1 or data2
+    :param out: ndarray where output cleaned data is stored (must be same length as data)
+    :param source: ndarray where output source labeling is stored (same length as data)
+    """
+    # Select all data where either data1 or data2 are within dt_thresh of model
+    for data, source_id in [(data1, 1), (data2, 2)]:
+        ok = np.abs(data - model) < dt_thresh
+        out[ok] = data[ok]
+        source[ok] = source_id
+
+    # Fill in gaps where possible by propagating model from last good data value
+    for ii in range(len(data1)):
+        if source[ii] != 0:
+            # Already got a good value so move on.
+            continue
+
+        if ii == 0:
+            model_prop_ii = model[0]
+        else:
+            # Propagate model using last point + delta-model
+            model_prop_ii = out[ii-1] + (model[ii] - model[ii-1])  # noqa
+
+        if abs(data1[ii] - model_prop_ii) < dt_thresh:
+            out[ii] = data1[ii]
+            source[ii] = 1
+        elif abs(data2[ii] - model_prop_ii) < dt_thresh:
+            out[ii] = data2[ii]
+            source[ii] = 2
+        else:
+            # No good match, use propagated model value and mark as such
+            out[ii] = model_prop_ii
+            source[ii] = 0
+
+
+def fetch_clean_msid(msid, start, stop=None, dt_thresh=5.0, median=7, model_spec=None):
+    """Fetch a cleaned version of telemetry for ``msid``.
+
+    If not supplied the model spec will be downloaded from github using this URL:
+      https://raw.githubusercontent.com/sot/chandra_models/master/chandra_models/xija/
+              mups_valve/{msid}_spec.json
+
+    This function returns a `fetch.Msid` object like a normal fetch but with extra attributes:
+
+    - vals: cleaned telemetry (either original or corrected telemetry, or xija model prediction)
+    - source: label for each vals data point
+      - 0: unrecoverable, so use xija model value
+      - 1: original telemetry
+      - 2: corrected telemetry
+    - vals_raw: raw (uncleaned) telemetry
+    - vals_nan: cleaned telem but with np.nan at points where data are unrecoverable (this is
+                for plotting)
+    - vals_corr: telemetry with the MUPS correction applied
+    - vals_model: xija model prediction
+
+    :param start: start time
+    :param stop: stop time (default=NOW)
+    :param dt_thresh: tolerance for matching model to data in degF (default=5 degF)
+    :param median: length of median filter (default=7, use 0 to disable)
+    :param model_spec: file name or URL containing relevant xija model spec
+
+    :returns: fetch.Msid object
+    """
+    if model_spec is None or not os.path.exists(model_spec):
+        url = (f'https://raw.githubusercontent.com/sot/chandra_models/master/chandra_models/xija/'
+               f'mups_valve/{msid}_spec.json')
+        model_spec = download_file(url, cache=True)
+
+    dat = fetch_eng.Msid(msid, start, stop)
+
+    t_obs = dat.vals
+    if median:
+        t_obs = median_filter(t_obs, size=median)
+    t_corr = get_corr_mups_temp(t_obs)
+
+    mdl = XijaModel(model_spec=model_spec,
+                    start=dat.times[0] - 400000,
+                    stop=dat.times[-1])
+    mdl.comp['mups0'].set_data(75)
+    mdl.make()
+    mdl.calc()
+
+    t_model = np.interp(xp=mdl.times, fp=c2f(mdl.comp[msid].mvals), x=dat.times)
+
+    out = np.zeros_like(dat.vals)
+    source = np.zeros(len(dat.vals), dtype=int)
+    select_using_model(t_obs, t_corr, t_model, dt_thresh=dt_thresh, out=out, source=source)
+
+    dat.vals_raw = dat.vals
+
+    dat.vals = out
+    dat.vals_nan = out.copy()
+
+    dat.bads = (source == 0)
+    dat.vals_nan[dat.bads] = np.nan
+
+    dat.source = source
+    dat.vals_corr = t_corr
+    dat.vals_model = t_model
+
+    return dat

--- a/Ska/engarchive/derived/mups_valve.py
+++ b/Ska/engarchive/derived/mups_valve.py
@@ -91,13 +91,18 @@ pp_temps = np.array([369.5305, 263.32577, 239.03652, 222.30608, 203.6944, 183.26
 count_to_degf = interp1d(pp_counts, pp_temps)
 degf_to_counts = interp1d(pp_temps, pp_counts)
 
+
 # Define MUPS valve thermistor voltage point pair calibration table.
-count_to_volts = lambda counts: counts / 256 * 5.12
-volts_to_counts = lambda volts: volts / 5.12 * 256
+def count_to_volts(counts):
+    return counts / 256 * 5.12
+
+
+def volts_to_counts(volts):
+    return volts / 5.12 * 256
+
 
 # Voltage and Temperature, with and without resistor (see flight note 447 for
 # the source of these numbers).
-
 volt_with_resistor = [4.153325779, 3.676396578, 3.175100371, 2.587948965, 2.435, 2.025223702,
                       1.538506813, 1.148359251, 0.63128179, 0.354868907, 0.208375569]
 volt_without_resistor = [28.223, 15, 9.1231, 5.5228, 4.87, 3.467, 2.249,

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -585,8 +585,6 @@ class MSID(object):
 
         comp_cls = ComputedMsid.get_matching_comp_cls(self.msid)
         if comp_cls:
-            if self.stat:
-                raise ValueError('stats are not supported for computed MSIDs')
             self._get_comp_data(comp_cls)
             return
 
@@ -636,7 +634,7 @@ class MSID(object):
         logger.info(f'Getting comp data for {self.msid}')
 
         # Do computation.  This returns a dict of MSID attribute values.
-        dat = comp_cls()(self.tstart, self.tstop, self.msid)
+        dat = comp_cls()(self.tstart, self.tstop, self.msid, self.stat)
 
         # Allow upstream class to be a bit sloppy on times and include samples
         # outside the time range.  This can happen with classes that inherit

--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -24,8 +24,8 @@ class Comp_Val_Plus_Five(ComputedMsid):
     """Silly base comp to add 5 to the value"""
     msid_match = r'comp_(\w+)_plus_five'
 
-    def get_msid_attrs(self, start, stop, msid, msid_args):
-        dat = self.fetch_eng.MSID(msid_args[0], start, stop)
+    def get_msid_attrs(self, tstart, tstop, msid, msid_args):
+        dat = self.fetch_eng.MSID(msid_args[0], tstart, tstop)
 
         out = {'vals': dat.vals + 5,
                'bads': dat.bads,
@@ -46,9 +46,9 @@ class Comp_CSS1_NPM_SUN(ComputedMsid, DerivedParameter):
     max_gap = 10.0
     msid_match = 'comp_css1_npm_sun'
 
-    def get_msid_attrs(self, start, stop, msid, msid_args):
+    def get_msid_attrs(self, tstart, tstop, msid, msid_args):
         # Get an interpolated MSIDset for rootparams
-        msids = self.fetch(start, stop)
+        msids = self.fetch(tstart, tstop)
 
         # Do the computation and set bad values
         npm_sun = ((msids['aopcadmd'].vals == 'NPNT') &

--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -104,13 +104,6 @@ def test_simple_comp_with_maude():
         assert np.all(dat1.bads == dat2.bads)
 
 
-def test_comp_with_stat():
-    with pytest.raises(ValueError,
-                       match='stats are not supported for computed MSIDs'):
-        fetch_eng.Msid('comp_tephin_plus_five',
-                       '2020:001', '2020:010', stat='5min')
-
-
 def test_mups_valve():
     colnames = ['times', 'vals', 'bads', 'vals_raw',
                 'vals_nan', 'vals_corr', 'vals_model', 'source']

--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -102,27 +102,27 @@ def test_mups_valve():
     colnames = ['times', 'vals', 'bads', 'vals_raw',
                 'vals_nan', 'vals_corr', 'vals_model', 'source']
 
-    dat = fetch.MSID('comp_PM2THV1T', '2020:001', '2020:010')
+    dat = fetch.MSID('PM2THV1T_clean', '2020:001', '2020:010')
     assert len(dat.vals) == 36661
     assert np.count_nonzero(dat.source != 0) == 34499
     assert dat.colnames == colnames
     for attr in colnames:
         assert len(dat.vals) == len(getattr(dat, attr))
 
-    dat = fetch.Msid('comp_PM2THV1T', '2020:001', '2020:010')
+    dat = fetch.Msid('PM2THV1T_clean', '2020:001', '2020:010')
     assert len(dat.vals) == 34499  # Some bad values
     assert dat.colnames == colnames
     for attr in colnames:
         if attr != 'bads':
             assert len(dat.vals) == len(getattr(dat, attr))
 
-    dat = fetch.MSID('comp_PM1THV2T', '2020:001', '2020:010')
+    dat = fetch.MSID('PM1THV2T_clean', '2020:001', '2020:010')
     assert len(dat.vals) == 36661  # Same as PM2THV1T
     assert dat.colnames == colnames
     for attr in colnames:
         assert len(dat.vals) == len(getattr(dat, attr))
 
-    dat = fetch.Msid('comp_PM1THV2T', '2020:001', '2020:010')
+    dat = fetch.Msid('pm1thv2t_clean', '2020:001', '2020:010')
     assert len(dat.vals) == 36240  # Some bad values
     assert len(dat.source) == 36240  # Filtering applies to sources
     assert dat.colnames == colnames

--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -105,7 +105,7 @@ def test_simple_comp_with_maude():
 
 
 def test_mups_valve():
-    colnames = ['times', 'vals', 'bads', 'vals_raw',
+    colnames = ['vals', 'times', 'bads', 'vals_raw',
                 'vals_nan', 'vals_corr', 'vals_model', 'source']
 
     dat = fetch.MSID('PM2THV1T_clean', '2020:001', '2020:010')
@@ -172,4 +172,3 @@ def test_stats(stat):
             assert np.allclose(val, valc)
         else:
             assert np.all(val == valc)
-

--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -1,0 +1,132 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Test that computed MSIDs work as expected."""
+
+import numpy as np
+import pytest
+
+from ..derived.base import DerivedParameter
+from ..derived.comps import ComputedMsid
+
+try:
+    import maude
+    date1 = '2016:001:00:00:00.1'
+    date2 = '2016:001:00:00:02.0'
+    maude.get_msids(msids='ccsdsid', start=date1, stop=date2)
+except Exception:
+    HAS_MAUDE = False
+else:
+    HAS_MAUDE = True
+
+
+class Comp_Plus_Five:
+    """Silly base comp to add 5 to the value"""
+    def get_MSID(self, start, stop):
+        dat = self.fetch_eng.MSID(self.msid, start, stop)
+        dat.vals = dat.vals + 5
+        return dat
+
+
+class Comp_TEPHIN_Plus_Five(Comp_Plus_Five, ComputedMsid):
+    msid = 'tephin'
+
+
+class Comp_CSS1_NPM_SUN(DerivedParameter, ComputedMsid):
+    """Coarse Sun Sensor Counts 1 filtered for NPM and SA Illuminated
+
+    Defined as CSS-1 current converted back into counts
+    (AOCSSI1 * 4095 / 5.49549) when in NPM (AOPCADMD==1) and SA is illuminated
+    (AOSAILLM==1).  Otherwise, "Bads" flag is set equal to one.
+
+    """
+    rootparams = ['aocssi1', 'aopcadmd', 'aosaillm']
+    time_step = 1.025
+    max_gap = 10.0
+
+    def __call__(self, start, stop):
+        # Get an interpolated MSIDset for rootparams
+        msids = self.fetch(start, stop)
+
+        # Do the computation and set bad values
+        npm_sun = ((msids['aopcadmd'].vals == 'NPNT') &
+                   (msids['aosaillm'].vals == 'ILLM'))
+        msids.bads = msids.bads | ~npm_sun
+        css1_npm_sun = msids['aocssi1'].vals * 4095 / 5.49549
+
+        out = {'vals': css1_npm_sun,
+               'times': msids.times,
+               'bads': msids.bads}
+        return out
+
+
+# Need to add classes before importing fetch
+from .. import fetch_eng, fetch
+
+
+def test_comp_from_derived_parameter():
+    """Test that on-the-fly comp gives same result as derived parameter from
+    same code.
+    """
+    dat1 = fetch_eng.Msid('comp_css1_npm_sun', '2020:001', '2020:010')
+    dat2 = fetch_eng.Msid('dp_css1_npm_sun', '2020:001', '2020:010')
+
+    for attr in ('vals', 'times', 'bads'):
+        assert np.all(getattr(dat1, attr) == getattr(dat2, attr))
+
+
+def test_simple_comp():
+    dat1 = fetch_eng.Msid('tephin', '2020:001', '2020:010')
+    dat2 = fetch_eng.Msid('comp_tephin_plus_five', '2020:001', '2020:010')
+    assert np.all(dat1.vals + 5 == dat2.vals)
+    assert np.all(dat1.times == dat2.times)
+    assert np.all(dat1.bads == dat2.bads)
+
+
+@pytest.mark.skipif("not HAS_MAUDE")
+def test_simple_comp_with_maude():
+    with fetch.data_source('maude'):
+        dat1 = fetch_eng.Msid('tephin', '2020:001', '2020:003')
+        dat2 = fetch_eng.Msid('comp_tephin_plus_five', '2020:001', '2020:003')
+        assert np.all(dat1.vals + 5 == dat2.vals)
+        assert np.all(dat1.times == dat2.times)
+        assert np.all(dat1.bads == dat2.bads)
+
+
+def test_comp_with_stat():
+    with pytest.raises(ValueError,
+                       match='stats are not supported for computed MSIDs'):
+        fetch_eng.Msid('comp_tephin_plus_five',
+                       '2020:001', '2020:010', stat='5min')
+
+
+def test_mups_valve():
+    colnames = ['times', 'vals', 'bads', 'vals_raw',
+                'vals_nan', 'vals_corr', 'vals_model', 'source']
+
+    dat = fetch.MSID('comp_PM2THV1T', '2020:001', '2020:010')
+    assert len(dat.vals) == 36661
+    assert np.count_nonzero(dat.source != 0) == 34499
+    assert dat.colnames == colnames
+    for attr in colnames:
+        assert len(dat.vals) == len(getattr(dat, attr))
+
+    dat = fetch.Msid('comp_PM2THV1T', '2020:001', '2020:010')
+    assert len(dat.vals) == 34499  # Some bad values
+    assert dat.colnames == colnames
+    for attr in colnames:
+        if attr != 'bads':
+            assert len(dat.vals) == len(getattr(dat, attr))
+
+    dat = fetch.MSID('comp_PM1THV2T', '2020:001', '2020:010')
+    assert len(dat.vals) == 36661  # Same as PM2THV1T
+    assert dat.colnames == colnames
+    for attr in colnames:
+        assert len(dat.vals) == len(getattr(dat, attr))
+
+    dat = fetch.Msid('comp_PM1THV2T', '2020:001', '2020:010')
+    assert len(dat.vals) == 36240  # Some bad values
+    assert len(dat.source) == 36240  # Filtering applies to sources
+    assert dat.colnames == colnames
+    for attr in colnames:
+        if attr != 'bads':
+            assert len(dat.vals) == len(getattr(dat, attr))

--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-from .. import fetch_eng, fetch
+from .. import fetch_eng, fetch_sci, fetch as fetch_cxc
 from ..derived.base import DerivedParameter
 from ..derived.comps import ComputedMsid
 
@@ -29,7 +29,8 @@ class Comp_Passthru(ComputedMsid):
 
         out = {'vals': dat.vals,
                'bads': dat.bads,
-               'times': dat.times}
+               'times': dat.times,
+               'unit': dat.unit}
         return out
 
 
@@ -38,11 +39,12 @@ class Comp_Val_Plus_Five(ComputedMsid):
     msid_match = r'comp_(\w+)_plus_five'
 
     def get_msid_attrs(self, tstart, tstop, msid, msid_args):
-        dat = self.fetch_eng.MSID(msid_args[0], tstart, tstop)
+        dat = self.fetch_sys.MSID(msid_args[0], tstart, tstop)
 
         out = {'vals': dat.vals + 5,
                'bads': dat.bads,
-               'times': dat.times}
+               'times': dat.times,
+               'unit': dat.unit}
         return out
 
 
@@ -71,7 +73,8 @@ class Comp_CSS1_NPM_SUN(ComputedMsid, DerivedParameter):
 
         out = {'vals': css1_npm_sun,
                'times': msids.times,
-               'bads': msids.bads}
+               'bads': msids.bads,
+               'unit': None}
         return out
 
 
@@ -82,53 +85,74 @@ def test_comp_from_derived_parameter():
     dat1 = fetch_eng.Msid('comp_css1_npm_sun', '2020:001', '2020:010')
     dat2 = fetch_eng.Msid('dp_css1_npm_sun', '2020:001', '2020:010')
 
-    for attr in ('vals', 'times', 'bads'):
+    for attr in ('vals', 'times', 'bads', 'unit'):
         assert np.all(getattr(dat1, attr) == getattr(dat2, attr))
 
 
-def test_simple_comp():
-    dat1 = fetch_eng.Msid('tephin', '2020:001', '2020:010')
-    dat2 = fetch_eng.Msid('comp_tephin_plus_five', '2020:001', '2020:010')
+@pytest.mark.parametrize('fetch,unit', [(fetch_eng, 'DEGF'),
+                                        (fetch_sci, 'DEGC'),
+                                        (fetch_cxc, 'K')])
+def test_simple_comp(fetch, unit):
+    dat1 = fetch.Msid('tephin', '2020:001', '2020:010')
+    dat2 = fetch.Msid('comp_tephin_plus_five', '2020:001', '2020:010')
     assert np.all(dat1.vals + 5 == dat2.vals)
     assert np.all(dat1.times == dat2.times)
     assert np.all(dat1.bads == dat2.bads)
+    assert dat1.unit == dat2.unit
+    assert dat2.unit == unit
 
 
 @pytest.mark.skipif("not HAS_MAUDE")
-def test_simple_comp_with_maude():
+@pytest.mark.parametrize('fetch,unit', [(fetch_eng, 'DEGF'),
+                                        (fetch_sci, 'DEGC'),
+                                        (fetch_cxc, 'K')])
+def test_simple_comp_with_maude(fetch, unit):
     with fetch.data_source('maude'):
-        dat1 = fetch_eng.Msid('tephin', '2020:001', '2020:003')
-        dat2 = fetch_eng.Msid('comp_tephin_plus_five', '2020:001', '2020:003')
+        dat1 = fetch.Msid('tephin', '2020:001', '2020:003')
+        dat2 = fetch.Msid('comp_tephin_plus_five', '2020:001', '2020:003')
         assert np.all(dat1.vals + 5 == dat2.vals)
         assert np.all(dat1.times == dat2.times)
         assert np.all(dat1.bads == dat2.bads)
+        assert dat1.unit == dat2.unit
+        assert dat2.unit == unit
 
 
 def test_mups_valve():
     colnames = ['vals', 'times', 'bads', 'vals_raw',
                 'vals_nan', 'vals_corr', 'vals_model', 'source']
 
-    dat = fetch.MSID('PM2THV1T_clean', '2020:001', '2020:010')
+    dat = fetch_eng.MSID('PM2THV1T_clean', '2020:001', '2020:010')
+    assert dat.unit == 'DEGF'
     assert len(dat.vals) == 36661
-    assert np.count_nonzero(dat.source != 0) == 34499
+    ok = dat.source != 0
+    # Temps are reasonable for degF
+    assert np.all((dat.vals[ok] > 55) & (dat.vals[ok] < 220))
+    assert np.count_nonzero(ok) == 34499
     assert dat.colnames == colnames
     for attr in colnames:
         assert len(dat.vals) == len(getattr(dat, attr))
 
-    dat = fetch.Msid('PM2THV1T_clean', '2020:001', '2020:010')
+    dat = fetch_sci.Msid('PM2THV1T_clean', '2020:001', '2020:010')
+    assert dat.unit == 'DEGC'
+    ok = dat.source != 0
+    # Temps are reasonable for degC
+    assert np.all((dat.vals[ok] > 10) & (dat.vals[ok] < 110))
     assert len(dat.vals) == 34499  # Some bad values
     assert dat.colnames == colnames
     for attr in colnames:
         if attr != 'bads':
             assert len(dat.vals) == len(getattr(dat, attr))
 
-    dat = fetch.MSID('PM1THV2T_clean', '2020:001', '2020:010')
+    dat = fetch_cxc.MSID('PM1THV2T_clean', '2020:001', '2020:010')
+    ok = dat.source != 0
+    # Temps are reasonable for K
+    assert np.all((dat.vals[ok] > 280) & (dat.vals[ok] < 380))
     assert len(dat.vals) == 36661  # Same as PM2THV1T
     assert dat.colnames == colnames
     for attr in colnames:
         assert len(dat.vals) == len(getattr(dat, attr))
 
-    dat = fetch.Msid('pm1thv2t_clean', '2020:001', '2020:010')
+    dat = fetch_eng.Msid('pm1thv2t_clean', '2020:001', '2020:010')
     assert len(dat.vals) == 36240  # Some bad values
     assert len(dat.source) == 36240  # Filtering applies to sources
     assert dat.colnames == colnames
@@ -139,15 +163,16 @@ def test_mups_valve():
 
 def test_cmd_states():
     start, stop = '2020:002:08:00:00', '2020:002:10:00:00'
-    dat = fetch.Msid('cmd_state_pitch_1000', start, stop)
+    dat = fetch_eng.Msid('cmd_state_pitch_1000', start, stop)
     exp_vals = np.array([55.99128956, 55.8747053, 55.8747053, 90.66266599,
                          159.06945155, 173.11528258, 173.11528258, 173.11528258])
     assert np.allclose(dat.vals, exp_vals)
     assert type(dat.vals) is np.ndarray
     assert np.allclose(np.diff(dat.times), 1025.0)
     assert not np.any(dat.bads)
+    assert dat.unit is None
 
-    dat = fetch.Msid('cmd_state_pcad_mode_1000', start, stop)
+    dat = fetch_eng.Msid('cmd_state_pcad_mode_1000', start, stop)
     exp_vals = np.array(['NPNT', 'NPNT', 'NPNT', 'NMAN', 'NMAN', 'NPNT', 'NPNT', 'NPNT'])
     assert np.all(dat.vals == exp_vals)
     assert type(dat.vals) is np.ndarray
@@ -158,8 +183,8 @@ def test_cmd_states():
 def test_stats(stat):
     start, stop = '2020:001', '2020:010'
 
-    dat = fetch.Msid('pitch', start, stop, stat=stat)
-    datc = fetch.Msid('passthru_pitch', start, stop, stat=stat)
+    dat = fetch_eng.Msid('pitch', start, stop, stat=stat)
+    datc = fetch_eng.Msid('passthru_pitch', start, stop, stat=stat)
 
     for attr in datc.colnames:
         val = getattr(dat, attr)

--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -129,3 +129,20 @@ def test_mups_valve():
     for attr in colnames:
         if attr != 'bads':
             assert len(dat.vals) == len(getattr(dat, attr))
+
+
+def test_cmd_states():
+    start, stop = '2020:002:08:00:00', '2020:002:10:00:00'
+    dat = fetch.Msid('cmd_state_pitch_1000', start, stop)
+    exp_vals = np.array([55.99128956, 55.8747053, 55.8747053, 90.66266599,
+                         159.06945155, 173.11528258, 173.11528258, 173.11528258])
+    assert np.allclose(dat.vals, exp_vals)
+    assert type(dat.vals) is np.ndarray
+    assert np.allclose(np.diff(dat.times), 1025.0)
+    assert not np.any(dat.bads)
+
+    dat = fetch.Msid('cmd_state_pcad_mode_1000', start, stop)
+    exp_vals = np.array(['NPNT', 'NPNT', 'NPNT', 'NMAN', 'NMAN', 'NPNT', 'NPNT', 'NPNT'])
+    assert np.all(dat.vals == exp_vals)
+    assert type(dat.vals) is np.ndarray
+    assert np.allclose(np.diff(dat.times), 1025.0)

--- a/Ska/engarchive/units.py
+++ b/Ska/engarchive/units.py
@@ -93,6 +93,13 @@ def F_to_C(vals, delta_val=False):
         return (vals - 32.0) / 1.8
 
 
+def C_to_F(vals, delta_val=False):
+    if delta_val:
+        return vals * 1.8
+    else:
+        return vals * 1.8 + 32
+
+
 def C_to_K(vals, delta_val=False):
     if delta_val:
         return vals
@@ -171,6 +178,7 @@ converters = {
     ('mm', 'TSCSTEP'): mult(1.0 / 0.00251431530156, decimals=3),
     ('mm', 'FASTEP'): mm_to_FASTEP,
     ('PWM', 'PWMSTEP'): mult(16),
+    ('DEGC', 'DEGF'): C_to_F,
 
     # Eng units to CXC or Sci
     ('DEGC', 'K'): C_to_K,

--- a/doc/fetch_tutorial.rst
+++ b/doc/fetch_tutorial.rst
@@ -1547,7 +1547,7 @@ local or remote.
 In order to use this option, the user must have a special key file
 ``ska_remote_access.json``placed at the root of the local Python installation folder.  This is
 placed in the directory shown with ``import sys; print(sys.prefix)``.  To get a copy of this file
- contact Mark Baski or Tom Aldcroft.
+contact Mark Baski or Tom Aldcroft.
 
 Remote access is controlled as follows:
 
@@ -1559,3 +1559,11 @@ Remote access is controlled as follows:
   is *enabled* unless the system finds a local engineering data archive.  It looks
   for data in either ``$SKA/data/eng_archive`` or ``$ENG_ARCHIVE``, where those
   refer to user-defined environment variables.
+
+Local cheta archive
+===================
+
+Instructions for creating, using, and maintaining a local cheta archive (on your
+laptop for instance) are found at the `Tutorial for installing and maintaining a
+cheta telemetry archive
+<https://github.com/sot/eng_archive/wiki/Tutorial:-install-and-maintain-cheta-telemetry-archive>`_.

--- a/doc/pseudo_msids.rst
+++ b/doc/pseudo_msids.rst
@@ -663,9 +663,15 @@ Computed MSIDs
 Cheta provides support for on-the-fly computed MSIDs with the following features:
 
 * Designed for simplicity and ease of use by non-expert Ska3 users.
-* Following a simple recipe in user code, new MSIDs are automatically registered to fetch.
-* Computed MSIDs can included embedded parameters to allow further customization or application of a function to any other MSID.
+* Following a simple recipe in user code, new MSIDs are automatically registered
+  to fetch.
+* Computed MSIDs can included embedded parameters to allow further customization
+  or application of a function to any other MSID.
 * Support for 5-minute and daily stats also included.
+
+See the `DAWG computed MSIDs notebook
+<https://nbviewer.jupyter.org/urls/cxc.harvard.edu/mta/ASPECT/ipynb/misc/DAWG-cheta-computed-msids.ipynb>`_
+for a longer introduction to the topic with a number of examples.
 
 What's the advantage?
 ^^^^^^^^^^^^^^^^^^^^^
@@ -674,19 +680,80 @@ If you have a function of MSID values, what is the advantage of going through
 this formalism to create a computed MSID instead of just using the function
 output directly?
 
-* It gives you the entire :func:`~Ska.engarchive.fetch.MSID` API!  You get for free all the
-  `fetch bling <https://cxc.cfa.harvard.edu/mta/ASPECT/tool_doc/eng_archive/fetch_tutorial.html`_
+* It gives you the entire fetch API!  You get for free all the
+  `fetch bling <https://cxc.cfa.harvard.edu/mta/ASPECT/tool_doc/eng_archive/fetch_tutorial.html>`_
   like plotting, selecting intervals, kadi event integration, interpolation.
-* If your computed MSID is useful enough it will be trivial to add to the released ``cheta``
-  for other users.
+* If your computed MSID is useful to the community it is simple to add to the
+  released ``cheta`` package for other users.
 * It allows creation of arbitrary MSIDs that can be used in xija models.  Examples:
   - ``pm2tv1t_clean`` as a ``Node`` component
   - ``cmd_state_acisfp_temp_32`` as a telemetry input (``TelemData`` component).
 
-  Built-in computed MSIDs and API
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Example
+^^^^^^^
 
-  .. automodule:: Ska.engarchive.derived.thermal
+This example is not terribly useful but illustrates the key concepts and
+requirements for defining a computed MSID::
+
+   from cheta.derived.comps import ComputedMsid  # Inherit from this class
+
+   # Class name is arbitrary, but by convention start with `Comp_`
+   class Comp_Val_Plus_Offset(ComputedMsid):
+      """
+      Computed MSID to add an integer offset to MSID value.
+
+      MSID format is "<MSID>_plus_<offset>", where <MSID> is an existing MSID
+      in the archive and <offset> is an integer offset.
+
+      """
+      msid_match = r'(\w+)_plus_(\d+)'
+
+      # `msid_match` is a class attribute that defines a regular expresion to
+      # match for this computed MSID.  This must be defined and it must be
+      # unambiguous (not matching an existing MSID or other computed MSID).
+      #
+      # The two groups in parentheses specify the arguments <MSID> and <offset>.
+      # These are passed to `get_msid_attrs` as msid_args[0] and msid_args[1].
+      # The \w symbol means to match a-z, A-Z, 0-9 and underscore (_).
+      # The \d symbol means to match digits 0-9.
+
+      def get_msid_attrs(self, tstart, tstop, msid, msid_args):
+          """
+          Get attributes for computed MSID: ``vals``, ``bads``, ``times``,
+          ``raw_vals``, and ``offset``.  The first three must always be
+          provided.
+
+          :param tstart: start time (CXC secs)
+          :param tstop: stop time (CXC secs)
+          :param msid: full MSID name e.g. tephin_plus_5
+          :param msid_args: tuple of regex match groups (msid_name,)
+             :returns: dict of MSID attributes
+          """
+          # Process the arguments parsed from the MSID
+          msid  msid_args[0]
+          offset = int(msid_args[1])
+
+          # Get the raw telemetry value in engineering units
+          dat = self.fetch_eng.MSID(msid, tstart, tstop)
+
+          # Do the computation
+          vals = dat.vals + offset
+
+          # Return a dict with at least `vals`, `times` and `bads`.
+          # Additional attributes are allowed and will be set on the
+          # final MSID object.
+          out = {'vals': vals,
+                 'bads': dat.bads,
+                 'times': dat.times,
+                 'vals_raw': dat.vals,  # Provide original values without offset
+                 'offset': offset  # Provide the offset for reference
+                 }
+          return out
+
+Built-in computed MSIDs and API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  .. automodule:: Ska.engarchive.derived.comps
    :members:
    :undoc-members:
 

--- a/doc/pseudo_msids.rst
+++ b/doc/pseudo_msids.rst
@@ -8,7 +8,8 @@ stream are also available in the archive.  These are:
 * ACIS DEA housekeeping: status from the DEA (including detector focal plane temperature)
 * Ephemeris: predictive and definitive orbital (Chandra), solar, and lunar ephemeris values
 * SIM telemetry: SIM position and moving status
-* Derived parameters: values computed from other MSIDs in the archive
+* Derived parameters: values computed from other MSIDs in the archive and stored in archive files
+* Computed parameters: values computed on the fly from other MSIDs
 
 ACIS DEA housekeeping
 --------------------------------------------------
@@ -653,6 +654,39 @@ PCAD
 Thermal
 ^^^^^^^^^
 .. automodule:: Ska.engarchive.derived.thermal
+   :members:
+   :undoc-members:
+
+Computed MSIDs
+--------------
+
+Cheta provides support for on-the-fly computed MSIDs with the following features:
+
+* Designed for simplicity and ease of use by non-expert Ska3 users.
+* Following a simple recipe in user code, new MSIDs are automatically registered to fetch.
+* Computed MSIDs can included embedded parameters to allow further customization or application of a function to any other MSID.
+* Support for 5-minute and daily stats also included.
+
+What's the advantage?
+^^^^^^^^^^^^^^^^^^^^^
+
+If you have a function of MSID values, what is the advantage of going through
+this formalism to create a computed MSID instead of just using the function
+output directly?
+
+* It gives you the entire :func:`~Ska.engarchive.fetch.MSID` API!  You get for free all the
+  `fetch bling <https://cxc.cfa.harvard.edu/mta/ASPECT/tool_doc/eng_archive/fetch_tutorial.html`_
+  like plotting, selecting intervals, kadi event integration, interpolation.
+* If your computed MSID is useful enough it will be trivial to add to the released ``cheta``
+  for other users.
+* It allows creation of arbitrary MSIDs that can be used in xija models.  Examples:
+  - ``pm2tv1t_clean`` as a ``Node`` component
+  - ``cmd_state_acisfp_temp_32`` as a telemetry input (``TelemData`` component).
+
+  Built-in computed MSIDs and API
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  .. automodule:: Ska.engarchive.derived.thermal
    :members:
    :undoc-members:
 

--- a/doc/pseudo_msids.rst
+++ b/doc/pseudo_msids.rst
@@ -686,8 +686,8 @@ output directly?
 * If your computed MSID is useful to the community it is simple to add to the
   released ``cheta`` package for other users.
 * It allows creation of arbitrary MSIDs that can be used in xija models.  Examples:
-  - ``pm2tv1t_clean`` as a ``Node`` component
-  - ``cmd_state_acisfp_temp_32`` as a telemetry input (``TelemData`` component).
+  * ``pm2tv1t_clean`` as a ``Node`` component
+  * ``cmd_state_acisfp_temp_32`` as a telemetry input (``TelemData`` component).
 
 Example
 ^^^^^^^
@@ -695,60 +695,60 @@ Example
 This example is not terribly useful but illustrates the key concepts and
 requirements for defining a computed MSID::
 
-   from cheta.derived.comps import ComputedMsid  # Inherit from this class
+    from cheta.derived.comps import ComputedMsid  # Inherit from this class
 
-   # Class name is arbitrary, but by convention start with `Comp_`
-   class Comp_Val_Plus_Offset(ComputedMsid):
-      """
-      Computed MSID to add an integer offset to MSID value.
+    # Class name is arbitrary, but by convention start with `Comp_`
+    class Comp_Val_Plus_Offset(ComputedMsid):
+        """
+        Computed MSID to add an integer offset to MSID value.
 
-      MSID format is "<MSID>_plus_<offset>", where <MSID> is an existing MSID
-      in the archive and <offset> is an integer offset.
+        MSID format is "<MSID>_plus_<offset>", where <MSID> is an existing MSID
+        in the archive and <offset> is an integer offset.
 
-      """
-      msid_match = r'(\w+)_plus_(\d+)'
+        """
+        msid_match = r'(\w+)_plus_(\d+)'
 
-      # `msid_match` is a class attribute that defines a regular expresion to
-      # match for this computed MSID.  This must be defined and it must be
-      # unambiguous (not matching an existing MSID or other computed MSID).
-      #
-      # The two groups in parentheses specify the arguments <MSID> and <offset>.
-      # These are passed to `get_msid_attrs` as msid_args[0] and msid_args[1].
-      # The \w symbol means to match a-z, A-Z, 0-9 and underscore (_).
-      # The \d symbol means to match digits 0-9.
+        # `msid_match` is a class attribute that defines a regular expresion to
+        # match for this computed MSID.  This must be defined and it must be
+        # unambiguous (not matching an existing MSID or other computed MSID).
+        #
+        # The two groups in parentheses specify the arguments <MSID> and <offset>.
+        # These are passed to `get_msid_attrs` as msid_args[0] and msid_args[1].
+        # The \w symbol means to match a-z, A-Z, 0-9 and underscore (_).
+        # The \d symbol means to match digits 0-9.
 
-      def get_msid_attrs(self, tstart, tstop, msid, msid_args):
-          """
-          Get attributes for computed MSID: ``vals``, ``bads``, ``times``,
-          ``raw_vals``, and ``offset``.  The first three must always be
-          provided.
+        def get_msid_attrs(self, tstart, tstop, msid, msid_args):
+            """
+            Get attributes for computed MSID: ``vals``, ``bads``, ``times``,
+            ``raw_vals``, and ``offset``.  The first three must always be
+            provided.
 
-          :param tstart: start time (CXC secs)
-          :param tstop: stop time (CXC secs)
-          :param msid: full MSID name e.g. tephin_plus_5
-          :param msid_args: tuple of regex match groups (msid_name,)
-             :returns: dict of MSID attributes
-          """
-          # Process the arguments parsed from the MSID
-          msid  msid_args[0]
-          offset = int(msid_args[1])
+            :param tstart: start time (CXC secs)
+            :param tstop: stop time (CXC secs)
+            :param msid: full MSID name e.g. tephin_plus_5
+            :param msid_args: tuple of regex match groups (msid_name,)
+            :returns: dict of MSID attributes
+            """
+            # Process the arguments parsed from the MSID
+            msid  msid_args[0]
+            offset = int(msid_args[1])
 
-          # Get the raw telemetry value in engineering units
-          dat = self.fetch_eng.MSID(msid, tstart, tstop)
+            # Get the raw telemetry value in engineering units
+            dat = self.fetch_eng.MSID(msid, tstart, tstop)
 
-          # Do the computation
-          vals = dat.vals + offset
+            # Do the computation
+            vals = dat.vals + offset
 
-          # Return a dict with at least `vals`, `times` and `bads`.
-          # Additional attributes are allowed and will be set on the
-          # final MSID object.
-          out = {'vals': vals,
-                 'bads': dat.bads,
-                 'times': dat.times,
-                 'vals_raw': dat.vals,  # Provide original values without offset
-                 'offset': offset  # Provide the offset for reference
-                 }
-          return out
+            # Return a dict with at least `vals`, `times` and `bads`.
+            # Additional attributes are allowed and will be set on the
+            # final MSID object.
+            out = {'vals': vals,
+                    'bads': dat.bads,
+                    'times': dat.times,
+                    'vals_raw': dat.vals,  # Provide original values without offset
+                    'offset': offset  # Provide the offset for reference
+                    }
+            return out
 
 Built-in computed MSIDs and API
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

This adds new functionality to allow for on-the-fly computed MSIDs.

It also adds new built-in computed MSIDs for MUPS valve temperatures.

To do:

- [x] Documentation

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing
  - New unit tests.
