### PR TITLE
Better caching in fetch

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -741,8 +741,14 @@ class MSID(object):
         # the required time range plus a little padding on each end.
         h5_slice = get_interval(content, tstart, tstop)
 
+        # Cache the last set of TIME values so repeated queries from within a
+        # content type use the already-available times. Use the content, start
+        # row and stop row as key. This guarantees that the times array matches
+        # the subsequent values.
+        cache_key = (content, h5_slice.start, h5_slice.stop)
+
         # Read the TIME values either from cache or from disk.
-        if times_cache['key'] == (content, tstart, tstop):
+        if times_cache['key'] == cache_key:
             logger.info('Using times_cache for %s %s to %s',
                         content, tstart, tstop)
             times = times_cache['val']  # Already filtered on times_ok
@@ -772,7 +778,7 @@ class MSID(object):
             if not times_all_ok:
                 times = times[times_ok]
 
-            times_cache.update(dict(key=(content, tstart, tstop),
+            times_cache.update(dict(key=cache_key,
                                     val=times,
                                     ok=times_ok,
                                     all_ok=times_all_ok))

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -33,6 +33,7 @@ from .lazy import LazyDict
 from . import __version__  # noqa
 
 from Chandra.Time import DateTime
+from ska_helpers.utils import lru_cache_timed
 
 # Module-level units, defaults to CXC units (e.g. Kelvins etc)
 UNITS = Units(system='cxc')
@@ -1864,11 +1865,15 @@ def get_telem(msids, start=None, stop=None, sampling='full', unit_system='eng',
                      max_fetch_Mb, max_output_Mb)
 
 
-@memoized
+@lru_cache_timed(maxsize=1000, timeout=600)
 def get_interval(content, tstart, tstop):
     """
     Get the approximate row intervals that enclose the specified ``tstart`` and
     ``tstop`` times for the ``content`` type.
+
+    The output of this function is cached with an LRU cache of the most recent
+    1000 results. The cache expires every 10 minutes to ensure that a persistent
+    session will get new data if the archive gets updated.
 
     :param content: content type (e.g. 'pcad3eng', 'thm1eng')
     :param tstart: start time (CXC seconds)


### PR DESCRIPTION
## Description

This improves the caching in fetch in two ways:
1. Use a timeout for the cache of the row start/stop interval for given content, tstart, tstop inputs.
1. Use a more robust cache key for caching the times arrays for a query. The previous key could lead to a failure if the archive was updated between subsequent queries.

The inspiration is an issue with the cheta archive where a persistent session was unable to see new updates in the data.

This requires https://github.com/sot/ska_helpers/pull/20.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing

### Functional testing: 1

The `fetch.py` code was patched to have a 10-second timeout instead of the actual 10-minute timeout. Then this code was run:
```
from cheta import fetch
import time

t0 = time.time()

def fetch_msid(msid, wait):
    dt = time.time() - t0
    print(f'dt={dt:.0f} {msid=} {wait=}')
    fetch.Msid(msid, '2020:001', '2020:002')
    print(fetch.get_interval.cache_info())
    print()
    time.sleep(wait)

fetch_msid('tephin', 1)
fetch_msid('tephin', 1)
fetch_msid('tephin', 1)
fetch_msid('aopcadmd', 1)
fetch_msid('tephin', 8)
fetch_msid('tephin', 1)
fetch_msid('tephin', 1)
fetch_msid('tephin', 1)
fetch_msid('aopcadmd', 1)
```
**Output**
```
In [10]: run go                                                                                                                     
dt=0 msid='tephin' wait=1
CacheInfo(hits=0, misses=1, maxsize=1000, currsize=1)

dt=1 msid='tephin' wait=1
CacheInfo(hits=1, misses=1, maxsize=1000, currsize=1)

dt=2 msid='tephin' wait=1
CacheInfo(hits=2, misses=1, maxsize=1000, currsize=1)

dt=3 msid='aopcadmd' wait=1
CacheInfo(hits=2, misses=2, maxsize=1000, currsize=2)

dt=4 msid='tephin' wait=8
CacheInfo(hits=3, misses=2, maxsize=1000, currsize=2)

dt=12 msid='tephin' wait=1
CacheInfo(hits=0, misses=1, maxsize=1000, currsize=1)

dt=13 msid='tephin' wait=1
CacheInfo(hits=1, misses=1, maxsize=1000, currsize=1)

dt=14 msid='tephin' wait=1
CacheInfo(hits=2, misses=1, maxsize=1000, currsize=1)

dt=15 msid='aopcadmd' wait=1
CacheInfo(hits=2, misses=2, maxsize=1000, currsize=2)
```
#### Functional testing: 2

The fetch.py code was patched to have a 2-minute timeout instead of the actual 10-minute timeout. A local copy the cheta archive was created that is a week out of date. Then this code was run:


```
ska3-shiny) ➜  eng_archive git:(better-caching) ✗ ipython
Python 3.8.3 (default, Jul  2 2020, 11:26:31) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from cheta import fetch                                                                                                     
fetch: using ENG_ARCHIVE=/Users/aldcroft/git/eng_archive for archive path

In [2]: fetch.add_logging_handler()                                                                                                 

In [3]: dat = fetch.Msid('AACCCDPT', '2020:340', '2021:001')                                                                        
_get_data: Getting data for AACCCDPT between 2020:340:00:00:00.000 to 2021:001:00:00:00.000
_get_msid_data_from_cxc: Reading /Users/aldcroft/git/eng_archive/data/pcad5eng/TIME.h5
_get_msid_data_from_cxc: Reading /Users/aldcroft/git/eng_archive/data/pcad5eng/AACCCDPT.h5
_get_msid_data_from_cxc: Slicing AACCCDPT arrays [165:18726]

In [4]: from cxotime import CxoTime                                                                                                 

In [5]: CxoTime(dat.times[-1]).date                                                                                                 
Out[5]: '2020:345:03:58:32.755'

#########################################################
### In another window update the local archive to up present
### using cheta_sync.
### Then fetch repeatedly at intervals.
#########################################################

In [6]: dat = fetch.Msid('AACCCDPT', '2020:340', '2021:001')                                                                        
_get_data: Getting data for AACCCDPT between 2020:340:00:00:00.000 to 2021:001:00:00:00.000
_get_msid_data_from_cxc: Using times_cache for pcad5eng 723513669.184 to 725846469.184
_get_msid_data_from_cxc: Reading /Users/aldcroft/git/eng_archive/data/pcad5eng/AACCCDPT.h5
_get_msid_data_from_cxc: Slicing AACCCDPT arrays [165:18726]

In [7]: CxoTime(dat.times[-1]).date                                                                                                 
Out[7]: '2020:345:03:58:32.755'

In [8]: dat = fetch.Msid('AACCCDPT', '2020:340', '2021:001')                                                                        
_get_data: Getting data for AACCCDPT between 2020:340:00:00:00.000 to 2021:001:00:00:00.000
_get_msid_data_from_cxc: Using times_cache for pcad5eng 723513669.184 to 725846469.184
_get_msid_data_from_cxc: Reading /Users/aldcroft/git/eng_archive/data/pcad5eng/AACCCDPT.h5
_get_msid_data_from_cxc: Slicing AACCCDPT arrays [165:18726]

In [9]: CxoTime(dat.times[-1]).date                                                                                                 
Out[9]: '2020:345:03:58:32.755'

In [10]: dat = fetch.Msid('AACCCDPT', '2020:340', '2021:001')                                                                       
_get_data: Getting data for AACCCDPT between 2020:340:00:00:00.000 to 2021:001:00:00:00.000
_get_msid_data_from_cxc: Using times_cache for pcad5eng 723513669.184 to 725846469.184
_get_msid_data_from_cxc: Reading /Users/aldcroft/git/eng_archive/data/pcad5eng/AACCCDPT.h5
_get_msid_data_from_cxc: Slicing AACCCDPT arrays [165:18726]

In [11]: CxoTime(dat.times[-1]).date                                                                                                
Out[11]: '2020:345:03:58:32.755'

In [12]: dat = fetch.Msid('AACCCDPT', '2020:340', '2021:001')                                                                       
_get_data: Getting data for AACCCDPT between 2020:340:00:00:00.000 to 2021:001:00:00:00.000
_get_msid_data_from_cxc: Using times_cache for pcad5eng 723513669.184 to 725846469.184
_get_msid_data_from_cxc: Reading /Users/aldcroft/git/eng_archive/data/pcad5eng/AACCCDPT.h5
_get_msid_data_from_cxc: Slicing AACCCDPT arrays [165:18726]

In [13]: dat = fetch.Msid('AACCCDPT', '2020:340', '2021:001')                                                                       
_get_data: Getting data for AACCCDPT between 2020:340:00:00:00.000 to 2021:001:00:00:00.000
_get_msid_data_from_cxc: Using times_cache for pcad5eng 723513669.184 to 725846469.184
_get_msid_data_from_cxc: Reading /Users/aldcroft/git/eng_archive/data/pcad5eng/AACCCDPT.h5
_get_msid_data_from_cxc: Slicing AACCCDPT arrays [165:18726]

In [14]: dat = fetch.Msid('AACCCDPT', '2020:340', '2021:001')                                                                       
_get_data: Getting data for AACCCDPT between 2020:340:00:00:00.000 to 2021:001:00:00:00.000
_get_msid_data_from_cxc: Using times_cache for pcad5eng 723513669.184 to 725846469.184
_get_msid_data_from_cxc: Reading /Users/aldcroft/git/eng_archive/data/pcad5eng/AACCCDPT.h5
_get_msid_data_from_cxc: Slicing AACCCDPT arrays [165:18726]

In [15]: dat = fetch.Msid('AACCCDPT', '2020:340', '2021:001')                                                                       
_get_data: Getting data for AACCCDPT between 2020:340:00:00:00.000 to 2021:001:00:00:00.000
_get_msid_data_from_cxc: Using times_cache for pcad5eng 723513669.184 to 725846469.184
_get_msid_data_from_cxc: Reading /Users/aldcroft/git/eng_archive/data/pcad5eng/AACCCDPT.h5
_get_msid_data_from_cxc: Slicing AACCCDPT arrays [165:18726]

In [16]: dat = fetch.Msid('AACCCDPT', '2020:340', '2021:001')                                                                       
_get_data: Getting data for AACCCDPT between 2020:340:00:00:00.000 to 2021:001:00:00:00.000
_get_msid_data_from_cxc: Using times_cache for pcad5eng 723513669.184 to 725846469.184
_get_msid_data_from_cxc: Reading /Users/aldcroft/git/eng_archive/data/pcad5eng/AACCCDPT.h5
_get_msid_data_from_cxc: Slicing AACCCDPT arrays [165:18726]

##############################################
### More than 2 minutes passed, cache gets cleared
##############################################

In [17]: dat = fetch.Msid('AACCCDPT', '2020:340', '2021:001')                                                                       
_get_data: Getting data for AACCCDPT between 2020:340:00:00:00.000 to 2021:001:00:00:00.000
_get_msid_data_from_cxc: Reading /Users/aldcroft/git/eng_archive/data/pcad5eng/TIME.h5       <======
_get_msid_data_from_cxc: Reading /Users/aldcroft/git/eng_archive/data/pcad5eng/AACCCDPT.h5
_get_msid_data_from_cxc: Slicing AACCCDPT arrays [165:41916]

In [18]: dat = fetch.Msid('AACCCDPT', '2020:340', '2021:001')                                                                       
_get_data: Getting data for AACCCDPT between 2020:340:00:00:00.000 to 2021:001:00:00:00.000
_get_msid_data_from_cxc: Using times_cache for pcad5eng 723513669.184 to 725846469.184
_get_msid_data_from_cxc: Reading /Users/aldcroft/git/eng_archive/data/pcad5eng/AACCCDPT.h5
_get_msid_data_from_cxc: Slicing AACCCDPT arrays [165:41916]

In [19]: CxoTime(dat.times[-1]).date                                                                                                
Out[19]: '2020:352:02:08:06.392'
```
