### PR TITLE
Retry tables open file

### DIFF
--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -22,12 +22,12 @@ import astropy.io.fits as pyfits
 import tables
 import numpy as np
 import scipy.stats.mstats
+from ska_helpers.retry import tables_open_file
 
 import Ska.engarchive.fetch as fetch
 import Ska.engarchive.converters as converters
 import Ska.engarchive.file_defs as file_defs
 import Ska.engarchive.derived as derived
-from Ska.engarchive.utils import tables_open_file
 import Ska.arc5gl
 
 

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -1,16 +1,13 @@
 #!/usr/bin/env python
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import print_function, division, absolute_import
-
 import re
 import os
 import glob
 import time
 from pathlib import Path
 
-from six.moves import cPickle as pickle
-from six.moves import zip
+import pickle
 import argparse
 import itertools
 from collections import OrderedDict
@@ -30,6 +27,7 @@ import Ska.engarchive.fetch as fetch
 import Ska.engarchive.converters as converters
 import Ska.engarchive.file_defs as file_defs
 import Ska.engarchive.derived as derived
+from Ska.engarchive.utils import tables_open_file
 import Ska.arc5gl
 
 
@@ -309,7 +307,7 @@ def fix_misorders(filetype):
             ft['msid'] = colname
             logger.info('Fixing %s', msid_files['msid'].abs)
             if not opt.dry_run:
-                h5 = tables.open_file(msid_files['msid'].abs, mode='a')
+                h5 = tables_open_file(msid_files['msid'].abs, mode='a')
                 hrd = h5.root.data
                 hrq = h5.root.quality
 
@@ -368,7 +366,7 @@ def del_stats(colname, time0, interval):
 
     logger.info('Fixing stats file %s after time %s', stats_file, DateTime(time0).date)
 
-    stats = tables.open_file(stats_file, mode='a',
+    stats = tables_open_file(stats_file, mode='a',
                              filters=tables.Filters(complevel=5, complib='zlib'))
     index0 = time0 // dt - 1
     indexes = stats.root.data.col('index')[:]
@@ -504,7 +502,7 @@ def update_stats(colname, interval, msid=None):
         logger.info('Making stats dir {}'.format(msid_files['statsdir'].abs))
         os.makedirs(msid_files['statsdir'].abs)
 
-    stats = tables.open_file(stats_file, mode='a',
+    stats = tables_open_file(stats_file, mode='a',
                              filters=tables.Filters(complevel=5, complib='zlib'))
 
     # INDEX0 is somewhat before any CXC archive data (which starts around 1999:205)
@@ -580,6 +578,7 @@ def update_derived(filetype):
     colnames = pickle.load(open(msid_files['colnames'].abs, 'rb'))
     colnames = [x for x in colnames if x.startswith('DP_')]
     msids = set()
+    time_step = None
     for colname in colnames:
         dp_class = getattr(derived, colname)
         dp = dp_class()
@@ -595,7 +594,7 @@ def update_derived(filetype):
         ft['msid'] = 'TIME'
         content = ft['content'] = fetch.content[msid]
         if content not in last_times:
-            h5 = tables.open_file(fetch.msid_files['msid'].abs, mode='r')
+            h5 = tables_open_file(fetch.msid_files['msid'].abs, mode='r')
             last_times[content] = h5.root.data[-1]
             h5.close()
     last_time = min(last_times.values()) - 1000
@@ -654,7 +653,7 @@ def make_h5_col_file(dats, colname):
     n_rows = int(86400 * 365 * 20 / dt)
 
     filters = tables.Filters(complevel=5, complib='zlib')
-    h5 = tables.open_file(filename, mode='w', filters=filters)
+    h5 = tables_open_file(filename, mode='w', filters=filters)
 
     col = dats[-1][colname]
     h5shape = (0,) + col.shape[1:]
@@ -689,7 +688,7 @@ def append_filled_h5_col(dats, colname, data_len):
     quals = np.zeros(fill_len, dtype=bool)
 
     # Append zeros (for the data type) and quality=True (bad)
-    h5 = tables.open_file(msid_files['msid'].abs, mode='a')
+    h5 = tables_open_file(msid_files['msid'].abs, mode='a')
     logger.verbose('Appending %d zeros to %s' % (len(zeros), msid_files['msid'].abs))
     if not opt.dry_run:
         h5.root.data.append(zeros)
@@ -710,7 +709,7 @@ def append_h5_col(dats, colname, files_overlaps):
         """Return the index for `colname` in `dat`"""
         return list(dat.dtype.names).index(colname)
 
-    h5 = tables.open_file(msid_files['msid'].abs, mode='a')
+    h5 = tables_open_file(msid_files['msid'].abs, mode='a')
     stacked_data = np.hstack([x[colname] for x in dats])
     stacked_quality = np.hstack([x['QUALITY'][:, i_colname(x)] for x in dats])
     logger.verbose('Appending %d items to %s' % (len(stacked_data), msid_files['msid'].abs))
@@ -779,7 +778,7 @@ def truncate_archive(filetype, date):
         filename = msid_files['msid'].abs
         if os.path.exists(filename):
             if not opt.dry_run:
-                h5 = tables.open_file(filename, mode='a')
+                h5 = tables_open_file(filename, mode='a')
                 h5.root.data.truncate(rowstart)
                 h5.root.quality.truncate(rowstart)
                 h5.close()

--- a/Ska/engarchive/utils.py
+++ b/Ska/engarchive/utils.py
@@ -18,26 +18,6 @@ STATS_DT = {'5min': 328,
             'daily': 86400}
 
 
-def tables_open_file(*args, **kwargs):
-    """Call tables.open_file(*args, **kwargs) with retry up to 3 times.
-
-    This only catches tables.exceptions.HDF5ExtError. After an initial failure
-    it will try again after 2 seconds and once more after 4 seconds.
-
-    :param *args: args passed through to tables.open_file()
-    :param **kwargs: kwargs passed through to tables.open_file()
-    :returns: tables file handle
-    """
-    import ska_helpers.retry
-    import tables
-
-    h5 = ska_helpers.retry.retry_call(
-        tables.open_file, args=args, kwargs=kwargs,
-        exceptions=tables.exceptions.HDF5ExtError,
-        delay=2, tries=3, backoff=2)
-    return h5
-
-
 def get_fetch_size(msids, start, stop, stat=None, interpolate_dt=None, fast=True):
     """
     Estimate the memory size required to fetch the ``msids`` between ``start`` and

--- a/Ska/engarchive/utils.py
+++ b/Ska/engarchive/utils.py
@@ -2,13 +2,10 @@
 """
 Utilities for the engineering archive.
 """
-from __future__ import print_function, division, absolute_import
-
 import re
 from contextlib import contextmanager
 
 import six
-from six.moves import zip
 import numpy as np
 from Chandra.Time import DateTime
 
@@ -19,6 +16,26 @@ FETCH_SIZES = {}
 # Standard intervals for 5min and daily telemetry
 STATS_DT = {'5min': 328,
             'daily': 86400}
+
+
+def tables_open_file(*args, **kwargs):
+    """Call tables.open_file(*args, **kwargs) with retry up to 3 times.
+
+    This only catches tables.exceptions.HDF5ExtError. After an initial failure
+    it will try again after 2 seconds and once more after 4 seconds.
+
+    :param *args: args passed through to tables.open_file()
+    :param **kwargs: kwargs passed through to tables.open_file()
+    :returns: tables file handle
+    """
+    import ska_helpers.retry
+    import tables
+
+    h5 = ska_helpers.retry.retry_call(
+        tables.open_file, args=args, kwargs=kwargs,
+        exceptions=tables.exceptions.HDF5ExtError,
+        delay=2, tries=3, backoff=2)
+    return h5
 
 
 def get_fetch_size(msids, start, stop, stat=None, interpolate_dt=None, fast=True):


### PR DESCRIPTION
## Description

Use https://github.com/sot/ska_helpers/pull/21 to hopefully make the daily archive updates more resilient to HEAD NetApp issues.

```
2021-02-08 04:03:57,089 Updating stats file /proj/sot/ska3/flight/data/eng_archive/data/acisdeahk/daily/TMP_FEP1_MONG.h5
2021-02-08 04:03:57,175   Adding 3 records
2021-02-08 04:03:57,211 Updating stats file /proj/sot/ska3/flight/data/eng_archive/data/acisdeahk/5min/TMP_FEP1_MONG.h5
Traceback (most recent call last):
  File "/proj/sot/ska3/flight/bin/cheta_update_server_archive", line 33, in <module>
    sys.exit(load_entry_point('Ska.engarchive==4.51.0', 'console_scripts', 'cheta_update_server_archive')())
  File "/proj/sot/ska3/flight/lib/python3.8/site-packages/cheta/update_archive.py", line 1186, in main
    main_loop()
  File "/proj/sot/ska3/flight/lib/python3.8/site-packages/cheta/update_archive.py", line 266, in main_loop
    update_stats(colname, '5min', msid)
  File "/proj/sot/ska3/flight/lib/python3.8/site-packages/cheta/update_archive.py", line 507, in update_stats
    stats = tables.open_file(stats_file, mode='a',
  File "/proj/sot/ska3/flight/lib/python3.8/site-packages/tables/file.py", line 315, in open_file
    return File(filename, mode, title, root_uep, filters, **kwargs)
  File "/proj/sot/ska3/flight/lib/python3.8/site-packages/tables/file.py", line 778, in __init__
    self._g_new(filename, mode, **params)
  File "tables/hdf5extension.pyx", line 492, in tables.hdf5extension.File._g_new
tables.exceptions.HDF5ExtError: HDF5 error back trace

  File "H5F.c", line 509, in H5Fopen
    unable to open file
  File "H5Fint.c", line 1400, in H5F__open
    unable to open file
  File "H5Fint.c", line 1615, in H5F_open
    unable to lock the file
  File "H5FD.c", line 1640, in H5FD_lock
    driver lock request failed
  File "H5FDsec2.c", line 941, in H5FD_sec2_lock
    unable to lock file, errno = 11, error message = 'Resource temporarily unavailable'

End of HDF5 error back trace

Unable to open/create file '/proj/sot/ska3/flight/data/eng_archive/data/acisdeahk/5min/TMP_FEP1_MONG.h5'
```

## Testing

- [N/A] Passes unit tests
- [x] Functional testing

- Updated `Ska.engarchive.update_archive` to use this new function in every place that an HDF5 file is opened (substitute `tables_open_file` for `tables.open_file`.
- Make a new conda env on HEAD
- Install this package and Ska.engarchive into the environment using `python setup.py install --single-version-externally-managed --record=record.txt`
- Go to `ska_testr` repo and run `run_testr --include Ska.engarchive`. This runs the long test that exercises `update_archive` and this new function. PASS.

