### PR TITLE
Fix server data root regex for copying server files

### DIFF
--- a/Ska/engarchive/tests/test_sync.py
+++ b/Ska/engarchive/tests/test_sync.py
@@ -348,3 +348,22 @@ def test_sync(tmpdir, content):
     # Clean up if test successful (otherwise check_content raises)
     if Path(tmpdir).exists():
         shutil.rmtree(tmpdir)
+
+
+def test_parse_server_data_root():
+    username, hostname, server_path = update_client_archive.parse_server_data_root(
+        "christian.anderson@host.name.com:/path/to/data/root"
+    )
+    assert username == "christian.anderson"
+    assert hostname == "host.name.com"
+    assert server_path == ":/path/to/data/root"
+
+    username, hostname, server_path = update_client_archive.parse_server_data_root(
+        "chris_and-son@host"
+    )
+    assert username == "chris_and-son"
+    assert hostname == "host"
+    assert server_path is None
+
+    with pytest.raises(ValueError, match="could not parse"):
+        update_client_archive.parse_server_data_root("_chris_and-son@host")

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -236,10 +236,7 @@ def copy_server_files_ssh(opt, logger, copy_files):
     """
     import paramiko
 
-    match = re.match(r'(\w+)@([\w.]+)(:.+)?', opt.server_data_root)
-    if not match:
-        raise ValueError(f'could not parse {opt.server_data_root} into username@host:path')
-    username, hostname, server_path = match.groups()
+    username, hostname, server_path = parse_server_data_root(opt.server_data_root)
     server_path = server_path or '/proj/sot/ska/data/eng_archive'
 
     logger.info(f'Connecting to {hostname}')
@@ -265,6 +262,16 @@ def copy_server_files_ssh(opt, logger, copy_files):
                       as_posix=True)
     sftp_client.close()
     ssh_client.close()
+
+
+def parse_server_data_root(server_data_root):
+    match = re.match(r"([a-zA-Z][-.\w]*)@([\w.]+)(:.+)?", server_data_root)
+    if not match:
+        raise ValueError(
+            f"could not parse {server_data_root} into username@host:path"
+        )
+    username, hostname, server_path = match.groups()
+    return username, hostname, server_path
 
 
 def get_copy_files(logger, msids, msids_content):


### PR DESCRIPTION
## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #239 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac : FAILING two tests that use MAUDE. This is unrelated and apparently due to MAUDE server problems.

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
```
$ python -m cheta.update_client_archive --add-msids=msid_specs --data-root=. \
--server-data-root=aldcroft@kadi.cfa.harvard.edu --dry-run

fetch: using ENG_ARCHIVE=/Users/aldcroft/git/eng_archive for archive path
2022-09-13 09:19:54,845 Running cheta_update_client_archive version 4.56.1.dev11+g8ed7a4c
2022-09-13 09:19:54,845   /Users/aldcroft/git/eng_archive/cheta/update_client_archive.py
2022-09-13 09:19:54,845 
2022-09-13 09:19:54,845 Updating client archive at /Users/aldcroft/git/eng_archive
2022-09-13 09:19:54,845 Reading available cheta archive MSIDs from https://icxc.cfa.harvard.edu/aspect/cheta/
2022-09-13 09:19:55,092 Reading cheta MSIDs list file https://icxc.cfa.harvard.edu/aspect/cheta/sync/msid_contents.pkl.gz
2022-09-13 09:19:55,097 Reading MSID specs from msid_specs
2022-09-13 09:19:55,097 Assembling list of MSIDs that match MSID specs
2022-09-13 09:19:55,104   Found 1 MSIDs for AOPCADMD
2022-09-13 09:19:55,110   Found 2 MSIDs for AACCCD*
2022-09-13 09:19:55,110   Found 9 MSIDs for */1WRAT with content = acis4eng
2022-09-13 09:19:55,110   Found 12 matching MSIDs total
2022-09-13 09:19:55,172 Found 45 local archive files that are missing and need to be copied
2022-09-13 09:19:55,265 Connecting to kadi.cfa.harvard.edu
Password for aldcroft@kadi.cfa.harvard.edu: 
2022-09-13 09:20:12,423 Copying 45 files from aldcroft@kadi.cfa.harvard.edu to /Users/aldcroft/git/eng_archive
2022-09-13 09:20:12,423 DRY RUN
|>--------------------------------------------------------------------------------------------------------------------------------|   0 / 45  ( 0.00%)2022-09-13 09:20:12,424 copy data/acis4eng/1PIN1AT.h5
2022-09-13 09:20:12,424 copy data/acis4eng/1SSMYT.h5
2022-09-13 09:20:12,424 copy data/acis4eng/1SSPYT.h5
2022-09-13 09:20:12,425 copy data/acis4eng/1VAHCAT.h5
2022-09-13 09:20:12,425 copy data/acis4eng/1VAHCBT.h5
2022-09-13 09:20:12,425 copy data/acis4eng/1VAHOAT.h5
2022-09-13 09:20:12,425 copy data/acis4eng/1VAHOBT.h5
2022-09-13 09:20:12,426 copy data/acis4eng/1WRAT.h5
2022-09-13 09:20:12,426 copy data/acis4eng/1WRBT.h5
2022-09-13 09:20:12,426 copy data/acis4eng/5min/1PIN1AT.h5
2022-09-13 09:20:12,426 copy data/acis4eng/5min/1SSMYT.h5
2022-09-13 09:20:12,426 copy data/acis4eng/5min/1SSPYT.h5
2022-09-13 09:20:12,426 copy data/acis4eng/5min/1VAHCAT.h5
2022-09-13 09:20:12,427 copy data/acis4eng/5min/1VAHCBT.h5
2022-09-13 09:20:12,427 copy data/acis4eng/5min/1VAHOAT.h5
2022-09-13 09:20:12,427 copy data/acis4eng/5min/1VAHOBT.h5
2022-09-13 09:20:12,427 copy data/acis4eng/5min/1WRAT.h5
2022-09-13 09:20:12,427 copy data/acis4eng/5min/1WRBT.h5
2022-09-13 09:20:12,427 copy data/acis4eng/TIME.h5
2022-09-13 09:20:12,427 copy data/acis4eng/archfiles.db3
2022-09-13 09:20:12,427 copy data/acis4eng/colnames.pickle
2022-09-13 09:20:12,428 copy data/acis4eng/daily/1PIN1AT.h5
2022-09-13 09:20:12,428 copy data/acis4eng/daily/1SSMYT.h5
2022-09-13 09:20:12,428 copy data/acis4eng/daily/1SSPYT.h5
2022-09-13 09:20:12,428 copy data/acis4eng/daily/1VAHCAT.h5
2022-09-13 09:20:12,428 copy data/acis4eng/daily/1VAHCBT.h5
2022-09-13 09:20:12,428 copy data/acis4eng/daily/1VAHOAT.h5
2022-09-13 09:20:12,429 copy data/acis4eng/daily/1VAHOBT.h5
2022-09-13 09:20:12,429 copy data/acis4eng/daily/1WRAT.h5
2022-09-13 09:20:12,429 copy data/acis4eng/daily/1WRBT.h5
2022-09-13 09:20:12,429 copy data/pcad3eng/5min/AOPCADMD.h5
2022-09-13 09:20:12,429 copy data/pcad3eng/AOPCADMD.h5
2022-09-13 09:20:12,429 copy data/pcad3eng/TIME.h5
2022-09-13 09:20:12,429 copy data/pcad3eng/archfiles.db3
2022-09-13 09:20:12,430 copy data/pcad3eng/colnames.pickle
2022-09-13 09:20:12,430 copy data/pcad3eng/daily/AOPCADMD.h5
2022-09-13 09:20:12,430 copy data/pcad5eng/5min/AACCCDPT.h5
2022-09-13 09:20:12,430 copy data/pcad5eng/5min/AACCCDRT.h5
2022-09-13 09:20:12,431 copy data/pcad5eng/AACCCDPT.h5
2022-09-13 09:20:12,431 copy data/pcad5eng/AACCCDRT.h5
2022-09-13 09:20:12,431 copy data/pcad5eng/TIME.h5
2022-09-13 09:20:12,431 copy data/pcad5eng/archfiles.db3
2022-09-13 09:20:12,431 copy data/pcad5eng/colnames.pickle
2022-09-13 09:20:12,431 copy data/pcad5eng/daily/AACCCDPT.h5
2022-09-13 09:20:12,432 copy data/pcad5eng/daily/AACCCDRT.h5
```
