### PR TITLE
Use get_xija_model_spec instead of GitHub for pftank2t model

### DIFF
--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -363,13 +363,13 @@ class Comp_MUPS_Valve_Temp_Clean(ComputedMsid):
         """
         from .mups_valve import fetch_clean_msid
 
-        # Git branch of chandra_models to use for MUPS model spec from 2nd match group.
-        # If not supplied it will be None so use master.
-        branch = 'master' if msid_args[1] is None else msid_args[1][1:]
+        # Git version of chandra_models to use for MUPS model spec from 2nd match group.
+        # If not supplied it will be None so use default main version.
+        version = None if msid_args[1] is None else msid_args[1][1:]
 
         # Get cleaned MUPS valve temperature data as an MSID object
         dat = fetch_clean_msid(msid_args[0], tstart, tstop,
-                               dt_thresh=5.0, median=7, model_spec=None, branch=branch)
+                               dt_thresh=5.0, median=7, model_spec=None, version=version)
 
         # Convert to dict as required by the get_msids_attrs API.  `fetch_clean_msid`
         # returns an MSID object with the following attrs.

--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -121,11 +121,11 @@ def test_mups_valve():
     colnames = ['vals', 'times', 'bads', 'vals_raw',
                 'vals_nan', 'vals_corr', 'vals_model', 'source']
 
-    # Use the chandra_models e1a900cc commit for testing. This is a commit of
+    # Use the chandra_models 6854df4d commit for testing. This is a commit of
     # chandra_models that has the epoch dates changes to fully-qualified values
     # like 2017:123:12:00:00 (instead of 2017:123). This allows these regression
     # tests to pass with Chandra.Time 3.x or 4.0+.
-    dat = fetch_eng.MSID('PM2THV1T_clean_e1a900cc', '2020:001:12:00:00', '2020:010:12:00:00')
+    dat = fetch_eng.MSID('PM2THV1T_clean_6854df4d', '2020:001:12:00:00', '2020:010:12:00:00')
     assert dat.unit == 'DEGF'
     assert len(dat.vals) == 36661
     ok = dat.source != 0
@@ -136,7 +136,7 @@ def test_mups_valve():
     for attr in colnames:
         assert len(dat.vals) == len(getattr(dat, attr))
 
-    dat = fetch_sci.Msid('PM2THV1T_clean_e1a900cc', '2020:001:12:00:00', '2020:010:12:00:00')
+    dat = fetch_sci.Msid('PM2THV1T_clean_6854df4d', '2020:001:12:00:00', '2020:010:12:00:00')
     assert dat.unit == 'DEGC'
     ok = dat.source != 0
     # Temps are reasonable for degC
@@ -147,7 +147,7 @@ def test_mups_valve():
         if attr != 'bads':
             assert len(dat.vals) == len(getattr(dat, attr))
 
-    dat = fetch_cxc.MSID('PM1THV2T_clean_e1a900cc', '2020:001:12:00:00', '2020:010:12:00:00')
+    dat = fetch_cxc.MSID('PM1THV2T_clean_6854df4d', '2020:001:12:00:00', '2020:010:12:00:00')
     ok = dat.source != 0
     # Temps are reasonable for K
     assert np.all((dat.vals[ok] > 280) & (dat.vals[ok] < 380))


### PR DESCRIPTION
## Description

This takes advantage of the new xija_get_model_spec() function in xija to remove the dependency on GitHub for the MUPS valve computation. It also fixes the test fail on cheru which cannot see GitHub.

There was an oddity where the commit that was hardwired into the testing was orphaned somehow (maybe lost from a rebase?). That commit did not appear in a clone from GitHub.

## Testing

- [x] Passes unit tests on MacOS, linux (cheru)
