### PR TITLE
Change `MSIDset.filter_bad()` to apply to individual MSIDs by default

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -1482,12 +1482,15 @@ class MSIDset(collections.OrderedDict):
     def copy(self):
         return self.__deepcopy__()
 
-    def filter_bad(self, copy=False):
+    def filter_bad(self, copy=False, union=False):
         """Filter bad values for the MSID set.
 
-        This function applies the union (logical-OR) of bad value masks for all
-        MSIDs in the set with the same content type.  The result is that the
-        filtered MSID samples are valid for *all* MSIDs within the
+        By default (``union=False``) the bad values are filtered individually for
+        each MSID.
+
+        If ``union=True`` this method applies the union (logical-OR) of bad value
+        masks for all MSIDs in the set with the same content type.  The result
+        is that the filtered MSID samples are valid for *all* MSIDs within the
         content type and the arrays all match up.
 
         For example::
@@ -1513,6 +1516,15 @@ class MSIDset(collections.OrderedDict):
         """
         obj = self.copy() if copy else self
 
+        if not union:
+            # Filter bad values individually for each MSID
+            for msid in obj.values():
+                msid.filter_bad()
+            # Maintain existing function API to return None for copy=False
+            return obj if copy else None
+
+        # Union of bad value masks for all MSIDs in the set with the same
+        # content type.
         for content in set(x.content for x in obj.values()):
             bads = None
 


### PR DESCRIPTION
## Description

The `MSIDset.filter_bad()` method was previously trying to be too clever and doing correlated union-based filtering on MSIDs within each content type. This is strongly tied to the concept of content types in the `cxc` dataset, but with increasing use of MAUDE as the backend this idea is less applicable.

Although it is an API change that might have an impact, this PR is to change the default behavior of filtering bad data in a set to simply filter each MSID in the set individually.

A small tag-along here is ensuring that MAUDE-dependent tests in `test_fetch.py` are skipped if MAUDE is not available.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #234 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

This changes the default behavior of `MSIDset.filter_bad()`, and therefore the default behavior of `Msidset()` which calls `filter_bad()`. This API change should not impact much code in practice:
- `Msidset()` is not a good way to get correlated MSIDs so hopefully it is not used that much (instead `MSIDset()` is better).
- Actual incidence of `bad` values is extremely low due.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac with new unit test

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
