### PR TITLE
Better warnings

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -18,4 +18,4 @@ jobs:
         pip install flake8
         # Note: only check files in Ska.engarchive package.  Many other files in
         # the repo are not maintained as PEP8 compliant.
-        flake8 Ska --count --exclude=Ska/engarchive/file_defs.py --ignore=W503,W504 --max-line-length=100 --show-source --statistics
+        flake8 Ska --count --exclude=Ska/engarchive/file_defs.py --ignore=W503,W504,F541 --max-line-length=100 --show-source --statistics

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -811,7 +811,7 @@ def truncate_archive(filetype, date):
             os.unlink(filename)
             logger.info(f'Removed {filename}')
 
-    cmd = 'DELETE FROM archfiles WHERE (year>={0} AND doy>={1}) OR year>{0}'.format(year, doy, year)
+    cmd = 'DELETE FROM archfiles WHERE (year>={0} AND doy>={1}) OR year>{0}'.format(year, doy)
     if not opt.dry_run:
         db.execute(cmd)
         db.commit()

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -1003,12 +1003,12 @@ def update_msid_files(filetype, archfiles):
             logger.warning('WARNING: found gap of %.2f secs between archfiles %s and %s',
                            time_gap, last_archfile['filename'], archfiles_row['filename'])
             if opt.create:
-                logger.warning('       Allowing gap because of opt.create=True')
+                logger.warning('WARNING: Allowing gap because of opt.create=True')
             elif DateTime() - DateTime(archfiles_row['tstart']) > opt.allow_gap_after_days:
                 # After 4 days (by default) just let it go through because this is
                 # likely a real gap and will not be fixed by subsequent processing.
                 # This can happen after normal sun mode to SIM products.
-                logger.warning('       Allowing gap because arch file '
+                logger.warning('WARNING: Allowing gap because arch file '
                                'start is more than {} days old'
                                .format(opt.allow_gap_after_days))
             else:

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -741,7 +741,7 @@ def append_h5_col(dats, colname, files_overlaps):
                     # record.  Thus file0['tstop'] is generally very close to file1['tstart'],
                     # but in this case there can a tiny overlap (<< 1 ms) that triggers an
                     # overlap entry.
-                    logger.verbose('WARNING: Unexpected null file overlap file0=%s file1=%s'
+                    logger.verbose('INFO: Unexpected null file overlap file0=%s file1=%s'
                                    % (file0, file1))
 
     data_len = len(h5.root.data)


### PR DESCRIPTION
## Description

The task_schedule log checking is looking for warnings, but the code that indicated a telemetry gap was being allowed because 4 days have passed was being issued without WARNING.  This meant the alert email was missing that key information.

Along the way I decided that the null file overlap is no never actionable, so downgraded that to INFO.

This also does some flake8 updates.

## Testing

No applicable unit tests.  Doing functional testing is not especially easy. Given the scope of changes just being updating the value of strings, it is not necessary.
