### PR TITLE
Allow model version in MUPS clean computed MSID and fix tests

### DIFF
--- a/Ska/engarchive/derived/mups_valve.py
+++ b/Ska/engarchive/derived/mups_valve.py
@@ -134,7 +134,7 @@ def get_corr_mups_temp(temp):
     return new_temp
 
 
-@numba.autojit()
+@numba.jit()
 def select_using_model(data1, data2, model, dt_thresh, out, source):
     """Select from either ``data1`` or ``data2`` using ``model`` to get clean data.
 
@@ -151,12 +151,6 @@ def select_using_model(data1, data2, model, dt_thresh, out, source):
     :param out: ndarray where output cleaned data is stored (must be same length as data)
     :param source: ndarray where output source labeling is stored (same length as data)
     """
-    # Select all data where either data1 or data2 are within dt_thresh of model
-    for data, source_id in [(data1, 1), (data2, 2)]:
-        ok = np.abs(data - model) < dt_thresh
-        out[ok] = data[ok]
-        source[ok] = source_id
-
     # Fill in gaps where possible by propagating model from last good data value
     for ii in range(len(data1)):
         if source[ii] != 0:
@@ -181,7 +175,8 @@ def select_using_model(data1, data2, model, dt_thresh, out, source):
             source[ii] = 0
 
 
-def fetch_clean_msid(msid, start, stop=None, dt_thresh=5.0, median=7, model_spec=None):
+def fetch_clean_msid(msid, start, stop=None, dt_thresh=5.0, median=7, model_spec=None,
+                     branch='master'):
     """Fetch a cleaned version of telemetry for ``msid``.
 
     If not supplied the model spec will be downloaded from github using this URL:
@@ -210,7 +205,7 @@ def fetch_clean_msid(msid, start, stop=None, dt_thresh=5.0, median=7, model_spec
     :returns: fetch.Msid object
     """
     if model_spec is None or not os.path.exists(model_spec):
-        url = (f'https://raw.githubusercontent.com/sot/chandra_models/master/chandra_models/xija/'
+        url = (f'https://raw.githubusercontent.com/sot/chandra_models/{branch}/chandra_models/xija/'
                f'mups_valve/{msid}_spec.json')
         model_spec = download_file(url, cache=True)
 
@@ -236,6 +231,13 @@ def fetch_clean_msid(msid, start, stop=None, dt_thresh=5.0, median=7, model_spec
 
     out = np.zeros_like(dat.vals)
     source = np.zeros(len(dat.vals), dtype=int)
+
+    # Select all data where either data1 or data2 are within dt_thresh of model
+    for data, source_id in [(t_obs, 1), (t_corr, 2)]:
+        ok = np.abs(data - t_model) < dt_thresh
+        out[ok] = data[ok]
+        source[ok] = source_id
+
     select_using_model(t_obs, t_corr, t_model, dt_thresh=dt_thresh, out=out, source=source)
 
     dat.vals_raw = dat.vals

--- a/Ska/engarchive/derived/mups_valve.py
+++ b/Ska/engarchive/derived/mups_valve.py
@@ -134,7 +134,7 @@ def get_corr_mups_temp(temp):
     return new_temp
 
 
-@numba.jit()
+@numba.jit(nopython=True)
 def select_using_model(data1, data2, model, dt_thresh, out, source):
     """Select from either ``data1`` or ``data2`` using ``model`` to get clean data.
 

--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -121,29 +121,30 @@ def test_mups_valve():
     colnames = ['vals', 'times', 'bads', 'vals_raw',
                 'vals_nan', 'vals_corr', 'vals_model', 'source']
 
-    dat = fetch_eng.MSID('PM2THV1T_clean', '2020:001', '2020:010')
+    # Use the 3.30 release always for testing.
+    dat = fetch_eng.MSID('PM2THV1T_clean_3.30', '2020:001', '2020:010')
     assert dat.unit == 'DEGF'
     assert len(dat.vals) == 36661
     ok = dat.source != 0
     # Temps are reasonable for degF
     assert np.all((dat.vals[ok] > 55) & (dat.vals[ok] < 220))
-    assert np.count_nonzero(ok) == 34499
+    assert np.count_nonzero(ok) == 31524
     assert dat.colnames == colnames
     for attr in colnames:
         assert len(dat.vals) == len(getattr(dat, attr))
 
-    dat = fetch_sci.Msid('PM2THV1T_clean', '2020:001', '2020:010')
+    dat = fetch_sci.Msid('PM2THV1T_clean_3.30', '2020:001', '2020:010')
     assert dat.unit == 'DEGC'
     ok = dat.source != 0
     # Temps are reasonable for degC
     assert np.all((dat.vals[ok] > 10) & (dat.vals[ok] < 110))
-    assert len(dat.vals) == 34499  # Some bad values
+    assert len(dat.vals) == 31524  # Some bad values
     assert dat.colnames == colnames
     for attr in colnames:
         if attr != 'bads':
             assert len(dat.vals) == len(getattr(dat, attr))
 
-    dat = fetch_cxc.MSID('PM1THV2T_clean', '2020:001', '2020:010')
+    dat = fetch_cxc.MSID('PM1THV2T_clean_3.30', '2020:001', '2020:010')
     ok = dat.source != 0
     # Temps are reasonable for K
     assert np.all((dat.vals[ok] > 280) & (dat.vals[ok] < 380))
@@ -152,6 +153,7 @@ def test_mups_valve():
     for attr in colnames:
         assert len(dat.vals) == len(getattr(dat, attr))
 
+    # Check using default master branch
     dat = fetch_eng.Msid('pm1thv2t_clean', '2020:001', '2020:010')
     assert len(dat.vals) == 36240  # Some bad values
     assert len(dat.source) == 36240  # Filtering applies to sources


### PR DESCRIPTION
## Description

This introduces an optional element of the computed cleaned MUPS value temperature MSIDs which allows specifying the MUPS model version. It now accepts an MSID like `pm1thv2t_clean_3.28` which would use release 3.28 of https://github.com/sot/chandra_models to get the model spec file. This is crucial for reproducible tests going forward. The default version is still from current master.

The tests were updated to pass with release 3.30. I spent some time trying to find a version of chandra_models for which the original tests would pass but failed. This is something of a mystery since tests were definitely passing at the time the original computed MSIDs PR was merged. Regardless, tests are passing now.

Related to fixing tests, one bit of non-numba-able code was moved out of a `@numba.jit()` function. I also added `nopython=True` to be sure the code stays fully compiled in the future.

## Testing

- [x] Passes unit tests on MacOS, except for known fail of cheta sync tests fixed by #195.
- [x] Functional testing [N/A]
