### PR TITLE
Lazy-load inital content and remote access setup

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -20,9 +20,8 @@ from pathlib import Path
 import numpy as np
 from astropy.io import ascii
 import pyyaks.context
-import six
-from six.moves import cPickle as pickle
-from six.moves import zip
+
+import pickle
 
 from . import file_defs
 from .units import Units
@@ -282,10 +281,9 @@ for filetype in filetypes:
 # Function to load MSID names from the files (executed remotely, if necessary)
 @local_or_remote_function("Loading MSID names from Ska eng archive server...")
 def load_msid_names(all_msid_names_files):
-    import six
-    from six.moves import cPickle as pickle
+    import pickle
     all_colnames = dict()
-    for k, msid_names_file in six.iteritems(all_msid_names_files):
+    for k, msid_names_file in all_msid_names_files.items():
         try:
             all_colnames[k] = pickle.load(open(os.path.join(*msid_names_file), 'rb'))
         except IOError:
@@ -297,7 +295,7 @@ def load_msid_names(all_msid_names_files):
 all_colnames = load_msid_names(all_msid_names_files)
 
 # Save the names
-for k, colnames in six.iteritems(all_colnames):
+for k, colnames in all_colnames.items():
     content.update((x, k) for x in sorted(colnames)
                    if x not in IGNORE_COLNAMES)
 
@@ -709,14 +707,13 @@ class MSID(object):
             self.midvals = self.vals
             self.vals = self.means
 
-        # Possibly convert vals to unicode for Python 3+.  If this MSID is a
+        # Convert vals to unicode for Python 3+.  If this MSID is a
         # state-valued MSID (with string value) then `vals` is the only possible
         # string attribute.  None of the others like mins/maxes etc will exist.
-        if not six.PY2:
-            for colname in self.colnames:
-                vals = getattr(self, colname)
-                if vals.dtype.kind == 'S':
-                    setattr(self, colname, vals.astype('U'))
+        for colname in self.colnames:
+            vals = getattr(self, colname)
+            if vals.dtype.kind == 'S':
+                setattr(self, colname, vals.astype('U'))
 
     @staticmethod
     @cache.lru_cache(30)
@@ -816,8 +813,8 @@ class MSID(object):
         # have incorrect values in CXCDS telemetry
         bads = _fix_ctu_dwell_mode_bads(msid, bads)
 
-        # In Python 3+ change bytestring to (unicode) string
-        if not six.PY2 and vals.dtype.kind == 'S':
+        # Change bytestring to (unicode) string
+        if vals.dtype.kind == 'S':
             vals = vals.astype('U')
 
         return (vals, times, bads)

--- a/Ska/engarchive/lazy.py
+++ b/Ska/engarchive/lazy.py
@@ -43,6 +43,6 @@ class LazyDict(dict):
         self.load()
         return super().__len__()
 
-    def get(self, key, default=None, /):
+    def get(self, key, default=None):
         self.load()
         return super().get(key, default)

--- a/Ska/engarchive/lazy.py
+++ b/Ska/engarchive/lazy.py
@@ -1,0 +1,48 @@
+class LazyDict(dict):
+    def __init__(self, load_func, *args, **kwargs):
+        self._load_func = load_func
+        self._args = args
+        self._kwargs = kwargs
+        self._loaded = False
+        super().__init__()
+
+    def load(self):
+        if not self._loaded:
+            self.update(self._load_func(*self._args, **self._kwargs))
+            self._loaded = True
+
+            # Clear these out so pickling always works (pickling a func can fail)
+            self._load_func = None
+            self._args = None
+            self._kwargs = None
+
+    def __getitem__(self, item):
+        try:
+            return super().__getitem__(item)
+        except KeyError:
+            self.load()
+            return super().__getitem__(item)
+
+    def __contains__(self, item):
+        self.load()
+        return super().__contains__(item)
+
+    def keys(self):
+        self.load()
+        return super().keys()
+
+    def values(self):
+        self.load()
+        return super().values()
+
+    def items(self):
+        self.load()
+        return super().items()
+
+    def __len__(self):
+        self.load()
+        return super().__len__()
+
+    def get(self, key, default=None, /):
+        self.load()
+        return super().get(key, default)


### PR DESCRIPTION
## Description

This removes the step of initializing the list of available MSIDs during the import of `cheta.fetch`. This step had previously kicked off the setup of the remote server in the case of remote access.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

This script works on Windows and MacOS in this branch. On Window in `master`, it fails because the remote setup ends up re-importing the script and redoing the remote setup.
```
import os
print(f'Running imports with process id={os.getpid()}')
os.environ.pop('SKA', None)
os.environ.pop('ENG_ARCHIVE', None)
os.environ['SKA_ACCESS_REMOTELY'] = 'True'
from Ska.engarchive import fetch, remote_access  # noqa

def main():
    print(f'  HERE main() with process id={os.getpid()}')
    fetch.add_logging_handler()
    assert remote_access.access_remotely is True
    fetch.Msid('tephin', '2018:001', '2018:010')

if __name__ == '__main__':
    main()
```
