### PR TITLE
Fix a problem adding MSIDs to existing content type

### DIFF
--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -202,6 +202,8 @@ def copy_server_files(opt, logger, copy_files, server_path, copy_func, as_posix=
         for copy_file in copy_files:
             local_file = Path(opt.data_root, copy_file)
             server_file = Path(server_path, copy_file)
+            logger.debug(f'Local file={local_file}')
+            logger.debug(f'Server file={server_file}')
             if as_posix:
                 server_file = server_file.as_posix()
             local_file.parent.mkdir(parents=True, exist_ok=True)
@@ -294,11 +296,16 @@ def get_copy_files(logger, msids, msids_content):
             ft['msid'] = ft_msid
             ft['interval'] = interval
             pth = Path(msid_files[filetype].abs)
-            if not pth.exists():
+            # Copy files that do not exist locally. An exception is the colnames
+            # file (colnames.pkl), which must get updated even if it exists.
+            if not pth.exists() or filetype == 'colnames':
                 copy_files.add(str(pth.relative_to(basedir)))
 
     logger.info(f'Found {len(copy_files)} local archive files that are '
                 f'missing and need to be copied')
+    logger.debug(f'Copy_files:')
+    for copy_file in sorted(copy_files):
+        logger.debug(copy_file)
 
     return sorted(copy_files)
 


### PR DESCRIPTION
## Description

When adding MSIDs to a cheta local archive where the content type already exists, it does not update the `colname.pkl` file, thus leaving the new MSIDs invisible to fetch.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### Functional testing

Ran this on my Mac on an up-to-date local archive and confirmed:
- The `colnames.pkl` files were still copied even though they exist
- New debug logging appears

```
(ska3) ➜  eng_archive git:(fix-add-msids) python -m cheta.update_client_archive --add-msids=p015.txt --server-data-root=aldcroft@ccosmos.cfa.harvard.edu --dry-run --log-level=1
2021-03-25 06:45:06,948 Running cheta_update_client_archive version 4.52.1.dev1+gaf6a60d
2021-03-25 06:45:06,948   /Users/aldcroft/git/eng_archive/cheta/update_client_archive.py
2021-03-25 06:45:06,948 
2021-03-25 06:45:06,948 Updating client archive at /Users/aldcroft/ska/data/eng_archive
2021-03-25 06:45:06,948 Reading available cheta archive MSIDs from https://icxc.cfa.harvard.edu/aspect/cheta/
2021-03-25 06:45:07,052 Reading cheta MSIDs list file https://icxc.cfa.harvard.edu/aspect/cheta/sync/msid_contents.pkl.gz
2021-03-25 06:45:07,055 Reading MSID specs from p015.txt
2021-03-25 06:45:07,055 Assembling list of MSIDs that match MSID specs
2021-03-25 06:45:07,061   Found 1 MSIDs for 1AHITMPF
2021-03-25 06:45:07,067   Found 1 MSIDs for 1OATMF
2021-03-25 06:45:07,073   Found 1 MSIDs for 1OATMST
2021-03-25 06:45:07,073   Found 3 matching MSIDs total
2021-03-25 06:45:07,088 Found 3 local archive files that are missing and need to be copied
2021-03-25 06:45:07,088 Copy_files:
2021-03-25 06:45:07,088 data/acis3eng/colnames.pickle
2021-03-25 06:45:07,088 data/pcad3eng/colnames.pickle
2021-03-25 06:45:07,088 data/pcad8eng/colnames.pickle
2021-03-25 06:45:07,140 Connecting to ccosmos.cfa.harvard.edu
Password for aldcroft@ccosmos.cfa.harvard.edu: 
2021-03-25 06:45:10,955 Copying 3 files from aldcroft@ccosmos.cfa.harvard.edu to /Users/aldcroft/ska/data/eng_archive
2021-03-25 06:45:10,955 DRY RUN
|>-------------------------------------------------------------------------|   0 /  3  ( 0.00%)2021-03-25 06:45:10,956 Local file=/Users/aldcroft/ska/data/eng_archive/data/acis3eng/colnames.pickle
2021-03-25 06:45:10,956 Server file=/proj/sot/ska/data/eng_archive/data/acis3eng/colnames.pickle
2021-03-25 06:45:10,956 copy data/acis3eng/colnames.pickle
2021-03-25 06:45:10,956 Local file=/Users/aldcroft/ska/data/eng_archive/data/pcad3eng/colnames.pickle
2021-03-25 06:45:10,956 Server file=/proj/sot/ska/data/eng_archive/data/pcad3eng/colnames.pickle
2021-03-25 06:45:10,956 copy data/pcad3eng/colnames.pickle
2021-03-25 06:45:10,957 Local file=/Users/aldcroft/ska/data/eng_archive/data/pcad8eng/colnames.pickle
2021-03-25 06:45:10,957 Server file=/proj/sot/ska/data/eng_archive/data/pcad8eng/colnames.pickle
2021-03-25 06:45:10,957 copy data/pcad8eng/colnames.pickle
```