### PR TITLE
Fix test failure from updated MUPS model

### DIFF
--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -158,8 +158,8 @@ def test_mups_valve():
 
     # Check using default master branch
     dat = fetch_eng.Msid('pm1thv2t_clean', '2020:001:12:00:00', '2020:010:12:00:00')
-    assert len(dat.vals) == 36240  # Some bad values
-    assert len(dat.source) == 36240  # Filtering applies to sources
+    assert len(dat.vals) < 36661  # Some bad values (36661 is number of raw samples)
+    assert len(dat.source) == len(dat.vals)  # Filtering applies to sources
     assert dat.colnames == colnames
     for attr in colnames:
         if attr != 'bads':


### PR DESCRIPTION
## Description

This fixes the failure below, which is due to a change in the number of "bad" samples after the underlying MUPS thermal model was changed in `chandra_models` master since the test was written. The original test was badly designed and susceptible to this failure.

```
_______________________________ test_mups_valve ________________________________

    def test_mups_valve():
        colnames = ['vals', 'times', 'bads', 'vals_raw',
                    'vals_nan', 'vals_corr', 'vals_model', 'source']
    
        # Use the chandra_models 6854df4d commit for testing. This is a commit of
        # chandra_models that has the epoch dates changes to fully-qualified values
        # like 2017:123:12:00:00 (instead of 2017:123). This allows these regression
        # tests to pass with Chandra.Time 3.x or 4.0+.
        dat = fetch_eng.MSID('PM2THV1T_clean_6854df4d', '2020:001:12:00:00', '2020:010:12:00:00')
        assert dat.unit == 'DEGF'
        assert len(dat.vals) == 36661
...
        # Check using default master branch
        dat = fetch_eng.Msid('pm1thv2t_clean', '2020:001:12:00:00', '2020:010:12:00:00')
>       assert len(dat.vals) == 36240  # Some bad values
E       assert 36639 == 36240
E         +36639
E         -36240
```


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
