### PR TITLE
Fix sync index column order to match order from astropy 4.0

### DIFF
--- a/Ska/engarchive/file_defs.py
+++ b/Ska/engarchive/file_defs.py
@@ -57,6 +57,3 @@ sync_files = {'index':         'sync/{{ft.content}}/index.ecsv',
 # Used when originally creating database.
 orig_arch_root = '/data/cosmos2/tlm'
 orig_arch_files = {'contentdir':   '{{ft.content}}/'}
-
-# Define the order and names for the columns of the sync index file
-sync_index_cols = ['date_id', 'filetime0', 'filetime1', 'row0', 'row1']

--- a/Ska/engarchive/file_defs.py
+++ b/Ska/engarchive/file_defs.py
@@ -57,3 +57,6 @@ sync_files = {'index':         'sync/{{ft.content}}/index.ecsv',
 # Used when originally creating database.
 orig_arch_root = '/data/cosmos2/tlm'
 orig_arch_files = {'contentdir':   '{{ft.content}}/'}
+
+# Define the order and names for the columns of the sync index file
+sync_index_cols = ['date_id', 'filetime0', 'filetime1', 'row0', 'row1']

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -476,14 +476,14 @@ def update_full_h5_files(dat, logger, msid_files, msids, opt):
 def get_full_data_sets(ft, index_tbl, logger, opt):
     # Iterate over sync files that contain new data
     dats = []
-    for entry in index_tbl:
+    for row in index_tbl:
 
         # Limit processed archfiles by date
-        if entry['filetime0'] > DateTime(opt.date_stop).secs:
+        if row['filetime0'] > DateTime(opt.date_stop).secs:
             break
 
         # File names like sync/acis4eng/2019-07-08T1150z/full.npz
-        ft['date_id'] = entry['date_id']
+        ft['date_id'] = row['date_id']
 
         # Read the file with all the MSID data as a hash with keys like {msid}.data
         # {msid}.quality etc, plus an `archive` key with the table of corresponding
@@ -588,11 +588,11 @@ def _sync_stat_archive(opt, msid_files, logger, content, stat, index_tbl):
 def get_stat_data_sets(ft, index_tbl, last_date_id, logger, opt):
     # Iterate over sync files that contain new data
     dats = []
-    for entry in index_tbl:
-        date_id = entry['date_id']
+    for row in index_tbl:
+        date_id = row['date_id']
 
         # Limit processed archfiles by date
-        if entry['filetime0'] > DateTime(opt.date_stop).secs:
+        if row['filetime0'] > DateTime(opt.date_stop).secs:
             logger.verbose(f'Index {date_id} filetime0 > date_stop, breaking')
             break
 

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -476,13 +476,14 @@ def update_full_h5_files(dat, logger, msid_files, msids, opt):
 def get_full_data_sets(ft, index_tbl, logger, opt):
     # Iterate over sync files that contain new data
     dats = []
-    for date_id, filetime0, filetime1, row0, row1 in index_tbl:
+    for entry in index_tbl:
+
         # Limit processed archfiles by date
-        if filetime0 > DateTime(opt.date_stop).secs:
+        if entry['filetime0'] > DateTime(opt.date_stop).secs:
             break
 
         # File names like sync/acis4eng/2019-07-08T1150z/full.npz
-        ft['date_id'] = date_id
+        ft['date_id'] = entry['date_id']
 
         # Read the file with all the MSID data as a hash with keys like {msid}.data
         # {msid}.quality etc, plus an `archive` key with the table of corresponding
@@ -587,9 +588,11 @@ def _sync_stat_archive(opt, msid_files, logger, content, stat, index_tbl):
 def get_stat_data_sets(ft, index_tbl, last_date_id, logger, opt):
     # Iterate over sync files that contain new data
     dats = []
-    for date_id, filetime0, filetime1, row0, row1 in index_tbl:
+    for entry in index_tbl:
+        date_id = entry['date_id']
+
         # Limit processed archfiles by date
-        if filetime0 > DateTime(opt.date_stop).secs:
+        if entry['filetime0'] > DateTime(opt.date_stop).secs:
             logger.verbose(f'Index {date_id} filetime0 > date_stop, breaking')
             break
 

--- a/Ska/engarchive/update_server_sync.py
+++ b/Ska/engarchive/update_server_sync.py
@@ -196,9 +196,9 @@ def get_row_from_archfiles(archfiles):
     # date like 2019-02-20T2109z, human-readable and Windows-friendly (no :) for a unique
     # identifier for this set of updates.
     date_id = get_date_id(DateTime(archfiles[0]['filetime']).fits)
-    row = {'filetime0': archfiles[0]['filetime'],
+    row = {'date_id': date_id,
+           'filetime0': archfiles[0]['filetime'],
            'filetime1': archfiles[-1]['filetime'],
-           'date_id': date_id,
            'row0': archfiles[0]['rowstart'],
            'row1': archfiles[-1]['rowstop']}
     return row

--- a/Ska/engarchive/update_server_sync.py
+++ b/Ska/engarchive/update_server_sync.py
@@ -157,7 +157,7 @@ def remove_outdated_sync_files(opt, logger, index_tbl, index_file):
 
     index_tbl = index_tbl[idx0:]
     logger.info(f'Writing {len(index_tbl)} row(s) to index file {index_file}')
-    index_tbl.write(index_file, format='ascii.ecsv', overwrite=True)
+    index_tbl[file_defs.sync_index_cols].write(index_file, format='ascii.ecsv', overwrite=True)
 
 
 def update_sync_repo(opt, logger, content):
@@ -312,7 +312,7 @@ def update_index_file(index_file, opt, logger):
         return None
 
     logger.info(f'Writing {len(rows)} row(s) to index file {index_file}')
-    index_tbl.write(index_file, format='ascii.ecsv')
+    index_tbl[file_defs.sync_index_cols].write(index_file, format='ascii.ecsv')
 
     return index_tbl
 

--- a/Ska/engarchive/update_server_sync.py
+++ b/Ska/engarchive/update_server_sync.py
@@ -157,7 +157,7 @@ def remove_outdated_sync_files(opt, logger, index_tbl, index_file):
 
     index_tbl = index_tbl[idx0:]
     logger.info(f'Writing {len(index_tbl)} row(s) to index file {index_file}')
-    index_tbl[file_defs.sync_index_cols].write(index_file, format='ascii.ecsv', overwrite=True)
+    index_tbl.write(index_file, format='ascii.ecsv', overwrite=True)
 
 
 def update_sync_repo(opt, logger, content):
@@ -312,7 +312,7 @@ def update_index_file(index_file, opt, logger):
         return None
 
     logger.info(f'Writing {len(rows)} row(s) to index file {index_file}')
-    index_tbl[file_defs.sync_index_cols].write(index_file, format='ascii.ecsv')
+    index_tbl.write(index_file, format='ascii.ecsv')
 
     return index_tbl
 


### PR DESCRIPTION
## Description

Set sync index column order to match the alphabetical order that resulted in astropy 4.0.  In astropy 4.2 the column order when initializing from a list of dict is the order of keys in the first row. Since astropy 4.2 requires Python 3.7, which has dict ordered, this makes more sense than the previous behavior of just alphabetizing.

## Testing

- [x] Passes unit tests on linux
- [N/A] Functional testing

This showed up in unit test failures with astropy 4.2 in skare 2021.2 env on linux, so the unit tests passing are probably sufficient.

Fixes #216 