### PR TITLE
Allow CALC_ prefix as an alias for DP_

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -3,8 +3,6 @@
 """
 Fetch values from the Ska engineering telemetry archive.
 """
-from __future__ import print_function, division, absolute_import
-
 import sys
 import os
 import time
@@ -382,8 +380,12 @@ def msid_glob(msid):
     :param msid: input MSID glob
     :returns: tuple (msids, MSIDs)
     """
-    msids = collections.OrderedDict()
-    MSIDS = collections.OrderedDict()
+    msids = {}
+    MSIDS = {}
+
+    # CALC_ is taken as a synonym for DP_. MAUDE can accept either CALC_ or DP_
+    # (but cheta takes only DP_)
+    msid = re.sub(r'^CALC_', 'DP_', msid, flags=re.IGNORECASE)
 
     # First check if `msid` matches a computed class.  This does not allow
     # for globs, and here the output MSIDs is the single computed class.

--- a/Ska/engarchive/tests/test_fetch.py
+++ b/Ska/engarchive/tests/test_fetch.py
@@ -123,6 +123,15 @@ def test_filter_bad_times_default_copy():
     assert np.all(dates == DATES_EXPECT2)
 
 
+def test_fetch_derived_param_aliases():
+    dat1 = fetch.Msid('calc_pitch', '2020:001', '2020:002')
+    dat2 = fetch.Msid('dp_pitch', '2020:001', '2020:002')
+    dat3 = fetch.Msid('pitch', '2020:001', '2020:002')
+    for d1, d2 in ((dat1, dat2), (dat1, dat3)):
+        assert np.all(d1.times == d2.times)
+        assert np.all(d1.vals == d2.vals)
+
+
 def test_interpolate():
     dat = fetch.MSIDset(['aoattqt1', 'aogyrct1', 'aopcadmd'],
                         '2008:002:21:48:00', '2008:002:21:50:00')


### PR DESCRIPTION
## Description

MAUDE uses the prefix `CALC_` to indicate pseudo-MSIDs that are calculated from actual spacecraft MSIDs, for example `CALC_ROLL_FSS`. Cheta uses `DP_` for the same meaning, and many calcs have the same name apart from CALC_ vs DP_. The good news is that MAUDE also accepts `DP_` as a prefix.

This PR does a simple translation of `CALC_` to `DP_` in input MSIDs to enable interoperabiity. This is especially useful for a query that uses both CXC and MAUDE for the backend data source.

*This requires https://github.com/sot/maude/pull/39*

To do:

- [ ] Update docs

## Testing

- [x] Passes unit tests on MacOS (with new unit test)
- [n/a] Functional testing
