### PR TITLE
Add MSID title and unit y-label to plot

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -1389,6 +1389,9 @@ class MSID(object):
         plot_cxctime(self.times, vals, *args, state_codes=self.state_codes,
                      **kwargs)
         plt.margins(0.02, 0.05)
+        plt.title(self.MSID)
+        if self.unit:
+            plt.ylabel(self.unit)
 
 
 class MSIDset(collections.OrderedDict):


### PR DESCRIPTION
## Description

The adds a title and y-label to the standard cheta `MSID.plot()` output.  Should have done this a long time ago!

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing:
  - Made a plot for TEPHIN (with a unit), looks good
  - Made a plot for AOPCADMD (no unit), looks good
  - Made a plot for CMD_STATE_PITCH_32 (no unit), looks good
