### PR TITLE
Possibly fix derived param aliases test

### DIFF
--- a/Ska/engarchive/tests/test_fetch.py
+++ b/Ska/engarchive/tests/test_fetch.py
@@ -152,25 +152,27 @@ def test_filter_bad_times_default_copy():
     assert np.all(dates == DATES_EXPECT2)
 
 
-@pytest.mark.parametrize('msid', ['DP_piTch_fss', 'Calc_pitCH_fss'])
+@pytest.mark.parametrize('msid', ['DP_piTch_css', 'Calc_pitCH_css'])
 @pytest.mark.parametrize('sources', (('cxc',), ('maude',), ('cxc', 'maude')))
 def test_fetch_derived_param_aliases(msid, sources):
-    cxc_tstop = fetch.get_time_range('dp_pitch_fss', 'secs')[1]
+    cxc_tstop = fetch.get_time_range('dp_pitch', 'secs')[1]
+    dt = 2000  # seconds
+    msg = (f'{CxoTime(cxc_tstop).date=} {dt=}\n'
+           f'{CxoTime(cxc_tstop - dt).date=}\n'
+           f'{CxoTime(cxc_tstop + dt).date=}\n'
+           f'{CxoTime.now().date=}\n'
+           f'{CxoTime.now().iso=}\n'
+           f'{sources=} {msid=}')
+    print(msg)  # stdout gets reported for test failures
     with fetch.data_source(*sources):
-        # Get data from +/- 1 day from end of CXC data
-        dt = 86400  # seconds
-        d1 = fetch.Msid('piTch_fss', cxc_tstop - dt, cxc_tstop + dt)
+        # Get data within `dt` secs of end of CXC data
+        d1 = fetch.Msid('piTCh_css', cxc_tstop - dt, cxc_tstop + dt)
         d2 = fetch.Msid(msid, cxc_tstop - dt, cxc_tstop + dt)
     assert d2.msid == msid  # version as the user provide
     assert d2.MSID == d1.MSID  # normalized version for accessing databases
     assert np.all(d1.times == d2.times)
     assert np.all(d1.vals == d2.vals)
-    if len(d1) == 0:
-        msg = (f'No data found for cxo_tstop={CxoTime(cxc_tstop).date} {dt=}'
-               f' {sources=} {msid=} '
-               f'{CxoTime(cxc_tstop - dt).date=} '
-               f'{CxoTime(cxc_tstop + dt).date=}')
-        raise AssertionError(msg)
+    assert len(d1) > 0
 
 
 def test_interpolate():

--- a/Ska/engarchive/tests/test_fetch.py
+++ b/Ska/engarchive/tests/test_fetch.py
@@ -155,7 +155,7 @@ def test_filter_bad_times_default_copy():
 @pytest.mark.parametrize('msid', ['DP_piTch_css', 'Calc_pitCH_css'])
 @pytest.mark.parametrize('sources', (('cxc',), ('maude',), ('cxc', 'maude')))
 def test_fetch_derived_param_aliases(msid, sources):
-    cxc_tstop = fetch.get_time_range('dp_pitch', 'secs')[1]
+    cxc_tstop = fetch.get_time_range('dp_pitch_css', 'secs')[1]
     dt = 2000  # seconds
     msg = (f'{CxoTime(cxc_tstop).date=} {dt=}\n'
            f'{CxoTime(cxc_tstop - dt).date=}\n'
@@ -166,8 +166,8 @@ def test_fetch_derived_param_aliases(msid, sources):
     print(msg)  # stdout gets reported for test failures
     with fetch.data_source(*sources):
         # Get data within `dt` secs of end of CXC data
-        d1 = fetch.Msid('piTCh_css', cxc_tstop - dt, cxc_tstop + dt)
-        d2 = fetch.Msid(msid, cxc_tstop - dt, cxc_tstop + dt)
+        d1 = fetch.MSID('piTCh_css', cxc_tstop - dt, cxc_tstop + dt)
+        d2 = fetch.MSID(msid, cxc_tstop - dt, cxc_tstop + dt)
     assert d2.msid == msid  # version as the user provide
     assert d2.MSID == d1.MSID  # normalized version for accessing databases
     assert np.all(d1.times == d2.times)


### PR DESCRIPTION
## Description

This might finally fix the intermittent problems with derived param aliases:
- Getting no samples with the original dt=200 was due to the fact that PITCH_FSS is not defined out of the FSS field of view, beyond pitch > 135. So sometimes there really was no data.
  - Changed to PITCH_CSS. This is basically always available.
- Reduced interval from 86400 to 2000: I think that 86400 was too long and this was actually sampling realtime when the CXC archive was within a day of current. 
  - Notice that the final time is increasing during the tests, and indeed `CxoTime(7.71253565e+08).date` = '2022:161:13:04:55.816' was during a realtime comm pass.

```
=================================== FAILURES ===================================
___________ test_fetch_derived_param_aliases[sources1-DP_piTch_fss] ____________

msid = 'DP_piTch_fss', sources = ('maude',)

    @pytest.mark.parametrize('msid', ['DP_piTch_fss', 'Calc_pitCH_fss'])
    @pytest.mark.parametrize('sources', (('cxc',), ('maude',), ('cxc', 'maude')))
    def test_fetch_derived_param_aliases(msid, sources):
        cxc_tstop = fetch.get_time_range('dp_pitch_fss', 'secs')[1]
        with fetch.data_source(*sources):
            # Get data from +/- 1 day from end of CXC data
            dt = 86400  # seconds
            d1 = fetch.Msid('piTch_fss', cxc_tstop - dt, cxc_tstop + dt)
            d2 = fetch.Msid(msid, cxc_tstop - dt, cxc_tstop + dt)
        assert d2.msid == msid  # version as the user provide
        assert d2.MSID == d1.MSID  # normalized version for accessing databases
>       assert np.all(d1.times == d2.times)
E       assert False
E        +  where False = <function all at 0x7f1933413d30>(array([7.7110...71253564e+08]) == array([7.7110...71253565e+08])
E        +    where <function all at 0x7f1933413d30> = np.all
E           +array([7.71105988e+08, 7.71105989e+08, 7.71105990e+08, ...,\n
E           +       7.71253561e+08, 7.71253562e+08, 7.71253564e+08])
E           -array([7.71105988e+08, 7.71105989e+08, 7.71105990e+08, ...,\n
E           -       7.71253562e+08, 7.71253564e+08, 7.71253565e+08])
E           Full diff:
E             array([7.71105988e+08, 7.71105989e+08, 7.71105990e+08, ...,
E           -        7.71253562e+08, 7.71253564e+08, 7.71253565e+08],
E           +        7.71253561e+08, 7.71253562e+08, 7.71253564e+08],
E             ))

Ska/engarchive/tests/test_fetch.py:166: AssertionError
------------------------------ Captured log call -------------------------------
DEBUG    maude:maude.py:625 Getting URL http://telemetry.cfa.harvard.edu/maude/mrest/FLIGHT/msid.bin?m=DP_PITCH_FSS&ts=2022159200518241&tp=2022161200518241
DEBUG    maude:maude.py:625 Getting URL http://telemetry.cfa.harvard.edu/maude/mrest/FLIGHT/msid.bin?m=DP_PITCH_FSS&ts=2022159200518241&tp=2022161200518241
__________ test_fetch_derived_param_aliases[sources1-Calc_pitCH_fss] ___________

msid = 'Calc_pitCH_fss', sources = ('maude',)

    @pytest.mark.parametrize('msid', ['DP_piTch_fss', 'Calc_pitCH_fss'])
    @pytest.mark.parametrize('sources', (('cxc',), ('maude',), ('cxc', 'maude')))
    def test_fetch_derived_param_aliases(msid, sources):
        cxc_tstop = fetch.get_time_range('dp_pitch_fss', 'secs')[1]
        with fetch.data_source(*sources):
            # Get data from +/- 1 day from end of CXC data
            dt = 86400  # seconds
            d1 = fetch.Msid('piTch_fss', cxc_tstop - dt, cxc_tstop + dt)
            d2 = fetch.Msid(msid, cxc_tstop - dt, cxc_tstop + dt)
        assert d2.msid == msid  # version as the user provide
        assert d2.MSID == d1.MSID  # normalized version for accessing databases
>       assert np.all(d1.times == d2.times)
E       assert False
E        +  where False = <function all at 0x7f1933413d30>(array([7.7110...71253567e+08]) == array([7.7110...71253568e+08])
E        +    where <function all at 0x7f1933413d30> = np.all
E           +array([7.71105988e+08, 7.71105989e+08, 7.71105990e+08, ...,\n
E           +       7.71253565e+08, 7.71253566e+08, 7.71253567e+08])
E           -array([7.71105988e+08, 7.71105989e+08, 7.71105990e+08, ...,\n
E           -       7.71253566e+08, 7.71253567e+08, 7.71253568e+08])
E           Full diff:
E             array([7.71105988e+08, 7.71105989e+08, 7.71105990e+08, ...,
E           -        7.71253566e+08, 7.71253567e+08, 7.71253568e+08],
E           +        7.71253565e+08, 7.71253566e+08, 7.71253567e+08],
E             ))
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Changed the unit test to ensure failure, and got some semi-useful output:
```
----------------------------------------------------- Captured stdout call ------------------------------------------------------
CxoTime(cxc_tstop).date='2022:160:20:05:18.241' dt=2000
CxoTime(cxc_tstop - dt).date='2022:160:19:31:58.241'
CxoTime(cxc_tstop + dt).date='2022:160:20:38:38.241'
CxoTime.now().date='2022:163:11:29:51.692'
CxoTime.now().iso='2022-06-12 11:29:51.693'
sources=('maude',) msid='Calc_pitCH'
```

