### PR TITLE
Add warning/error to update_server_sync messages

### DIFF
--- a/Ska/engarchive/update_server_sync.py
+++ b/Ska/engarchive/update_server_sync.py
@@ -78,7 +78,8 @@ def get_options(args=None):
                         default=20,
                         help="Logging level")
     parser.add_argument("--date-start",
-                        help="Start process date (default=NOW - max-lookback)")
+                        help=("Start process date (default=NOW - max-lookback). "
+                              "Provide this parameter when creating a new sync directory."))
     parser.add_argument("--date-stop",
                         help="Stop process date (default=NOW)")
     return parser.parse_args(args)
@@ -177,7 +178,7 @@ def update_sync_repo(opt, logger, content):
 
     if index_tbl is None:
         # Index table was not created, nothing more to do here
-        logger.warning(f'WARNING: No index table for {content}')
+        logger.warning(f'WARNING: No index table for {content} (use --date-start to create)')
         return
 
     for row in index_tbl:

--- a/Ska/engarchive/update_server_sync.py
+++ b/Ska/engarchive/update_server_sync.py
@@ -177,7 +177,7 @@ def update_sync_repo(opt, logger, content):
 
     if index_tbl is None:
         # Index table was not created, nothing more to do here
-        logger.warning(f'No index table for {content}')
+        logger.warning(f'WARNING: No index table for {content}')
         return
 
     for row in index_tbl:
@@ -308,7 +308,7 @@ def update_index_file(index_file, opt, logger):
     if msg:
         msg += '\n'
         msg += '\n'.join(index_tbl.pformat(max_lines=-1, max_width=-1))
-        logger.error(f'Index table inconsistency: {msg}')
+        logger.error(f'ERROR: Index table inconsistency: {msg}')
         return None
 
     logger.info(f'Writing {len(rows)} row(s) to index file {index_file}')


### PR DESCRIPTION
## Description

This will trigger emails that notify the team about issues with maintaining the cheta sync archive.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
No testing given the scope of changes, which are limited to updates to format strings in the code.