### PR TITLE
Apply black and isort

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -18,4 +18,4 @@ jobs:
         pip install flake8
         # Note: only check files in Ska.engarchive package.  Many other files in
         # the repo are not maintained as PEP8 compliant.
-        flake8 Ska --count --ignore=W503,W504,F541 --max-line-length=100 --show-source --statistics
+        flake8 Ska --count --ignore=W503,W504,F541,E203 --max-line-length=100 --show-source --statistics

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+    - id: black
+      language_version: python3.8
+
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)

--- a/Ska/engarchive/__init__.py
+++ b/Ska/engarchive/__init__.py
@@ -10,4 +10,5 @@ def test(*args, **kwargs):
     Run py.test unit tests.
     '''
     import testr
+
     return testr.test(*args, **kwargs)

--- a/Ska/engarchive/__init__.py
+++ b/Ska/engarchive/__init__.py
@@ -2,13 +2,13 @@
 
 import ska_helpers
 
-__version__ = ska_helpers.get_version('Ska.engarchive')
+__version__ = ska_helpers.get_version("Ska.engarchive")
 
 
 def test(*args, **kwargs):
-    '''
+    """
     Run py.test unit tests.
-    '''
+    """
     import testr
 
     return testr.test(*args, **kwargs)

--- a/Ska/engarchive/__init__.py
+++ b/Ska/engarchive/__init__.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import ska_helpers
+
 __version__ = ska_helpers.get_version('Ska.engarchive')
 
 

--- a/Ska/engarchive/add_derived.py
+++ b/Ska/engarchive/add_derived.py
@@ -32,7 +32,7 @@ def get_options():
     parser.add_option("--stop", default="1999:260", help="Stop for initial data fetch")
     parser.add_option(
         "--content",
-        action='append',
+        action="append",
         help="Content type to process [match regex] (default = all)",
     )
     return parser.parse_args()
@@ -46,15 +46,15 @@ def make_archfiles_db(filename, content_def):
     datestart = DateTime(DateTime(opt.start).secs - 60)
     tstart = datestart.secs
     tstop = tstart
-    year, doy = datestart.date.split(':')[:2]
-    times, indexes = derived.times_indexes(tstart, tstop, content_def['time_step'])
+    year, doy = datestart.date.split(":")[:2]
+    times, indexes = derived.times_indexes(tstart, tstop, content_def["time_step"])
 
-    logger.info('Creating db {}'.format(filename))
-    archfiles_def = open(Path(__file__).parent / 'archfiles_def.sql').read()
-    db = Ska.DBI.DBI(dbi='sqlite', server=filename)
+    logger.info("Creating db {}".format(filename))
+    archfiles_def = open(Path(__file__).parent / "archfiles_def.sql").read()
+    db = Ska.DBI.DBI(dbi="sqlite", server=filename)
     db.execute(archfiles_def)
     archfiles_row = dict(
-        filename='{}:0:1'.format(content_def['content']),
+        filename="{}:0:1".format(content_def["content"]),
         filetime=0,
         year=year,
         doy=doy,
@@ -66,7 +66,7 @@ def make_archfiles_db(filename, content_def):
         stopmjf=indexes[-1],  # really index1
         date=datestart.date,
     )
-    db.insert(archfiles_row, 'archfiles')
+    db.insert(archfiles_row, "archfiles")
 
 
 def add_colname(filename, colname):
@@ -74,57 +74,57 @@ def add_colname(filename, colname):
     as needed.
     """
     if not os.path.exists(filename):
-        logger.info('Creating colnames pickle {}'.format(filename))
-        with open(filename, 'wb') as f:
+        logger.info("Creating colnames pickle {}".format(filename))
+        with open(filename, "wb") as f:
             pickle.dump(set(), f, protocol=0)
 
-    colnames = pickle.load(open(filename, 'rb'))
+    colnames = pickle.load(open(filename, "rb"))
     if colname not in colnames:
-        logger.info('Adding colname {} to colnames pickle {}'.format(colname, filename))
+        logger.info("Adding colname {} to colnames pickle {}".format(colname, filename))
         colnames.add(colname)
-        with open(filename, 'wb') as f:
+        with open(filename, "wb") as f:
             pickle.dump(colnames, f, protocol=0)
 
 
 def make_msid_file(colname, content, content_def):
-    ft['content'] = content
-    ft['msid'] = colname
-    filename = msid_files['data'].abs
+    ft["content"] = content
+    ft["msid"] = colname
+    filename = msid_files["data"].abs
     if os.path.exists(filename):
         return
 
-    logger.info('Making MSID data file %s', filename)
+    logger.info("Making MSID data file %s", filename)
 
-    if colname == 'TIME':
+    if colname == "TIME":
         dp_vals, indexes = derived.times_indexes(
-            opt.start, opt.stop, content_def['time_step']
+            opt.start, opt.stop, content_def["time_step"]
         )
     else:
-        dp = content_def['classes'][colname]()
+        dp = content_def["classes"][colname]()
         dataset = dp.fetch(opt.start, opt.stop)
         dp_vals = np.asarray(dp.calc(dataset), dtype=dp.dtype)
 
     # Finally make the actual MSID data file
-    filters = tables.Filters(complevel=5, complib='zlib')
-    h5 = tables.open_file(filename, mode='w', filters=filters)
+    filters = tables.Filters(complevel=5, complib="zlib")
+    h5 = tables.open_file(filename, mode="w", filters=filters)
 
-    n_rows = int(20 * 3e7 / content_def['time_step'])
+    n_rows = int(20 * 3e7 / content_def["time_step"])
     h5shape = (0,)
     h5type = tables.Atom.from_dtype(dp_vals.dtype)
     h5.create_earray(
-        h5.root, 'data', h5type, h5shape, title=colname, expectedrows=n_rows
+        h5.root, "data", h5type, h5shape, title=colname, expectedrows=n_rows
     )
     h5.create_earray(
         h5.root,
-        'quality',
+        "quality",
         tables.BoolAtom(),
         (0,),
-        title='Quality',
+        title="Quality",
         expectedrows=n_rows,
     )
 
     logger.info(
-        'Made {} shape={} with n_rows(1e6)={}'.format(colname, h5shape, n_rows / 1.0e6)
+        "Made {} shape={} with n_rows(1e6)={}".format(colname, h5shape, n_rows / 1.0e6)
     )
     h5.close()
 
@@ -135,56 +135,56 @@ def main():
     opt, args = get_options()
     ft = fetch.ft
     msid_files = pyyaks.context.ContextDict(
-        'add_derived.msid_files', basedir=opt.data_root
+        "add_derived.msid_files", basedir=opt.data_root
     )
     msid_files.update(file_defs.msid_files)
     logger = pyyaks.logger.get_logger(
-        name='engarchive', level=pyyaks.logger.VERBOSE, format="%(asctime)s %(message)s"
+        name="engarchive", level=pyyaks.logger.VERBOSE, format="%(asctime)s %(message)s"
     )
 
     # Get the derived parameter classes
-    dp_classes = (getattr(derived, x) for x in dir(derived) if x.startswith('DP_'))
+    dp_classes = (getattr(derived, x) for x in dir(derived) if x.startswith("DP_"))
     dp_classes = [
         x
         for x in dp_classes
-        if hasattr(x, '__base__') and issubclass(x, derived.DerivedParameter)
+        if hasattr(x, "__base__") and issubclass(x, derived.DerivedParameter)
     ]
     content_defs = {}
     for dp_class in dp_classes:
         colname = dp_class.__name__.upper()
         dp = dp_class()
         content = dp.content
-        if opt.content == [] or any(re.match(x + r'\d+', content) for x in opt.content):
+        if opt.content == [] or any(re.match(x + r"\d+", content) for x in opt.content):
             dpd = content_defs.setdefault(content, {})
-            dpd.setdefault('classes', {'TIME': None})
-            dpd['content'] = content
-            dpd['classes'][colname] = dp_class
-            dpd['mnf_step'] = dp.mnf_step
-            dpd['time_step'] = dp.time_step
+            dpd.setdefault("classes", {"TIME": None})
+            dpd["content"] = content
+            dpd["classes"][colname] = dp_class
+            dpd["mnf_step"] = dp.mnf_step
+            dpd["time_step"] = dp.time_step
 
     for content, content_def in content_defs.items():
-        ft['content'] = content
-        logger.info('CONTENT = {}'.format(content))
+        ft["content"] = content
+        logger.info("CONTENT = {}".format(content))
 
         # Make content directory
-        if not os.path.exists(msid_files['contentdir'].rel):
-            logger.info('Making directory {}'.format(msid_files['contentdir'].rel))
-            os.mkdir(msid_files['contentdir'].rel)
+        if not os.path.exists(msid_files["contentdir"].rel):
+            logger.info("Making directory {}".format(msid_files["contentdir"].rel))
+            os.mkdir(msid_files["contentdir"].rel)
 
         # Make the archfiles.db3 file (if needed)
-        make_archfiles_db(msid_files['archfiles'].abs, content_def)
+        make_archfiles_db(msid_files["archfiles"].abs, content_def)
 
-        for colname in content_def['classes']:
-            ft['msid'] = colname
-            logger.debug('MSID = {}'.format(colname))
+        for colname in content_def["classes"]:
+            ft["msid"] = colname
+            logger.debug("MSID = {}".format(colname))
             # Create colnames and colnames_all pickle files (if needed) and add colname
-            add_colname(msid_files['colnames'].rel, colname)
-            add_colname(msid_files['colnames_all'].rel, colname)
+            add_colname(msid_files["colnames"].rel, colname)
+            add_colname(msid_files["colnames_all"].rel, colname)
 
             make_msid_file(colname, content, content_def)
 
-        add_colname(msid_files['colnames_all'].rel, 'QUALITY')
+        add_colname(msid_files["colnames_all"].rel, "QUALITY")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/Ska/engarchive/add_derived.py
+++ b/Ska/engarchive/add_derived.py
@@ -1,24 +1,22 @@
 #!/usr/bin/env python
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import re
+import optparse
 import os
+import re
 from pathlib import Path
 
-from six.moves import cPickle as pickle
-import optparse
-
+import numpy as np
+import pyyaks.context
+import pyyaks.logger
+import Ska.DBI
 import tables
 from Chandra.Time import DateTime
+from six.moves import cPickle as pickle
 
-import Ska.DBI
-import pyyaks.logger
-import pyyaks.context
-import numpy as np
-
+import Ska.engarchive.derived as derived
 import Ska.engarchive.fetch as fetch
 import Ska.engarchive.file_defs as file_defs
-import Ska.engarchive.derived as derived
 
 
 def get_options():

--- a/Ska/engarchive/add_derived.py
+++ b/Ska/engarchive/add_derived.py
@@ -21,18 +21,20 @@ import Ska.engarchive.file_defs as file_defs
 
 def get_options():
     parser = optparse.OptionParser()
-    parser.add_option("--data-root",
-                      default=".",
-                      help="Engineering archive root directory for MSID and arch files")
-    parser.add_option("--start",
-                      default="1999:201",
-                      help="Start for initial data fetch")
-    parser.add_option("--stop",
-                      default="1999:260",
-                      help="Stop for initial data fetch")
-    parser.add_option("--content",
-                      action='append',
-                      help="Content type to process [match regex] (default = all)")
+    parser.add_option(
+        "--data-root",
+        default=".",
+        help="Engineering archive root directory for MSID and arch files",
+    )
+    parser.add_option(
+        "--start", default="1999:201", help="Start for initial data fetch"
+    )
+    parser.add_option("--stop", default="1999:260", help="Stop for initial data fetch")
+    parser.add_option(
+        "--content",
+        action='append',
+        help="Content type to process [match regex] (default = all)",
+    )
     return parser.parse_args()
 
 
@@ -51,17 +53,19 @@ def make_archfiles_db(filename, content_def):
     archfiles_def = open(Path(__file__).parent / 'archfiles_def.sql').read()
     db = Ska.DBI.DBI(dbi='sqlite', server=filename)
     db.execute(archfiles_def)
-    archfiles_row = dict(filename='{}:0:1'.format(content_def['content']),
-                         filetime=0,
-                         year=year,
-                         doy=doy,
-                         tstart=tstart,
-                         tstop=tstop,
-                         rowstart=0,
-                         rowstop=0,
-                         startmjf=indexes[0],  # really index0
-                         stopmjf=indexes[-1],  # really index1
-                         date=datestart.date)
+    archfiles_row = dict(
+        filename='{}:0:1'.format(content_def['content']),
+        filetime=0,
+        year=year,
+        doy=doy,
+        tstart=tstart,
+        tstop=tstop,
+        rowstart=0,
+        rowstop=0,
+        startmjf=indexes[0],  # really index0
+        stopmjf=indexes[-1],  # really index1
+        date=datestart.date,
+    )
     db.insert(archfiles_row, 'archfiles')
 
 
@@ -92,8 +96,9 @@ def make_msid_file(colname, content, content_def):
     logger.info('Making MSID data file %s', filename)
 
     if colname == 'TIME':
-        dp_vals, indexes = derived.times_indexes(opt.start, opt.stop,
-                                                 content_def['time_step'])
+        dp_vals, indexes = derived.times_indexes(
+            opt.start, opt.stop, content_def['time_step']
+        )
     else:
         dp = content_def['classes'][colname]()
         dataset = dp.fetch(opt.start, opt.stop)
@@ -106,12 +111,21 @@ def make_msid_file(colname, content, content_def):
     n_rows = int(20 * 3e7 / content_def['time_step'])
     h5shape = (0,)
     h5type = tables.Atom.from_dtype(dp_vals.dtype)
-    h5.create_earray(h5.root, 'data', h5type, h5shape, title=colname,
-                     expectedrows=n_rows)
-    h5.create_earray(h5.root, 'quality', tables.BoolAtom(), (0,), title='Quality',
-                     expectedrows=n_rows)
+    h5.create_earray(
+        h5.root, 'data', h5type, h5shape, title=colname, expectedrows=n_rows
+    )
+    h5.create_earray(
+        h5.root,
+        'quality',
+        tables.BoolAtom(),
+        (0,),
+        title='Quality',
+        expectedrows=n_rows,
+    )
 
-    logger.info('Made {} shape={} with n_rows(1e6)={}'.format(colname, h5shape, n_rows / 1.0e6))
+    logger.info(
+        'Made {} shape={} with n_rows(1e6)={}'.format(colname, h5shape, n_rows / 1.0e6)
+    )
     h5.close()
 
 
@@ -120,15 +134,21 @@ def main():
 
     opt, args = get_options()
     ft = fetch.ft
-    msid_files = pyyaks.context.ContextDict('add_derived.msid_files', basedir=opt.data_root)
+    msid_files = pyyaks.context.ContextDict(
+        'add_derived.msid_files', basedir=opt.data_root
+    )
     msid_files.update(file_defs.msid_files)
-    logger = pyyaks.logger.get_logger(name='engarchive', level=pyyaks.logger.VERBOSE,
-                                      format="%(asctime)s %(message)s")
+    logger = pyyaks.logger.get_logger(
+        name='engarchive', level=pyyaks.logger.VERBOSE, format="%(asctime)s %(message)s"
+    )
 
     # Get the derived parameter classes
     dp_classes = (getattr(derived, x) for x in dir(derived) if x.startswith('DP_'))
-    dp_classes = [x for x in dp_classes
-                  if hasattr(x, '__base__') and issubclass(x, derived.DerivedParameter)]
+    dp_classes = [
+        x
+        for x in dp_classes
+        if hasattr(x, '__base__') and issubclass(x, derived.DerivedParameter)
+    ]
     content_defs = {}
     for dp_class in dp_classes:
         colname = dp_class.__name__.upper()

--- a/Ska/engarchive/cache.py
+++ b/Ska/engarchive/cache.py
@@ -18,6 +18,7 @@ class Counter(dict):
 
 # TODO: replace with std_library version of this in Py3.6 (issue #173)
 
+
 def lru_cache(maxsize=30):
     '''Least-recently-used cache decorator.
 
@@ -29,12 +30,13 @@ def lru_cache(maxsize=30):
     '''
     maxqueue = maxsize * 10
 
-    def decorating_function(user_function,
-                            len=len, iter=iter, tuple=tuple, sorted=sorted, KeyError=KeyError):
-        cache = {}                  # mapping of args to results
+    def decorating_function(
+        user_function, len=len, iter=iter, tuple=tuple, sorted=sorted, KeyError=KeyError
+    ):
+        cache = {}  # mapping of args to results
         queue = collections.deque()  # order that keys have been used
-        refcount = Counter()        # times each key is in the queue
-        sentinel = object()         # marker for looping around the queue
+        refcount = Counter()  # times each key is in the queue
+        sentinel = object()  # marker for looping around the queue
 
         # lookup optimizations (ugly but fast)
         queue_append, queue_popleft = queue.append, queue.popleft
@@ -74,8 +76,9 @@ def lru_cache(maxsize=30):
             if len(queue) > maxqueue:
                 refcount.clear()
                 queue_appendleft(sentinel)
-                for key in filterfalse(refcount.__contains__,
-                                       iter(queue_pop, sentinel)):
+                for key in filterfalse(
+                    refcount.__contains__, iter(queue_pop, sentinel)
+                ):
                     queue_appendleft(key)
                     refcount[key] = 1
 
@@ -90,6 +93,7 @@ def lru_cache(maxsize=30):
         wrapper.hits = wrapper.misses = 0
         wrapper.clear = clear
         return wrapper
+
     return decorating_function
 
 
@@ -102,10 +106,11 @@ def lfu_cache(maxsize=100):
     http://en.wikipedia.org/wiki/Least_Frequently_Used
 
     '''
+
     def decorating_function(user_function):
-        cache = {}                      # mapping of args to results
-        use_count = Counter()           # times each key has been accessed
-        kwd_mark = object()             # separate positional and keyword args
+        cache = {}  # mapping of args to results
+        use_count = Counter()  # times each key has been accessed
+        kwd_mark = object()  # separate positional and keyword args
 
         @functools.wraps(user_function)
         def wrapper(*args, **kwds):
@@ -125,9 +130,9 @@ def lfu_cache(maxsize=100):
 
                 # purge least frequently used cache entry
                 if len(cache) > maxsize:
-                    for key, _ in nsmallest(maxsize // 10,
-                                            six.iteritems(use_count),
-                                            key=itemgetter(1)):
+                    for key, _ in nsmallest(
+                        maxsize // 10, six.iteritems(use_count), key=itemgetter(1)
+                    ):
                         del cache[key], use_count[key]
 
             return result
@@ -140,6 +145,7 @@ def lfu_cache(maxsize=100):
         wrapper.hits = wrapper.misses = 0
         wrapper.clear = clear
         return wrapper
+
     return decorating_function
 
 
@@ -151,6 +157,7 @@ if __name__ == '__main__':
 
     domain = list(range(5))
     from random import choice
+
     for i in range(1000):
         r = f(choice(domain), choice(domain))
 
@@ -162,6 +169,7 @@ if __name__ == '__main__':
 
     domain = list(range(5))
     from random import choice
+
     for i in range(1000):
         r = f(choice(domain), choice(domain))
 

--- a/Ska/engarchive/cache.py
+++ b/Ska/engarchive/cache.py
@@ -2,10 +2,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import collections
 import functools
-import six
-from six.moves import filterfalse
 from heapq import nsmallest
 from operator import itemgetter
+
+import six
+from six.moves import filterfalse
 
 
 class Counter(dict):

--- a/Ska/engarchive/cache.py
+++ b/Ska/engarchive/cache.py
@@ -10,7 +10,7 @@ from six.moves import filterfalse
 
 
 class Counter(dict):
-    'Mapping where default values are zero'
+    "Mapping where default values are zero"
 
     def __missing__(self, key):
         return 0
@@ -20,14 +20,14 @@ class Counter(dict):
 
 
 def lru_cache(maxsize=30):
-    '''Least-recently-used cache decorator.
+    """Least-recently-used cache decorator.
 
     Arguments to the cached function must be hashable.
     Cache performance statistics stored in f.hits and f.misses.
     Clear the cache with f.clear().
     http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used
 
-    '''
+    """
     maxqueue = maxsize * 10
 
     def decorating_function(
@@ -98,14 +98,14 @@ def lru_cache(maxsize=30):
 
 
 def lfu_cache(maxsize=100):
-    '''Least-frequenty-used cache decorator.
+    """Least-frequenty-used cache decorator.
 
     Arguments to the cached function must be hashable.
     Cache performance statistics stored in f.hits and f.misses.
     Clear the cache with f.clear().
     http://en.wikipedia.org/wiki/Least_Frequently_Used
 
-    '''
+    """
 
     def decorating_function(user_function):
         cache = {}  # mapping of args to results
@@ -149,7 +149,7 @@ def lfu_cache(maxsize=100):
     return decorating_function
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     @lru_cache(maxsize=20)
     def f(x, y):

--- a/Ska/engarchive/check_integrity.py
+++ b/Ska/engarchive/check_integrity.py
@@ -52,67 +52,67 @@ def get_options():
     )
     parser.add_option(
         "--content",
-        action='append',
+        action="append",
         help="Content type to process [match regex] (default = all)",
     )
     return parser.parse_args()
 
 
 def check_filetype(filetype):
-    ft['content'] = filetype.content.lower()
+    ft["content"] = filetype.content.lower()
 
-    if not os.path.exists(msid_files['archfiles'].abs):
-        logger.info('No archfiles.db3 for %s - skipping' % ft['content'])
+    if not os.path.exists(msid_files["archfiles"].abs):
+        logger.info("No archfiles.db3 for %s - skipping" % ft["content"])
         return
 
     logger.info(
-        'Checking {} content type, archfiles {}'.format(
-            ft['content'], msid_files['archfiles'].abs
+        "Checking {} content type, archfiles {}".format(
+            ft["content"], msid_files["archfiles"].abs
         )
     )
 
-    db = Ska.DBI.DBI(dbi='sqlite', server=msid_files['archfiles'].abs)
-    archfiles = db.fetchall('select * from archfiles')
+    db = Ska.DBI.DBI(dbi="sqlite", server=msid_files["archfiles"].abs)
+    archfiles = db.fetchall("select * from archfiles")
     db.conn.close()
 
     if opt.check_order:
         for archfile0, archfile1 in zip(archfiles[:-1], archfiles[1:]):
             exception = (
-                archfile0['startmjf'] == 77826
-                and archfile0['year'] == 2004
-                and archfile0['doy'] == 309
+                archfile0["startmjf"] == 77826
+                and archfile0["year"] == 2004
+                and archfile0["doy"] == 309
             )
-            if archfile1['tstart'] < archfile0['tstart'] and not exception:
+            if archfile1["tstart"] < archfile0["tstart"] and not exception:
                 logger.info(
-                    'ERROR: archfile order inconsistency\n {}\n{}'.format(
+                    "ERROR: archfile order inconsistency\n {}\n{}".format(
                         archfile0, archfile1
                     )
                 )
 
     if not opt.check_lengths:
-        colnames = ['TIME']
+        colnames = ["TIME"]
     else:
         colnames = [
             x
-            for x in pickle.load(open(msid_files['colnames'].abs))
+            for x in pickle.load(open(msid_files["colnames"].abs))
             if x not in fetch.IGNORE_COLNAMES
         ]
 
     lengths = set()
     for colname in colnames:
-        ft['msid'] = colname
+        ft["msid"] = colname
 
-        h5 = tables.open_file(msid_files['msid'].abs, mode='r')
+        h5 = tables.open_file(msid_files["msid"].abs, mode="r")
         length = len(h5.root.data)
         h5.root.data[length - 1]
         h5.close()
 
-        logger.verbose('MSID {} has length {}'.format(colname, length))
+        logger.verbose("MSID {} has length {}".format(colname, length))
         lengths.add(length)
         if len(lengths) != 1:
             logger.info(
-                'ERROR: inconsistent MSID length {} {} {}'.format(
-                    ft['content'], colname, lengths
+                "ERROR: inconsistent MSID length {} {} {}".format(
+                    ft["content"], colname, lengths
                 )
             )
             return  # Other checks don't make sense now
@@ -120,10 +120,10 @@ def check_filetype(filetype):
     length = lengths.pop()
 
     archfile = archfiles[-1]
-    if archfile['rowstop'] != length:
+    if archfile["rowstop"] != length:
         logger.info(
-            'ERROR: inconsistent archfile {}: last rowstop={} MSID length={}'.format(
-                ft['content'], archfile['rowstop'], length
+            "ERROR: inconsistent archfile {}: last rowstop={} MSID length={}".format(
+                ft["content"], archfile["rowstop"], length
             )
         )
         if opt.find_glitch:
@@ -131,24 +131,24 @@ def check_filetype(filetype):
 
 
 def find_glitch():
-    ft['msid'] = 'TIME'
-    h5 = tables.open_file(msid_files['msid'].abs, mode='r')
+    ft["msid"] = "TIME"
+    h5 = tables.open_file(msid_files["msid"].abs, mode="r")
     times = h5.root.data
 
-    db = Ska.DBI.DBI(dbi='sqlite', server=msid_files['archfiles'].abs)
-    archfiles = db.fetchall('select * from archfiles')
+    db = Ska.DBI.DBI(dbi="sqlite", server=msid_files["archfiles"].abs)
+    archfiles = db.fetchall("select * from archfiles")
     db.conn.close()
 
     for archfile in archfiles:
         logger.verbose(
-            'archfile {} {} {}'.format(
-                archfile['filename'], archfile['year'], archfile['doy']
+            "archfile {} {} {}".format(
+                archfile["filename"], archfile["year"], archfile["doy"]
             )
         )
-        tstart = archfile['tstart']
-        rowstart = archfile['rowstart']
+        tstart = archfile["tstart"]
+        rowstart = archfile["rowstart"]
         if abs(tstart - times[rowstart]) > opt.max_tstart_mismatch:
-            logger.info('ERROR: inconsistency\n {}'.format(archfile))
+            logger.info("ERROR: inconsistency\n {}".format(archfile))
             break
 
     h5.close()
@@ -167,17 +167,17 @@ def main():
     # fetch.ENG_ARCHIVE.  Fetch is a read-only process so this is safe when
     # testing.
     if opt.data_root:
-        fetch.msid_files.basedir = ':'.join([opt.data_root, fetch.ENG_ARCHIVE])
+        fetch.msid_files.basedir = ":".join([opt.data_root, fetch.ENG_ARCHIVE])
 
     # Set up logging
     loglevel = pyyaks.logger.VERBOSE if opt.verbose else pyyaks.logger.INFO
     logger = pyyaks.logger.get_logger(
-        name='engarchive', level=loglevel, format="%(asctime)s %(message)s"
+        name="engarchive", level=loglevel, format="%(asctime)s %(message)s"
     )
 
-    logger.info('Run time options: \n{}'.format(opt))
-    logger.info('check_archfiles file: {}'.format(os.path.abspath(__file__)))
-    logger.info('Fetch module file: {}'.format(os.path.abspath(fetch.__file__)))
+    logger.info("Run time options: \n{}".format(opt))
+    logger.info("check_archfiles file: {}".format(os.path.abspath(__file__)))
+    logger.info("Fetch module file: {}".format(os.path.abspath(fetch.__file__)))
 
     # Get the archive content filetypes
     filetypes = fetch.filetypes

--- a/Ska/engarchive/check_integrity.py
+++ b/Ska/engarchive/check_integrity.py
@@ -21,33 +21,40 @@ logger = None
 
 def get_options():
     parser = optparse.OptionParser()
-    parser.add_option("--data-root",
-                      default=".",
-                      help="Engineering archive root directory for "
-                           "MSID and arch files")
-    parser.add_option("--check-order",
-                      default=False,
-                      action="store_true",
-                      help="Check the order of archfiles (increasing in time)")
-    parser.add_option("--check-lengths",
-                      default=False,
-                      action="store_true",
-                      help="Check all MSID file lengths")
-    parser.add_option("--find-glitch",
-                      default=False,
-                      action="store_true",
-                      help="Find inconsistency in archfiles")
-    parser.add_option("--verbose",
-                      default=False,
-                      action="store_true",
-                      help="Verbose")
-    parser.add_option("--max-tstart-mismatch",
-                      default=100,
-                      help="Max mismatch in time between archfiles and h5")
-    parser.add_option("--content",
-                      action='append',
-                      help="Content type to process [match regex] "
-                           "(default = all)")
+    parser.add_option(
+        "--data-root",
+        default=".",
+        help="Engineering archive root directory for MSID and arch files",
+    )
+    parser.add_option(
+        "--check-order",
+        default=False,
+        action="store_true",
+        help="Check the order of archfiles (increasing in time)",
+    )
+    parser.add_option(
+        "--check-lengths",
+        default=False,
+        action="store_true",
+        help="Check all MSID file lengths",
+    )
+    parser.add_option(
+        "--find-glitch",
+        default=False,
+        action="store_true",
+        help="Find inconsistency in archfiles",
+    )
+    parser.add_option("--verbose", default=False, action="store_true", help="Verbose")
+    parser.add_option(
+        "--max-tstart-mismatch",
+        default=100,
+        help="Max mismatch in time between archfiles and h5",
+    )
+    parser.add_option(
+        "--content",
+        action='append',
+        help="Content type to process [match regex] (default = all)",
+    )
     return parser.parse_args()
 
 
@@ -58,8 +65,11 @@ def check_filetype(filetype):
         logger.info('No archfiles.db3 for %s - skipping' % ft['content'])
         return
 
-    logger.info('Checking {} content type, archfiles {}'.format(
-        ft['content'], msid_files['archfiles'].abs))
+    logger.info(
+        'Checking {} content type, archfiles {}'.format(
+            ft['content'], msid_files['archfiles'].abs
+        )
+    )
 
     db = Ska.DBI.DBI(dbi='sqlite', server=msid_files['archfiles'].abs)
     archfiles = db.fetchall('select * from archfiles')
@@ -67,17 +77,26 @@ def check_filetype(filetype):
 
     if opt.check_order:
         for archfile0, archfile1 in zip(archfiles[:-1], archfiles[1:]):
-            exception = (archfile0['startmjf'] == 77826 and
-                         archfile0['year'] == 2004 and archfile0['doy'] == 309)
+            exception = (
+                archfile0['startmjf'] == 77826
+                and archfile0['year'] == 2004
+                and archfile0['doy'] == 309
+            )
             if archfile1['tstart'] < archfile0['tstart'] and not exception:
-                logger.info('ERROR: archfile order inconsistency\n {}\n{}'
-                            .format(archfile0, archfile1))
+                logger.info(
+                    'ERROR: archfile order inconsistency\n {}\n{}'.format(
+                        archfile0, archfile1
+                    )
+                )
 
     if not opt.check_lengths:
         colnames = ['TIME']
     else:
-        colnames = [x for x in pickle.load(open(msid_files['colnames'].abs))
-                    if x not in fetch.IGNORE_COLNAMES]
+        colnames = [
+            x
+            for x in pickle.load(open(msid_files['colnames'].abs))
+            if x not in fetch.IGNORE_COLNAMES
+        ]
 
     lengths = set()
     for colname in colnames:
@@ -91,17 +110,22 @@ def check_filetype(filetype):
         logger.verbose('MSID {} has length {}'.format(colname, length))
         lengths.add(length)
         if len(lengths) != 1:
-            logger.info('ERROR: inconsistent MSID length {} {} {}'.format(
-                ft['content'], colname, lengths))
+            logger.info(
+                'ERROR: inconsistent MSID length {} {} {}'.format(
+                    ft['content'], colname, lengths
+                )
+            )
             return  # Other checks don't make sense now
 
     length = lengths.pop()
 
     archfile = archfiles[-1]
     if archfile['rowstop'] != length:
-        logger.info('ERROR: inconsistent archfile {}: '
-                    'last rowstop={} MSID length={}'.format(
-                        ft['content'], archfile['rowstop'], length))
+        logger.info(
+            'ERROR: inconsistent archfile {}: last rowstop={} MSID length={}'.format(
+                ft['content'], archfile['rowstop'], length
+            )
+        )
         if opt.find_glitch:
             find_glitch()
 
@@ -116,8 +140,11 @@ def find_glitch():
     db.conn.close()
 
     for archfile in archfiles:
-        logger.verbose('archfile {} {} {}'.format(
-            archfile['filename'], archfile['year'], archfile['doy']))
+        logger.verbose(
+            'archfile {} {} {}'.format(
+                archfile['filename'], archfile['year'], archfile['doy']
+            )
+        )
         tstart = archfile['tstart']
         rowstart = archfile['rowstart']
         if abs(tstart - times[rowstart]) > opt.max_tstart_mismatch:
@@ -144,20 +171,21 @@ def main():
 
     # Set up logging
     loglevel = pyyaks.logger.VERBOSE if opt.verbose else pyyaks.logger.INFO
-    logger = pyyaks.logger.get_logger(name='engarchive', level=loglevel,
-                                      format="%(asctime)s %(message)s")
+    logger = pyyaks.logger.get_logger(
+        name='engarchive', level=loglevel, format="%(asctime)s %(message)s"
+    )
 
     logger.info('Run time options: \n{}'.format(opt))
     logger.info('check_archfiles file: {}'.format(os.path.abspath(__file__)))
-    logger.info('Fetch module file: {}'
-                .format(os.path.abspath(fetch.__file__)))
+    logger.info('Fetch module file: {}'.format(os.path.abspath(fetch.__file__)))
 
     # Get the archive content filetypes
     filetypes = fetch.filetypes
     if opt.content:
         contents = [x.upper() for x in opt.content]
-        filetypes = [x for x in filetypes
-                     if any(re.match(y, x.content) for y in contents)]
+        filetypes = [
+            x for x in filetypes if any(re.match(y, x.content) for y in contents)
+        ]
 
     for filetype in filetypes:
         check_filetype(filetype)

--- a/Ska/engarchive/check_integrity.py
+++ b/Ska/engarchive/check_integrity.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import re
-import os
 import optparse
+import os
+import re
+
+import pyyaks.context
+import pyyaks.logger
+import Ska.DBI
+import tables
 from six.moves import cPickle as pickle
 
-import tables
-import pyyaks.logger
-import pyyaks.context
-
 import Ska.engarchive.fetch as fetch
-import Ska.DBI
 
 opt = None
 ft = fetch.ft

--- a/Ska/engarchive/converters.py
+++ b/Ska/engarchive/converters.py
@@ -1,17 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
 
 import logging
-import numpy
 import sys
 from collections import OrderedDict
 
-from six.moves import zip
-
+import numpy
 import numpy as np
 import Ska.Numpy
-from Chandra.Time import DateTime
 import Ska.tdb
+from Chandra.Time import DateTime
+from six.moves import zip
 
 from . import units
 

--- a/Ska/engarchive/converters.py
+++ b/Ska/engarchive/converters.py
@@ -15,7 +15,7 @@ from six.moves import zip
 from . import units
 
 MODULE = sys.modules[__name__]
-logger = logging.getLogger('engarchive')
+logger = logging.getLogger("engarchive")
 
 
 class NoValidDataError(Exception):
@@ -28,7 +28,7 @@ class DataShapeError(Exception):
 
 def quality_index(dat, colname):
     """Return the index for `colname` in `dat`"""
-    colname = colname.split(':')[0]
+    colname = colname.split(":")[0]
     return list(dat.dtype.names).index(colname)
 
 
@@ -65,9 +65,9 @@ def generic_converter(prefix=None, add_quality=False, aliases=None):
             # Note to self: never change an enclosed reference, i.e. don't do
             # prefix = prefix.upper() + '_'
             # You will lose an hour again figuring this out if so.
-            PREFIX = prefix.upper() + '_'
+            PREFIX = prefix.upper() + "_"
             colnames_out = [
-                (x if x in ('TIME', 'QUALITY') else PREFIX + x) for x in colnames_out
+                (x if x in ("TIME", "QUALITY") else PREFIX + x) for x in colnames_out
             ]
 
         arrays = [dat.field(x) for x in colnames]
@@ -75,7 +75,7 @@ def generic_converter(prefix=None, add_quality=False, aliases=None):
         if add_quality:
             descrs = [(x,) + y[1:] for x, y in zip(colnames_out, dat.dtype.descr)]
             quals = numpy.zeros((len(dat), len(colnames) + 1), dtype=numpy.bool)
-            descrs += [('QUALITY', numpy.bool, (len(colnames) + 1,))]
+            descrs += [("QUALITY", numpy.bool, (len(colnames) + 1,))]
             arrays += [quals]
         else:
             descrs = [
@@ -89,12 +89,12 @@ def generic_converter(prefix=None, add_quality=False, aliases=None):
 
 
 def get_bit_array(dat, in_name, out_name, bit_index):
-    bit_indexes = [int(bi) for bi in bit_index.split(',')]
+    bit_indexes = [int(bi) for bi in bit_index.split(",")]
     bit_index = max(bit_indexes)
 
     if dat[in_name].shape[1] < bit_index:
         raise DataShapeError(
-            'column {} has shape {} but need at least {}'.format(
+            "column {} has shape {} but need at least {}".format(
                 in_name, dat[in_name].shape[1], bit_index + 1
             )
         )
@@ -112,15 +112,15 @@ def get_bit_array(dat, in_name, out_name, bit_index):
     else:
         try:
             tscs = Ska.tdb.msids[out_name].Tsc
-            scs = {tsc['LOW_RAW_COUNT']: tsc['STATE_CODE'] for tsc in tscs}
+            scs = {tsc["LOW_RAW_COUNT"]: tsc["STATE_CODE"] for tsc in tscs}
         except (KeyError, AttributeError):
-            scs = ['OFF', 'ON ']
+            scs = ["OFF", "ON "]
 
         # CXC telemetry stores state code vals with trailing spaces so all match
         # in length.  Annoying, but reproduce this here for consistency so
         # fetch Msid.raw_vals does the right thing.
         max_len = max(len(sc) for sc in scs.values())
-        fmtstr = '{:' + str(max_len) + 's}'
+        fmtstr = "{:" + str(max_len) + "s}"
         scs = [fmtstr.format(val) for key, val in scs.items()]
 
         out_array = np.where(dat[in_name][:, bit_index], scs[1], scs[0])
@@ -141,19 +141,19 @@ def generic_converter2(msid_cxc_map, default_dtypes=None):
 
     def _convert(dat):
         # Make quality bool array with entries for TIME, QUALITY, then all other cols
-        out_names = ['TIME', 'QUALITY'] + list(msid_cxc_map.keys())
+        out_names = ["TIME", "QUALITY"] + list(msid_cxc_map.keys())
         out_quality = np.zeros(shape=(len(dat), len(out_names)), dtype=np.bool)
-        out_arrays = {'TIME': dat['TIME'], 'QUALITY': out_quality}
+        out_arrays = {"TIME": dat["TIME"], "QUALITY": out_quality}
 
         for out_name, in_name in msid_cxc_map.items():
-            if ':' in in_name:
-                in_name, bit_index = in_name.split(':')
+            if ":" in in_name:
+                in_name, bit_index = in_name.split(":")
                 out_array = get_bit_array(dat, in_name, out_name, bit_index)
-                quality = dat['QUALITY'][:, quality_index(dat, in_name)]
+                quality = dat["QUALITY"][:, quality_index(dat, in_name)]
             else:
                 if in_name in dat.dtype.names:
                     out_array = dat[in_name]
-                    quality = dat['QUALITY'][:, quality_index(dat, in_name)]
+                    quality = dat["QUALITY"][:, quality_index(dat, in_name)]
                 else:
                     # Handle column that is intermittently available in `dat` by using the
                     # supplied default dtype.  Quality is True (missing) everywhere.
@@ -170,12 +170,12 @@ def generic_converter2(msid_cxc_map, default_dtypes=None):
     return _convert
 
 
-orbitephem0 = generic_converter('orbitephem0', add_quality=True)
-lunarephem0 = generic_converter('lunarephem0', add_quality=True)
-solarephem0 = generic_converter('solarephem0', add_quality=True)
-orbitephem1 = generic_converter('orbitephem1', add_quality=True)
-lunarephem1 = generic_converter('lunarephem1', add_quality=True)
-solarephem1 = generic_converter('solarephem1', add_quality=True)
+orbitephem0 = generic_converter("orbitephem0", add_quality=True)
+lunarephem0 = generic_converter("lunarephem0", add_quality=True)
+solarephem0 = generic_converter("solarephem0", add_quality=True)
+orbitephem1 = generic_converter("orbitephem1", add_quality=True)
+lunarephem1 = generic_converter("lunarephem1", add_quality=True)
+solarephem1 = generic_converter("solarephem1", add_quality=True)
 angleephem = generic_converter(add_quality=True)
 
 
@@ -191,7 +191,7 @@ def parse_alias_str(alias_str, invert=False):
 
 
 ALIASES = {
-    'simdiag': """
+    "simdiag": """
     RAMEXEC          3SDSWELF   SEA CSC Exectuting from RAM
     DSTACKPTR        3SDPSTKP   SEA Data Stack Ptr
     TSCEDGE          3SDTSEDG   TSC Tab Edge Detection Flags
@@ -220,7 +220,7 @@ ALIASES = {
     FAHISTO          3SDFAP     FA Most Recent PWM Histogram
     INVCMDCODE       3SDINCOD   SEA Invalid CommandCode
     """,
-    'sim_mrg': """
+    "sim_mrg": """
     TLMUPDATE    3SEATMUP   "Telemtry Update Flag"
     SEAIDENT     3SEAID     "SEA Identification Flag"
     SEARESET     3SEARSET   "SEA Reset Flag"
@@ -253,7 +253,7 @@ ALIASES = {
     FLEXBTSET    3SFLXBST   "Flexture B Temperature Setpoint"
     FLEXCTSET    3SFLXCST   "Flexture C Temperature Setpoint"
     """,
-    'hrc0ss': """
+    "hrc0ss": """
     TLEVART      2TLEV1RT
     VLEVART      2VLEV1RT
     SHEVART      2SHEV1RT
@@ -261,7 +261,7 @@ ALIASES = {
     VLEVART      2VLEV2RT
     SHEVART      2SHEV2RT
     """,
-    'hrc0hk': """
+    "hrc0hk": """
     SCIDPREN:0,1,2,3,8,9,10 HRC_SS_HK_BAD
     P24CAST:7     224PCAST
     P15CAST:7     215PCAST
@@ -380,50 +380,52 @@ def sim_mrg(dat):
     always "TSC".
     """
     # Start with the generic converter
-    out = generic_converter(aliases=CXC_TO_MSID['sim_mrg'])(dat)
+    out = generic_converter(aliases=CXC_TO_MSID["sim_mrg"])(dat)
 
     # Now do the fixes.  FOT mech has stated that 3LDRTMEK is always 'FA'
     # in practice.
-    bad = out['3LDRTMEK'] == b'FA '
+    bad = out["3LDRTMEK"] == b"FA "
     if np.count_nonzero(bad):
-        out['3LDRTMEK'][bad] = b'TSC'
-        pos_tsc_steps = units.converters['mm', 'FASTEP'](out['3LDRTPOS'][bad])
-        out['3LDRTPOS'][bad] = units.converters['TSCSTEP', 'mm'](pos_tsc_steps)
+        out["3LDRTMEK"][bad] = b"TSC"
+        pos_tsc_steps = units.converters["mm", "FASTEP"](out["3LDRTPOS"][bad])
+        out["3LDRTPOS"][bad] = units.converters["TSCSTEP", "mm"](pos_tsc_steps)
 
     return out
 
 
-simdiag = generic_converter(aliases=CXC_TO_MSID['simdiag'])
-hrc0ss = generic_converter2(MSID_TO_CXC['hrc0ss'])
+simdiag = generic_converter(aliases=CXC_TO_MSID["simdiag"])
+hrc0ss = generic_converter2(MSID_TO_CXC["hrc0ss"])
 
 
 def hrc0hk(dat):
     # Read the data and allow for missing columns in input L0 HK file.
-    default_dtypes = {'2CE00ATM': 'f4', '2CE01ATM': 'f4'}
-    out = generic_converter2(MSID_TO_CXC['hrc0hk'], default_dtypes)(dat)
+    default_dtypes = {"2CE00ATM": "f4", "2CE01ATM": "f4"}
+    out = generic_converter2(MSID_TO_CXC["hrc0hk"], default_dtypes)(dat)
 
     # Set all HRC HK data columns to bad quality where HRC_SS_HK_BAD is not zero
     # First three columns are TIME, QUALITY, and HRC_SS_HK_BAD -- do not filter these.
-    bad = out['HRC_SS_HK_BAD'] > 0
+    bad = out["HRC_SS_HK_BAD"] > 0
     if np.any(bad):
-        out['QUALITY'][bad, 3:] = True
+        out["QUALITY"][bad, 3:] = True
         logger.info(
-            'Setting {} readouts of all HRC HK telem to bad quality (bad SCIDPREN)'
-            .format(np.count_nonzero(bad))
+            "Setting {} readouts of all HRC HK telem to bad quality (bad SCIDPREN)".format(
+                np.count_nonzero(bad)
+            )
         )
 
     # Detect the secondary-science byte-shift anomaly by finding out-of-range 2SMTRATM values.
     # For those bad frames:
     # - Set bit 10 (from LSB) of HRC_SS_HK_BAD
     # - Set all analog MSIDs (2C05PALV and later in the list) to bad quality
-    bad = (out['2SMTRATM'] < -20) | (out['2SMTRATM'] > 50)
+    bad = (out["2SMTRATM"] < -20) | (out["2SMTRATM"] > 50)
     if np.any(bad):
-        out['HRC_SS_HK_BAD'][bad] |= 2**10  # 1024
-        analogs_index0 = list(out.dtype.names).index('2C05PALV')
-        out['QUALITY'][bad, analogs_index0:] = True
+        out["HRC_SS_HK_BAD"][bad] |= 2**10  # 1024
+        analogs_index0 = list(out.dtype.names).index("2C05PALV")
+        out["QUALITY"][bad, analogs_index0:] = True
         logger.info(
-            'Setting {} readouts of analog HRC HK telem to bad quality (bad 2SMTRATM)'
-            .format(np.count_nonzero(bad))
+            "Setting {} readouts of analog HRC HK telem to bad quality (bad 2SMTRATM)".format(
+                np.count_nonzero(bad)
+            )
         )
 
     return out
@@ -440,9 +442,9 @@ def obc4eng(dat):
     # MSIDs OOBTHR<msid_num> that went to _WIDE after the patch, which was done in parts A
     # and B.
     msid_nums = {
-        'a': '08 09 10 11 12 13 14 15 17 18 19 20 21 22 23 24 25 26 27 28 29'.split(),
-        'b': '30 31 33 34 35 36 37 38 39 40 41 44 45 46 49 50 51 52 53 54'.split(),
-        'c': '02 03 04 05 06 07'.split(),
+        "a": "08 09 10 11 12 13 14 15 17 18 19 20 21 22 23 24 25 26 27 28 29".split(),
+        "b": "30 31 33 34 35 36 37 38 39 40 41 44 45 46 49 50 51 52 53 54".split(),
+        "c": "02 03 04 05 06 07".split(),
     }
 
     # Convert using the baseline converter
@@ -451,24 +453,24 @@ def obc4eng(dat):
     # The patch times below correspond to roughly the middle of the major frame where
     # patches A and B were applied, respectively.
     patch_times = {
-        'a': DateTime('2014:342:16:29:30').secs,
-        'b': DateTime('2014:342:16:32:45').secs,
-        'c': DateTime('2017:312:16:11:16').secs,
+        "a": DateTime("2014:342:16:29:30").secs,
+        "b": DateTime("2014:342:16:32:45").secs,
+        "c": DateTime("2017:312:16:11:16").secs,
     }
 
-    for patch in ('a', 'b', 'c'):
+    for patch in ("a", "b", "c"):
         # Set a mask defining times after the activation of wide-range telemetry in PR-361
-        mask = out['TIME'] > patch_times[patch]
+        mask = out["TIME"] > patch_times[patch]
         if np.any(mask):
             for msid_num in msid_nums[patch]:
-                msid = 'OOBTHR' + msid_num
-                msid_wide = msid + '_WIDE'
-                print('Fixing MSID {}'.format(msid))
+                msid = "OOBTHR" + msid_num
+                msid_wide = msid + "_WIDE"
+                print("Fixing MSID {}".format(msid))
                 out[msid][mask] = out[msid_wide][mask]
 
                 q_index = quality_index(out, msid)
                 q_index_wide = quality_index(out, msid_wide)
-                out['QUALITY'][mask, q_index] = out['QUALITY'][mask, q_index_wide]
+                out["QUALITY"][mask, q_index] = out["QUALITY"][mask, q_index_wide]
 
     return out
 
@@ -489,16 +491,16 @@ def tel2eng(dat):
     # 4OAVOBAT is modified by both patches since it is an average of MSIDs in both parts of the
     # patch. Use the second time value as this is when the process is complete. See obc4eng() for
     # both times and further details.
-    patch_time = DateTime('2014:342:16:32:45').secs
+    patch_time = DateTime("2014:342:16:32:45").secs
 
-    mask = out['TIME'] > patch_time
+    mask = out["TIME"] > patch_time
     if np.any(mask):
-        print('Fixing MSID 4OAVOBAT')
-        out['4OAVOBAT'][mask] = out['4OAVOBAT_WIDE'][mask]
+        print("Fixing MSID 4OAVOBAT")
+        out["4OAVOBAT"][mask] = out["4OAVOBAT_WIDE"][mask]
 
-        q_index = quality_index(out, '4OAVOBAT')
-        q_index_wide = quality_index(out, '4OAVOBAT_WIDE')
-        out['QUALITY'][mask, q_index] = out['QUALITY'][mask, q_index_wide]
+        q_index = quality_index(out, "4OAVOBAT")
+        q_index_wide = quality_index(out, "4OAVOBAT_WIDE")
+        out["QUALITY"][mask, q_index] = out["QUALITY"][mask, q_index_wide]
 
     return out
 
@@ -511,15 +513,15 @@ def acisdeahk(dat):
     and put into a single row.  Write out to temp files and modify self->{arch_files}.
     """
 
-    logger.info('Converting acisdeahk data to eng0 format')
+    logger.info("Converting acisdeahk data to eng0 format")
 
     cols = _get_deahk_cols()
-    col_query_ids = tuple(x['query_id'] for x in cols)
-    col_names = tuple(x['name'].upper() for x in cols)
+    col_query_ids = tuple(x["query_id"] for x in cols)
+    col_names = tuple(x["name"].upper() for x in cols)
 
     # Filter only entries with ccd_id >= 10 which indicates data from the I/F control
     dat = pyfits_to_recarray(dat)
-    rows = dat[dat['CCD_ID'] >= 10]
+    rows = dat[dat["CCD_ID"] >= 10]
     if len(rows) == 0:
         raise NoValidDataError()
 
@@ -527,13 +529,13 @@ def acisdeahk(dat):
     # queries into a single row with a column for each query value.
     # Collect each assembled row into %data_out for writing to a FITS bin table
     block_idxs = 1 + numpy.flatnonzero(
-        numpy.abs(rows['TIME'][1:] - rows['TIME'][:-1]) > 0.001
+        numpy.abs(rows["TIME"][1:] - rows["TIME"][:-1]) > 0.001
     )
     block_idxs = numpy.hstack([[0], block_idxs, [len(rows)]])
-    query_val_tus = rows['QUERY_VAL_TU']
-    query_vals = rows['QUERY_VAL']
-    query_ids = rows['QUERY_ID']
-    times = rows['TIME']
+    query_val_tus = rows["QUERY_VAL_TU"]
+    query_vals = rows["QUERY_VAL"]
+    query_ids = rows["QUERY_ID"]
+    times = rows["TIME"]
 
     outs = []
     for i0, i1 in zip(block_idxs[:-1], block_idxs[1:]):
@@ -561,7 +563,7 @@ def acisdeahk(dat):
         quality = (False, False) + bads
         outs.append((times[i0], quality) + vals)
 
-    dtype = [('TIME', numpy.float64), ('QUALITY', numpy.bool, (len(col_names) + 2,))]
+    dtype = [("TIME", numpy.float64), ("QUALITY", numpy.bool, (len(col_names) + 2,))]
     dtype += [(col_name, numpy.float32) for col_name in col_names]
 
     return numpy.rec.fromrecords(outs, dtype=dtype)

--- a/Ska/engarchive/derived/__init__.py
+++ b/Ska/engarchive/derived/__init__.py
@@ -9,11 +9,10 @@ telemetry MSIDs.  All derived parameter names begin with the characters "DP_"
 MSIDs.
 """
 
-from .base import *  # noqa
-
-from .thermal import *  # noqa
-from .test import *  # noqa
 from .acispow import *  # noqa
-from .pcad import *  # noqa
-from .orbit import *  # noqa
+from .base import *  # noqa
 from .eps import *  # noqa
+from .orbit import *  # noqa
+from .pcad import *  # noqa
+from .test import *  # noqa
+from .thermal import *  # noqa

--- a/Ska/engarchive/derived/acispow.py
+++ b/Ska/engarchive/derived/acispow.py
@@ -8,18 +8,22 @@ from . import base
 
 class DP_DPA_POWER(base.DerivedParameter):
     """ACIS total DPA-A and DPA-B power"""
+
     rootparams = ['1dp28avo', '1dpicacu', '1dp28bvo', '1dpicbcu']
     time_step = 32.8
     content_root = 'acispow'
 
     def calc(self, data):
-        power = (data['1dp28avo'].vals * data['1dpicacu'].vals +
-                 data['1dp28bvo'].vals * data['1dpicbcu'].vals)
+        power = (
+            data['1dp28avo'].vals * data['1dpicacu'].vals
+            + data['1dp28bvo'].vals * data['1dpicbcu'].vals
+        )
         return power
 
 
 class DP_DEA_POWER(base.DerivedParameter):
     """ACIS DEA power"""
+
     rootparams = ['1de28avo', '1deicacu']
     time_step = 32.8
     content_root = 'acispow'
@@ -31,12 +35,22 @@ class DP_DEA_POWER(base.DerivedParameter):
 
 class DP_PSMC_POWER(base.DerivedParameter):
     """ACIS PSMC power"""
-    rootparams = ['1dp28avo', '1dpicacu', '1dp28bvo', '1dpicbcu', '1de28avo', '1deicacu']
+
+    rootparams = [
+        '1dp28avo',
+        '1dpicacu',
+        '1dp28bvo',
+        '1dpicbcu',
+        '1de28avo',
+        '1deicacu',
+    ]
     time_step = 32.8
     content_root = 'acispow'
 
     def calc(self, data):
-        power = (data['1dp28avo'].vals * data['1dpicacu'].vals +
-                 data['1dp28bvo'].vals * data['1dpicbcu'].vals +
-                 data['1de28avo'].vals * data['1deicacu'].vals)
+        power = (
+            data['1dp28avo'].vals * data['1dpicacu'].vals
+            + data['1dp28bvo'].vals * data['1dpicbcu'].vals
+            + data['1de28avo'].vals * data['1deicacu'].vals
+        )
         return power

--- a/Ska/engarchive/derived/acispow.py
+++ b/Ska/engarchive/derived/acispow.py
@@ -9,14 +9,14 @@ from . import base
 class DP_DPA_POWER(base.DerivedParameter):
     """ACIS total DPA-A and DPA-B power"""
 
-    rootparams = ['1dp28avo', '1dpicacu', '1dp28bvo', '1dpicbcu']
+    rootparams = ["1dp28avo", "1dpicacu", "1dp28bvo", "1dpicbcu"]
     time_step = 32.8
-    content_root = 'acispow'
+    content_root = "acispow"
 
     def calc(self, data):
         power = (
-            data['1dp28avo'].vals * data['1dpicacu'].vals
-            + data['1dp28bvo'].vals * data['1dpicbcu'].vals
+            data["1dp28avo"].vals * data["1dpicacu"].vals
+            + data["1dp28bvo"].vals * data["1dpicbcu"].vals
         )
         return power
 
@@ -24,12 +24,12 @@ class DP_DPA_POWER(base.DerivedParameter):
 class DP_DEA_POWER(base.DerivedParameter):
     """ACIS DEA power"""
 
-    rootparams = ['1de28avo', '1deicacu']
+    rootparams = ["1de28avo", "1deicacu"]
     time_step = 32.8
-    content_root = 'acispow'
+    content_root = "acispow"
 
     def calc(self, data):
-        power = data['1de28avo'].vals * data['1deicacu'].vals
+        power = data["1de28avo"].vals * data["1deicacu"].vals
         return power
 
 
@@ -37,20 +37,20 @@ class DP_PSMC_POWER(base.DerivedParameter):
     """ACIS PSMC power"""
 
     rootparams = [
-        '1dp28avo',
-        '1dpicacu',
-        '1dp28bvo',
-        '1dpicbcu',
-        '1de28avo',
-        '1deicacu',
+        "1dp28avo",
+        "1dpicacu",
+        "1dp28bvo",
+        "1dpicbcu",
+        "1de28avo",
+        "1deicacu",
     ]
     time_step = 32.8
-    content_root = 'acispow'
+    content_root = "acispow"
 
     def calc(self, data):
         power = (
-            data['1dp28avo'].vals * data['1dpicacu'].vals
-            + data['1dp28bvo'].vals * data['1dpicbcu'].vals
-            + data['1de28avo'].vals * data['1deicacu'].vals
+            data["1dp28avo"].vals * data["1dpicacu"].vals
+            + data["1dp28bvo"].vals * data["1dpicbcu"].vals
+            + data["1de28avo"].vals * data["1deicacu"].vals
         )
         return power

--- a/Ska/engarchive/derived/base.py
+++ b/Ska/engarchive/derived/base.py
@@ -1,8 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from Chandra.Time import DateTime
-import Ska.Numpy
 import numpy as np
+import Ska.Numpy
+from Chandra.Time import DateTime
+
 from .. import cache
 
 __all__ = ['MNF_TIME', 'times_indexes', 'DerivedParameter']

--- a/Ska/engarchive/derived/base.py
+++ b/Ska/engarchive/derived/base.py
@@ -6,7 +6,7 @@ from Chandra.Time import DateTime
 
 from .. import cache
 
-__all__ = ['MNF_TIME', 'times_indexes', 'DerivedParameter']
+__all__ = ["MNF_TIME", "times_indexes", "DerivedParameter"]
 
 MNF_TIME = 0.25625  # Minor Frame duration (seconds)
 
@@ -22,14 +22,14 @@ def times_indexes(start, stop, dt):
 @cache.lru_cache(20)
 def interpolate_times(keyvals, len_data_times, data_times=None, times=None):
     return Ska.Numpy.interpolate(
-        np.arange(len_data_times), data_times, times, method='nearest'
+        np.arange(len_data_times), data_times, times, method="nearest"
     )
 
 
 class DerivedParameter(object):
     max_gap = 66.0  # Max allowed data gap (seconds)
     max_gaps = {}
-    unit_system = 'eng'
+    unit_system = "eng"
     dtype = None  # If not None then cast to this dtype
 
     def calc(self, data):
@@ -45,10 +45,10 @@ class DerivedParameter(object):
 
         # Translate state codes "ON" and "OFF" to 1 and 0, respectively.
         for data in dataset.values():
-            if data.vals.dtype.name == 'str96' and set(data.vals).issubset(
-                set(['ON ', 'OFF'])
+            if data.vals.dtype.name == "str96" and set(data.vals).issubset(
+                set(["ON ", "OFF"])
             ):
-                data.vals = np.where(data.vals == 'OFF', np.int8(0), np.int8(1))
+                data.vals = np.where(data.vals == "OFF", np.int8(0), np.int8(1))
 
         times, indexes = times_indexes(start, stop, self.time_step)
         bads = np.zeros(len(times), dtype=np.bool_)  # All data OK (false)
@@ -62,7 +62,7 @@ class DerivedParameter(object):
                 data.bads = np.ones(2, dtype=np.bool_)  # all points bad
                 data.times = np.array([times[0], times[-1]])
                 print(
-                    'No data in {} between {} and {} (setting all bad)'.format(
+                    "No data in {} between {} and {} (setting all bad)".format(
                         msidname, DateTime(start).date, DateTime(stop).date
                     )
                 )
@@ -112,10 +112,10 @@ class DerivedParameter(object):
 
         # Translate state codes "ON" and "OFF" to 1 and 0, respectively.
         for data in dataset.values():
-            if data.vals.dtype.name == 'string24' and set(data.vals) == set(
-                ('ON ', 'OFF')
+            if data.vals.dtype.name == "string24" and set(data.vals) == set(
+                ("ON ", "OFF")
             ):
-                data.vals = np.where(data.vals == 'OFF', np.int8(0), np.int8(1))
+                data.vals = np.where(data.vals == "OFF", np.int8(0), np.int8(1))
 
         dataset.interpolate(dt=self.time_step)
 
@@ -131,4 +131,4 @@ class DerivedParameter(object):
 
     @property
     def content(self):
-        return 'dp_{}{}'.format(self.content_root.lower(), self.mnf_step)
+        return "dp_{}{}".format(self.content_root.lower(), self.mnf_step)

--- a/Ska/engarchive/derived/base.py
+++ b/Ska/engarchive/derived/base.py
@@ -8,7 +8,7 @@ from .. import cache
 
 __all__ = ['MNF_TIME', 'times_indexes', 'DerivedParameter']
 
-MNF_TIME = 0.25625              # Minor Frame duration (seconds)
+MNF_TIME = 0.25625  # Minor Frame duration (seconds)
 
 
 def times_indexes(start, stop, dt):
@@ -21,12 +21,13 @@ def times_indexes(start, stop, dt):
 
 @cache.lru_cache(20)
 def interpolate_times(keyvals, len_data_times, data_times=None, times=None):
-    return Ska.Numpy.interpolate(np.arange(len_data_times),
-                                 data_times, times, method='nearest')
+    return Ska.Numpy.interpolate(
+        np.arange(len_data_times), data_times, times, method='nearest'
+    )
 
 
 class DerivedParameter(object):
-    max_gap = 66.0              # Max allowed data gap (seconds)
+    max_gap = 66.0  # Max allowed data gap (seconds)
     max_gaps = {}
     unit_system = 'eng'
     dtype = None  # If not None then cast to this dtype
@@ -44,8 +45,9 @@ class DerivedParameter(object):
 
         # Translate state codes "ON" and "OFF" to 1 and 0, respectively.
         for data in dataset.values():
-            if (data.vals.dtype.name == 'str96'
-                    and set(data.vals).issubset(set(['ON ', 'OFF']))):
+            if data.vals.dtype.name == 'str96' and set(data.vals).issubset(
+                set(['ON ', 'OFF'])
+            ):
                 data.vals = np.where(data.vals == 'OFF', np.int8(0), np.int8(1))
 
         times, indexes = times_indexes(start, stop, self.time_step)
@@ -59,12 +61,22 @@ class DerivedParameter(object):
                 data.vals = np.zeros(2, dtype=data.vals.dtype)  # two null points
                 data.bads = np.ones(2, dtype=np.bool_)  # all points bad
                 data.times = np.array([times[0], times[-1]])
-                print('No data in {} between {} and {} (setting all bad)'
-                      .format(msidname, DateTime(start).date, DateTime(stop).date))
-            keyvals = (data.content, data.times[0], data.times[-1],
-                       len(times), times[0], times[-1])
-            idxs = interpolate_times(keyvals, len(data.times),
-                                     data_times=data.times, times=times)
+                print(
+                    'No data in {} between {} and {} (setting all bad)'.format(
+                        msidname, DateTime(start).date, DateTime(stop).date
+                    )
+                )
+            keyvals = (
+                data.content,
+                data.times[0],
+                data.times[-1],
+                len(times),
+                times[0],
+                times[-1],
+            )
+            idxs = interpolate_times(
+                keyvals, len(data.times), data_times=data.times, times=times
+            )
 
             # Loop over data attributes like "bads", "times", "vals" etc and
             # perform near-neighbor interpolation by indexing
@@ -78,10 +90,13 @@ class DerivedParameter(object):
             max_gap = self.max_gaps.get(msidname, self.max_gap)
             gap_bads = abs(data.times - times) > max_gap
             if np.any(gap_bads):
-                print("Setting bads because of gaps in {} between {} to {}"
-                      .format(msidname,
-                              DateTime(times[gap_bads][0]).date,
-                              DateTime(times[gap_bads][-1]).date))
+                print(
+                    "Setting bads because of gaps in {} between {} to {}".format(
+                        msidname,
+                        DateTime(times[gap_bads][0]).date,
+                        DateTime(times[gap_bads][-1]).date,
+                    )
+                )
             bads = bads | gap_bads
 
         dataset.times = times
@@ -92,12 +107,14 @@ class DerivedParameter(object):
 
     def __call__(self, start, stop):
         from .. import fetch_eng
+
         dataset = fetch_eng.MSIDset(self.rootparams, start, stop, filter_bad=True)
 
         # Translate state codes "ON" and "OFF" to 1 and 0, respectively.
         for data in dataset.values():
-            if (data.vals.dtype.name == 'string24'
-                    and set(data.vals) == set(('ON ', 'OFF'))):
+            if data.vals.dtype.name == 'string24' and set(data.vals) == set(
+                ('ON ', 'OFF')
+            ):
                 data.vals = np.where(data.vals == 'OFF', np.int8(0), np.int8(1))
 
         dataset.interpolate(dt=self.time_step)

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -477,8 +477,8 @@ class Comp_KadiCommandState(ComputedMsid):
 
         :returns: dict of MSID attributes
         """
-        from kadi.commands.states import get_states
         from Chandra.Time import date2secs
+        from kadi.commands.states import get_states
 
         state_key = msid_args[0]
         dt = 1.025 * int(msid_args[1])

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -16,7 +16,7 @@ from Chandra.Time import DateTime
 
 from ..units import converters as unit_converter_funcs
 
-__all__ = ['ComputedMsid', 'Comp_MUPS_Valve_Temp_Clean', 'Comp_KadiCommandState']
+__all__ = ["ComputedMsid", "Comp_MUPS_Valve_Temp_Clean", "Comp_KadiCommandState"]
 
 
 def calc_stats_vals(msid, rows, indexes, interval):
@@ -50,24 +50,24 @@ def calc_stats_vals(msid, rows, indexes, interval):
 
     # If MSID data is unicode, then for stats purposes cast back to bytes
     # by creating the output array as a like-sized S-type array.
-    if msid_dtype.kind == 'U':
-        msid_dtype = re.sub(r'U', 'S', msid.vals.dtype.str)
+    if msid_dtype.kind == "U":
+        msid_dtype = re.sub(r"U", "S", msid.vals.dtype.str)
 
     # Predeclare numpy arrays of correct type and sufficient size for accumulating results.
     out = {}
-    out['index'] = np.ndarray((n_out,), dtype=np.int32)
-    out['n'] = np.ndarray((n_out,), dtype=np.int32)
-    out['val'] = np.ndarray((n_out,), dtype=msid_dtype)
+    out["index"] = np.ndarray((n_out,), dtype=np.int32)
+    out["n"] = np.ndarray((n_out,), dtype=np.int32)
+    out["val"] = np.ndarray((n_out,), dtype=msid_dtype)
 
     if msid_is_numeric:
-        out['min'] = np.ndarray((n_out,), dtype=msid_dtype)
-        out['max'] = np.ndarray((n_out,), dtype=msid_dtype)
-        out['mean'] = np.ndarray((n_out,), dtype=np.float32)
+        out["min"] = np.ndarray((n_out,), dtype=msid_dtype)
+        out["max"] = np.ndarray((n_out,), dtype=msid_dtype)
+        out["mean"] = np.ndarray((n_out,), dtype=np.float32)
 
-        if interval == 'daily':
-            out['std'] = np.ndarray((n_out,), dtype=msid_dtype)
+        if interval == "daily":
+            out["std"] = np.ndarray((n_out,), dtype=msid_dtype)
             for quantile in quantiles:
-                out['p{:02d}'.format(quantile)] = np.ndarray((n_out,), dtype=msid_dtype)
+                out["p{:02d}".format(quantile)] = np.ndarray((n_out,), dtype=msid_dtype)
 
     i = 0
     for row0, row1, index in zip(rows[:-1], rows[1:], indexes[:-1]):
@@ -76,9 +76,9 @@ def calc_stats_vals(msid, rows, indexes, interval):
 
         n_vals = len(vals)
         if n_vals > 0:
-            out['index'][i] = index
-            out['n'][i] = n_vals
-            out['val'][i] = vals[n_vals // 2]
+            out["index"][i] = index
+            out["n"][i] = n_vals
+            out["val"][i] = vals[n_vals // 2]
             if msid_is_numeric:
                 if n_vals <= 2:
                     dts = np.ones(n_vals, dtype=np.float64)
@@ -96,7 +96,7 @@ def calc_stats_vals(msid, rows, indexes, interval):
                             for t, dt in zip(times[negs], dts[negs])
                         ]
                         raise ValueError(
-                            'WARNING - negative dts in {} at {}'.format(
+                            "WARNING - negative dts in {} at {}".format(
                                 msid.MSID, times_dts
                             )
                         )
@@ -109,19 +109,19 @@ def calc_stats_vals(msid, rows, indexes, interval):
                     dts.clip(0.001, 300.0, out=dts)
                 sum_dts = np.sum(dts)
 
-                out['min'][i] = np.min(vals)
-                out['max'][i] = np.max(vals)
-                out['mean'][i] = np.sum(dts * vals) / sum_dts
-                if interval == 'daily':
+                out["min"][i] = np.min(vals)
+                out["max"][i] = np.max(vals)
+                out["mean"][i] = np.sum(dts * vals) / sum_dts
+                if interval == "daily":
                     # biased weighted estimator of variance (N should be big enough)
                     # http://en.wikipedia.org/wiki/Mean_square_weighted_deviation
-                    sigma_sq = np.sum(dts * (vals - out['mean'][i]) ** 2) / sum_dts
-                    out['std'][i] = np.sqrt(sigma_sq)
+                    sigma_sq = np.sum(dts * (vals - out["mean"][i]) ** 2) / sum_dts
+                    out["std"][i] = np.sqrt(sigma_sq)
                     quant_vals = scipy.stats.mstats.mquantiles(
                         vals, np.array(quantiles) / 100.0
                     )
                     for quant_val, quantile in zip(quant_vals, quantiles):
-                        out['p%02d' % quantile][i] = quant_val
+                        out["p%02d" % quantile][i] = quant_val
 
             i += 1
 
@@ -150,15 +150,15 @@ class ComputedMsid:
     # Base units specification (None implies no unit handling)
     units = None
 
-    def __init__(self, unit_system='eng'):
+    def __init__(self, unit_system="eng"):
         self.unit_system = unit_system
 
     def __init_subclass__(cls, **kwargs):
         """Validate and register ComputedMSID subclass."""
         super().__init_subclass__(**kwargs)
 
-        if not hasattr(cls, 'msid_match'):
-            raise ValueError(f'comp {cls.__name__} must define msid_match')
+        if not hasattr(cls, "msid_match"):
+            raise ValueError(f"comp {cls.__name__} must define msid_match")
 
         cls.msid_classes.append(cls)
 
@@ -170,7 +170,7 @@ class ComputedMsid:
         :returns: first ComputedMsid subclass that matches ``msid`` or None
         """
         for comp_cls in ComputedMsid.msid_classes:
-            match = re.match(comp_cls.msid_match + '$', msid, re.IGNORECASE)
+            match = re.match(comp_cls.msid_match + "$", msid, re.IGNORECASE)
             if match:
                 return comp_cls
 
@@ -202,7 +202,7 @@ class ComputedMsid:
     @property
     def fetch_sys(self):
         """Fetch in the unit system specified for the class"""
-        fetch = getattr(self, f'fetch_{self.unit_system}')
+        fetch = getattr(self, f"fetch_{self.unit_system}")
         return fetch
 
     def __call__(self, tstart, tstop, msid, interval=None):
@@ -221,7 +221,7 @@ class ComputedMsid:
         # Parse any arguments from the input `msid`
         match = re.match(self.msid_match, msid, re.IGNORECASE)
         if not match:
-            raise RuntimeError(f'unexpected mismatch of {msid} with {self.msid_match}')
+            raise RuntimeError(f"unexpected mismatch of {msid} with {self.msid_match}")
         match_args = [
             arg.lower() if isinstance(arg, str) else arg for arg in match.groups()
         ]
@@ -230,11 +230,11 @@ class ComputedMsid:
             # Call the actual user-supplied work method to compute the MSID values
             msid_attrs = self.get_msid_attrs(tstart, tstop, msid.lower(), match_args)
 
-            for attr in ('vals', 'bads', 'times', 'unit'):
+            for attr in ("vals", "bads", "times", "unit"):
                 if attr not in msid_attrs:
                     raise ValueError(
-                        f'computed MSID {self.__class__.__name__} failed '
-                        f'to set required attribute {attr}'
+                        f"computed MSID {self.__class__.__name__} failed "
+                        f"to set required attribute {attr}"
                     )
 
             # Presence of a non-None `units` class attribute means that the MSID has
@@ -260,14 +260,14 @@ class ComputedMsid:
 
         :returns: dict, converted MSID attributes
         """
-        unit_current = self.units[self.units['internal_system']]
+        unit_current = self.units[self.units["internal_system"]]
         unit_new = self.units[self.unit_system]
 
         out = msid_attrs.copy()
-        out['unit'] = unit_new
+        out["unit"] = unit_new
 
         if unit_current != unit_new:
-            for attr in self.units['convert_attrs']:
+            for attr in self.units["convert_attrs"]:
                 out[attr] = unit_converter_funcs[unit_current, unit_new](
                     msid_attrs[attr]
                 )
@@ -288,7 +288,7 @@ class ComputedMsid:
         :param msid_args: tuple of regex match groups (msid_name,)
         :returns: dict of MSID attributes
         """
-        raise NotImplementedError('sub-class must implement get_msid_attrs()')
+        raise NotImplementedError("sub-class must implement get_msid_attrs()")
 
     def get_stats_attrs(self, tstart, tstop, msid, match_args, interval):
         """Get 5-min or daily stats attributes.
@@ -306,7 +306,7 @@ class ComputedMsid:
         # Replicate a stripped-down version of processing in update_archive.
         # This produces a recarray with columns that correspond to the raw
         # stats HDF5 files.
-        dt = {'5min': 328, 'daily': 86400}[interval]
+        dt = {"5min": 328, "daily": 86400}[interval]
         index0 = int(np.floor(tstart / dt))
         index1 = int(np.ceil(tstop / dt))
         tstart = (index0 - 1) * dt
@@ -327,13 +327,13 @@ class ComputedMsid:
         # to what is seen in a stats fetch query.
         out = {}
         for key in vals_stats.dtype.names:
-            out_key = _plural(key) if key != 'n' else 'samples'
+            out_key = _plural(key) if key != "n" else "samples"
             out[out_key] = vals_stats[key]
-        out['times'] = (vals_stats['index'] + 0.5) * dt
-        out['bads'] = np.zeros(len(vals_stats), dtype=bool)
-        out['midvals'] = out['vals']
-        out['vals'] = out['means']
-        out['unit'] = msid_obj.unit
+        out["times"] = (vals_stats["index"] + 0.5) * dt
+        out["bads"] = np.zeros(len(vals_stats), dtype=bool)
+        out["midvals"] = out["vals"]
+        out["vals"] = out["means"]
+        out["unit"] = msid_obj.unit
 
         return out
 
@@ -370,19 +370,19 @@ class Comp_Quat(ComputedMsid):
              [193.28908839,  19.16895134,  67.36206404]])
     """
 
-    msid_match = r'quat_(aoattqt|aoatupq|aocmdqt|aotarqt)'
+    msid_match = r"quat_(aoattqt|aoatupq|aocmdqt|aotarqt)"
 
     def get_msid_attrs(self, tstart, tstop, msid, msid_args):
         from Quaternion import Quat, normalize
 
-        if 'maude' in self.fetch_sys.data_source.sources():
+        if "maude" in self.fetch_sys.data_source.sources():
             raise ValueError(
-                f'{msid} is not available from MAUDE due to issues aligning telemetry'
+                f"{msid} is not available from MAUDE due to issues aligning telemetry"
             )
 
         msid_root = msid_args[0]
-        n_comp = 4 if msid_root == 'aoattqt' else 3
-        msids = [f'{msid_root}{ii}' for ii in range(1, n_comp + 1)]
+        n_comp = 4 if msid_root == "aoattqt" else 3
+        msids = [f"{msid_root}{ii}" for ii in range(1, n_comp + 1)]
         dat = self.fetch_sys.MSIDset(msids, tstart, tstop)
 
         # Interpolate to a common time base, leaving in flagged bad data and
@@ -404,7 +404,7 @@ class Comp_Quat(ComputedMsid):
         for msid in msids:
             bads |= dat[msid].bads
 
-        out = {'vals': quat, 'bads': bads, 'times': dat.times, 'unit': None}
+        out = {"vals": quat, "bads": bads, "times": dat.times, "unit": None}
         return out
 
 
@@ -425,15 +425,15 @@ class Comp_MUPS_Valve_Temp_Clean(ComputedMsid):
     from release 3.28 of chandra_models.
     """
 
-    msid_match = r'(pm2thv1t|pm1thv2t)_clean(_[\w\.]+)?'
+    msid_match = r"(pm2thv1t|pm1thv2t)_clean(_[\w\.]+)?"
 
     units = {
-        'internal_system': 'eng',  # Unit system for attrs from get_msid_attrs()
-        'eng': 'DEGF',  # Units for eng, sci, cxc systems
-        'sci': 'DEGC',
-        'cxc': 'K',
+        "internal_system": "eng",  # Unit system for attrs from get_msid_attrs()
+        "eng": "DEGF",  # Units for eng, sci, cxc systems
+        "sci": "DEGC",
+        "cxc": "K",
         # Attributes that need conversion
-        'convert_attrs': ['vals', 'vals_raw', 'vals_nan', 'vals_corr', 'vals_model'],
+        "convert_attrs": ["vals", "vals_raw", "vals_nan", "vals_corr", "vals_model"],
     }
 
     def get_msid_attrs(self, tstart, tstop, msid, msid_args):
@@ -466,17 +466,17 @@ class Comp_MUPS_Valve_Temp_Clean(ComputedMsid):
         # Convert to dict as required by the get_msids_attrs API.  `fetch_clean_msid`
         # returns an MSID object with the following attrs.
         attrs = (
-            'vals',
-            'times',
-            'bads',
-            'vals_raw',
-            'vals_nan',
-            'vals_corr',
-            'vals_model',
-            'source',
+            "vals",
+            "times",
+            "bads",
+            "vals_raw",
+            "vals_nan",
+            "vals_corr",
+            "vals_model",
+            "source",
         )
         msid_attrs = {attr: getattr(dat, attr) for attr in attrs}
-        msid_attrs['unit'] = 'DEGF'
+        msid_attrs["unit"] = "DEGF"
 
         return msid_attrs
 
@@ -497,7 +497,7 @@ class Comp_KadiCommandState(ComputedMsid):
       'cmd_state_acisfp_temp_32': sample ``acisfp_temp`` every 32.8 secs
     """
 
-    msid_match = r'cmd_state_(\w+)_(\d+)'
+    msid_match = r"cmd_state_(\w+)_(\d+)"
 
     def get_msid_attrs(self, tstart, tstop, msid, msid_args):
         """Get attributes for computed MSID: ``vals``, ``bads``, ``times``
@@ -516,8 +516,8 @@ class Comp_KadiCommandState(ComputedMsid):
         dt = 1.025 * int(msid_args[1])
         states = get_states(tstart, tstop, state_keys=[state_key])
 
-        tstart = date2secs(states['datestart'][0])
-        tstops = date2secs(states['datestop'])
+        tstart = date2secs(states["datestart"][0])
+        tstops = date2secs(states["datestop"])
 
         times = np.arange(tstart, tstops[-1], dt)
         vals = states[state_key].view(np.ndarray)
@@ -525,10 +525,10 @@ class Comp_KadiCommandState(ComputedMsid):
         indexes = np.searchsorted(tstops, times)
 
         out = {
-            'vals': vals[indexes],
-            'times': times,
-            'bads': np.zeros(len(times), dtype=bool),
-            'unit': None,
+            "vals": vals[indexes],
+            "times": times,
+            "bads": np.zeros(len(times), dtype=bool),
+            "unit": None,
         }
 
         return out

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -7,7 +7,7 @@ Support computed MSIDs in the cheta archive.
 - Commanded states 'cmd_state_<key>_<dt>' for any kadi commanded state value.
 
 See: https://nbviewer.jupyter.org/urls/cxc.harvard.edu/mta/ASPECT/ipynb/misc/DAWG-mups-valve-xija-filtering.ipynb
-""" # noqa
+"""  # noqa
 
 import re
 
@@ -86,14 +86,20 @@ def calc_stats_vals(msid, rows, indexes, interval):
                     dts = np.empty(n_vals, dtype=np.float64)
                     dts[0] = times[1] - times[0]
                     dts[-1] = times[-1] - times[-2]
-                    dts[1:-1] = ((times[1:-1] - times[:-2]) +
-                                 (times[2:] - times[1:-1])) / 2.0
+                    dts[1:-1] = (
+                        (times[1:-1] - times[:-2]) + (times[2:] - times[1:-1])
+                    ) / 2.0
                     negs = dts < 0.0
                     if np.any(negs):
-                        times_dts = [(DateTime(t).date, dt)
-                                     for t, dt in zip(times[negs], dts[negs])]
-                        raise ValueError('WARNING - negative dts in {} at {}'
-                                         .format(msid.MSID, times_dts))
+                        times_dts = [
+                            (DateTime(t).date, dt)
+                            for t, dt in zip(times[negs], dts[negs])
+                        ]
+                        raise ValueError(
+                            'WARNING - negative dts in {} at {}'.format(
+                                msid.MSID, times_dts
+                            )
+                        )
 
                     # Clip to range 0.001 to 300.0.  The low bound is just there
                     # for data with identical time stamps.  This shouldn't happen
@@ -111,7 +117,9 @@ def calc_stats_vals(msid, rows, indexes, interval):
                     # http://en.wikipedia.org/wiki/Mean_square_weighted_deviation
                     sigma_sq = np.sum(dts * (vals - out['mean'][i]) ** 2) / sum_dts
                     out['std'][i] = np.sqrt(sigma_sq)
-                    quant_vals = scipy.stats.mstats.mquantiles(vals, np.array(quantiles) / 100.0)
+                    quant_vals = scipy.stats.mstats.mquantiles(
+                        vals, np.array(quantiles) / 100.0
+                    )
                     for quant_val, quantile in zip(quant_vals, quantiles):
                         out['p%02d' % quantile][i] = quant_val
 
@@ -135,6 +143,7 @@ class ComputedMsid:
 
     See the fetch tutorial Computed MSIDs section for details.
     """
+
     # Global dict of registered computed MSIDs
     msid_classes = []
 
@@ -173,18 +182,21 @@ class ComputedMsid:
     def fetch_eng(self):
         """Fetch in TDB engineering units like DEGF"""
         from .. import fetch_eng
+
         return fetch_eng
 
     @property
     def fetch_sci(self):
         """Fetch in scientific units like DEGC"""
         from .. import fetch_sci
+
         return fetch_sci
 
     @property
     def fetch_cxc(self):
         """Fetch in CXC (FITS standard) units like K"""
         from .. import fetch
+
         return fetch
 
     @property
@@ -210,7 +222,9 @@ class ComputedMsid:
         match = re.match(self.msid_match, msid, re.IGNORECASE)
         if not match:
             raise RuntimeError(f'unexpected mismatch of {msid} with {self.msid_match}')
-        match_args = [arg.lower() if isinstance(arg, str) else arg for arg in match.groups()]
+        match_args = [
+            arg.lower() if isinstance(arg, str) else arg for arg in match.groups()
+        ]
 
         if interval is None:
             # Call the actual user-supplied work method to compute the MSID values
@@ -218,8 +232,10 @@ class ComputedMsid:
 
             for attr in ('vals', 'bads', 'times', 'unit'):
                 if attr not in msid_attrs:
-                    raise ValueError(f'computed MSID {self.__class__.__name__} failed '
-                                     f'to set required attribute {attr}')
+                    raise ValueError(
+                        f'computed MSID {self.__class__.__name__} failed '
+                        f'to set required attribute {attr}'
+                    )
 
             # Presence of a non-None `units` class attribute means that the MSID has
             # units that should be converted to `self.unit_system` if required, where
@@ -227,8 +243,9 @@ class ComputedMsid:
             if self.units is not None:
                 msid_attrs = self.convert_units(msid_attrs)
         else:
-            msid_attrs = self.get_stats_attrs(tstart, tstop, msid.lower(), match_args,
-                                              interval)
+            msid_attrs = self.get_stats_attrs(
+                tstart, tstop, msid.lower(), match_args, interval
+            )
 
         return msid_attrs
 
@@ -251,7 +268,9 @@ class ComputedMsid:
 
         if unit_current != unit_new:
             for attr in self.units['convert_attrs']:
-                out[attr] = unit_converter_funcs[unit_current, unit_new](msid_attrs[attr])
+                out[attr] = unit_converter_funcs[unit_current, unit_new](
+                    msid_attrs[attr]
+                )
 
         return out
 
@@ -287,8 +306,7 @@ class ComputedMsid:
         # Replicate a stripped-down version of processing in update_archive.
         # This produces a recarray with columns that correspond to the raw
         # stats HDF5 files.
-        dt = {'5min': 328,
-              'daily': 86400}[interval]
+        dt = {'5min': 328, 'daily': 86400}[interval]
         index0 = int(np.floor(tstart / dt))
         index1 = int(np.ceil(tstop / dt))
         tstart = (index0 - 1) * dt
@@ -318,6 +336,7 @@ class ComputedMsid:
         out['unit'] = msid_obj.unit
 
         return out
+
 
 ############################################################################
 #  Built-in computed MSIDs
@@ -350,6 +369,7 @@ class Comp_Quat(ComputedMsid):
              [193.28906329,  19.16893787,  67.36207699],
              [193.28908839,  19.16895134,  67.36206404]])
     """
+
     msid_match = r'quat_(aoattqt|aoatupq|aocmdqt|aotarqt)'
 
     def get_msid_attrs(self, tstart, tstop, msid, msid_args):
@@ -357,7 +377,8 @@ class Comp_Quat(ComputedMsid):
 
         if 'maude' in self.fetch_sys.data_source.sources():
             raise ValueError(
-                f'{msid} is not available from MAUDE due to issues aligning telemetry')
+                f'{msid} is not available from MAUDE due to issues aligning telemetry'
+            )
 
         msid_root = msid_args[0]
         n_comp = 4 if msid_root == 'aoattqt' else 3
@@ -367,10 +388,7 @@ class Comp_Quat(ComputedMsid):
         # Interpolate to a common time base, leaving in flagged bad data and
         # marking data bad if any of the set at each time are bad. See:
         # https://sot.github.io/eng_archive/fetch_tutorial.html#filtering-and-bad-values
-        dat.interpolate(
-            times=dat[msids[0]].times,
-            filter_bad=False,
-            bad_union=True)
+        dat.interpolate(times=dat[msids[0]].times, filter_bad=False, bad_union=True)
 
         q1 = dat[msids[0]].vals.astype(np.float64)
         q2 = dat[msids[1]].vals.astype(np.float64)
@@ -386,10 +404,7 @@ class Comp_Quat(ComputedMsid):
         for msid in msids:
             bads |= dat[msid].bads
 
-        out = {'vals': quat,
-               'bads': bads,
-               'times': dat.times,
-               'unit': None}
+        out = {'vals': quat, 'bads': bads, 'times': dat.times, 'unit': None}
         return out
 
 
@@ -409,6 +424,7 @@ class Comp_MUPS_Valve_Temp_Clean(ComputedMsid):
     specifications. For example you can use 'pm1thv2t_clean_3.28' to get the model
     from release 3.28 of chandra_models.
     """
+
     msid_match = r'(pm2thv1t|pm1thv2t)_clean(_[\w\.]+)?'
 
     units = {
@@ -417,7 +433,7 @@ class Comp_MUPS_Valve_Temp_Clean(ComputedMsid):
         'sci': 'DEGC',
         'cxc': 'K',
         # Attributes that need conversion
-        'convert_attrs': ['vals', 'vals_raw', 'vals_nan', 'vals_corr', 'vals_model']
+        'convert_attrs': ['vals', 'vals_raw', 'vals_nan', 'vals_corr', 'vals_model'],
     }
 
     def get_msid_attrs(self, tstart, tstop, msid, msid_args):
@@ -437,13 +453,28 @@ class Comp_MUPS_Valve_Temp_Clean(ComputedMsid):
         version = None if msid_args[1] is None else msid_args[1][1:]
 
         # Get cleaned MUPS valve temperature data as an MSID object
-        dat = fetch_clean_msid(msid_args[0], tstart, tstop,
-                               dt_thresh=5.0, median=7, model_spec=None, version=version)
+        dat = fetch_clean_msid(
+            msid_args[0],
+            tstart,
+            tstop,
+            dt_thresh=5.0,
+            median=7,
+            model_spec=None,
+            version=version,
+        )
 
         # Convert to dict as required by the get_msids_attrs API.  `fetch_clean_msid`
         # returns an MSID object with the following attrs.
-        attrs = ('vals', 'times', 'bads', 'vals_raw', 'vals_nan',
-                 'vals_corr', 'vals_model', 'source')
+        attrs = (
+            'vals',
+            'times',
+            'bads',
+            'vals_raw',
+            'vals_nan',
+            'vals_corr',
+            'vals_model',
+            'source',
+        )
         msid_attrs = {attr: getattr(dat, attr) for attr in attrs}
         msid_attrs['unit'] = 'DEGF'
 
@@ -465,6 +496,7 @@ class Comp_KadiCommandState(ComputedMsid):
       'cmd_state_pcad_mode_1': sample ``pcad_mode`` every 1.025 secs
       'cmd_state_acisfp_temp_32': sample ``acisfp_temp`` every 32.8 secs
     """
+
     msid_match = r'cmd_state_(\w+)_(\d+)'
 
     def get_msid_attrs(self, tstart, tstop, msid, msid_args):
@@ -492,9 +524,11 @@ class Comp_KadiCommandState(ComputedMsid):
 
         indexes = np.searchsorted(tstops, times)
 
-        out = {'vals': vals[indexes],
-               'times': times,
-               'bads': np.zeros(len(times), dtype=bool),
-               'unit': None}
+        out = {
+            'vals': vals[indexes],
+            'times': times,
+            'bads': np.zeros(len(times), dtype=bool),
+            'unit': None,
+        }
 
         return out

--- a/Ska/engarchive/derived/eps.py
+++ b/Ska/engarchive/derived/eps.py
@@ -13,7 +13,7 @@ from . import base
 
 
 class DerivedParameterEps(base.DerivedParameter):
-    content_root = 'eps'
+    content_root = "eps"
 
 
 # --------------------------------------------
@@ -22,11 +22,11 @@ class DP_BATT1_TAVE(DerivedParameterEps):
     Telemetry 16x / MF
     """
 
-    rootparams = ['TB1T1', 'TB1T2', 'TB1T3']
+    rootparams = ["TB1T1", "TB1T2", "TB1T3"]
     time_step = 2.05
 
     def calc(self, data):
-        BATT1_TAVE = (data['TB1T1'].vals + data['TB1T2'].vals + data['TB1T3'].vals) / 3
+        BATT1_TAVE = (data["TB1T1"].vals + data["TB1T2"].vals + data["TB1T3"].vals) / 3
         return BATT1_TAVE
 
 
@@ -36,11 +36,11 @@ class DP_BATT2_TAVE(DerivedParameterEps):
     Telemetry 16x / MF
     """
 
-    rootparams = ['TB2T1', 'TB2T2', 'TB2T3']
+    rootparams = ["TB2T1", "TB2T2", "TB2T3"]
     time_step = 2.05
 
     def calc(self, data):
-        BATT2_TAVE = (data['TB2T1'].vals + data['TB2T2'].vals + data['TB2T3'].vals) / 3
+        BATT2_TAVE = (data["TB2T1"].vals + data["TB2T2"].vals + data["TB2T3"].vals) / 3
         return BATT2_TAVE
 
 
@@ -50,11 +50,11 @@ class DP_BATT3_TAVE(DerivedParameterEps):
     Telemetry 16x / MF
     """
 
-    rootparams = ['TB3T1', 'TB3T2', 'TB3T3']
+    rootparams = ["TB3T1", "TB3T2", "TB3T3"]
     time_step = 2.05
 
     def calc(self, data):
-        BATT3_TAVE = (data['TB3T1'].vals + data['TB3T2'].vals + data['TB3T3'].vals) / 3
+        BATT3_TAVE = (data["TB3T1"].vals + data["TB3T2"].vals + data["TB3T3"].vals) / 3
         return BATT3_TAVE
 
 
@@ -64,11 +64,11 @@ class DP_EPOWER1(DerivedParameterEps):
     Telemetry 8x / MF
     """
 
-    rootparams = ['ELBI_LOW', 'ELBV']
+    rootparams = ["ELBI_LOW", "ELBV"]
     time_step = 4.1
 
     def calc(self, data):
-        EPOWER1 = data['ELBI_LOW'].vals * data['ELBV'].vals
+        EPOWER1 = data["ELBI_LOW"].vals * data["ELBV"].vals
         return EPOWER1
 
 
@@ -78,11 +78,11 @@ class DP_MYSAPOW(DerivedParameterEps):
     Telemetry 8x / MF
     """
 
-    rootparams = ['ESAMYI', 'ELBV']
+    rootparams = ["ESAMYI", "ELBV"]
     time_step = 4.1
 
     def calc(self, data):
-        MYSAPOW = data['ESAMYI'].vals * data['ELBV'].vals
+        MYSAPOW = data["ESAMYI"].vals * data["ELBV"].vals
         return MYSAPOW
 
 
@@ -92,9 +92,9 @@ class DP_PYSAPOW(DerivedParameterEps):
     Telemetry 8x / MF
     """
 
-    rootparams = ['ESAPYI', 'ELBV']
+    rootparams = ["ESAPYI", "ELBV"]
     time_step = 4.1
 
     def calc(self, data):
-        PYSAPOW = data['ESAPYI'].vals * data['ELBV'].vals
+        PYSAPOW = data["ESAPYI"].vals * data["ELBV"].vals
         return PYSAPOW

--- a/Ska/engarchive/derived/eps.py
+++ b/Ska/engarchive/derived/eps.py
@@ -19,79 +19,82 @@ class DerivedParameterEps(base.DerivedParameter):
 # --------------------------------------------
 class DP_BATT1_TAVE(DerivedParameterEps):
     """Battery 1 Average Temperature. Derived from average of all three battery temperature sensors.
-        Telemetry 16x / MF
+    Telemetry 16x / MF
     """
+
     rootparams = ['TB1T1', 'TB1T2', 'TB1T3']
     time_step = 2.05
 
     def calc(self, data):
-        BATT1_TAVE = (data['TB1T1'].vals + data['TB1T2'].vals +
-                      data['TB1T3'].vals) / 3
+        BATT1_TAVE = (data['TB1T1'].vals + data['TB1T2'].vals + data['TB1T3'].vals) / 3
         return BATT1_TAVE
 
 
 # --------------------------------------------
 class DP_BATT2_TAVE(DerivedParameterEps):
     """Battery 2 Average Temperature. Derived from average of all three battery temperature sensors.
-        Telemetry 16x / MF
+    Telemetry 16x / MF
     """
+
     rootparams = ['TB2T1', 'TB2T2', 'TB2T3']
     time_step = 2.05
 
     def calc(self, data):
-        BATT2_TAVE = (data['TB2T1'].vals + data['TB2T2'].vals +
-                      data['TB2T3'].vals) / 3
+        BATT2_TAVE = (data['TB2T1'].vals + data['TB2T2'].vals + data['TB2T3'].vals) / 3
         return BATT2_TAVE
 
 
 # --------------------------------------------
 class DP_BATT3_TAVE(DerivedParameterEps):
     """Battery 3 Average Temperature. Derived from average of all three battery temperature sensors.
-        Telemetry 16x / MF
+    Telemetry 16x / MF
     """
+
     rootparams = ['TB3T1', 'TB3T2', 'TB3T3']
     time_step = 2.05
 
     def calc(self, data):
-        BATT3_TAVE = (data['TB3T1'].vals + data['TB3T2'].vals +
-                      data['TB3T3'].vals) / 3
+        BATT3_TAVE = (data['TB3T1'].vals + data['TB3T2'].vals + data['TB3T3'].vals) / 3
         return BATT3_TAVE
 
 
 # --------------------------------------------
 class DP_EPOWER1(DerivedParameterEps):
     """Bus Power = ELBI_LOW * ELBV
-        Telemetry 8x / MF
+    Telemetry 8x / MF
     """
+
     rootparams = ['ELBI_LOW', 'ELBV']
     time_step = 4.1
 
     def calc(self, data):
-        EPOWER1 = (data['ELBI_LOW'].vals * data['ELBV'].vals)
+        EPOWER1 = data['ELBI_LOW'].vals * data['ELBV'].vals
         return EPOWER1
 
 
 # --------------------------------------------
 class DP_MYSAPOW(DerivedParameterEps):
     """-Y Solar Array Power = ESAMYI * ELBV
-        Telemetry 8x / MF
+    Telemetry 8x / MF
     """
+
     rootparams = ['ESAMYI', 'ELBV']
     time_step = 4.1
 
     def calc(self, data):
-        MYSAPOW = (data['ESAMYI'].vals * data['ELBV'].vals)
+        MYSAPOW = data['ESAMYI'].vals * data['ELBV'].vals
         return MYSAPOW
 
 
 # --------------------------------------------
 class DP_PYSAPOW(DerivedParameterEps):
     """+Y Solar Array Power = ESAPYI * ELBV
-        Telemetry 8x / MF
+    Telemetry 8x / MF
     """
+
     rootparams = ['ESAPYI', 'ELBV']
     time_step = 4.1
 
     def calc(self, data):
-        PYSAPOW = (data['ESAPYI'].vals * data['ELBV'].vals)
+        PYSAPOW = data['ESAPYI'].vals * data['ELBV'].vals
         return PYSAPOW

--- a/Ska/engarchive/derived/mups_valve.py
+++ b/Ska/engarchive/derived/mups_valve.py
@@ -68,14 +68,14 @@
 
 import os
 
-import numpy as np
 import numba
+import numpy as np
 from scipy.interpolate import interp1d
 from scipy.ndimage import median_filter
-
-from cheta import fetch_eng
 from xija import XijaModel
 from xija.get_model_spec import get_xija_model_spec
+
+from cheta import fetch_eng
 
 
 def c2f(degc):

--- a/Ska/engarchive/derived/mups_valve.py
+++ b/Ska/engarchive/derived/mups_valve.py
@@ -267,7 +267,7 @@ def fetch_clean_msid(
     mdl = XijaModel(
         model_spec=model_spec, start=dat.times[0] - 400000, stop=dat.times[-1]
     )
-    mdl.comp['mups0'].set_data(75)  # degC
+    mdl.comp["mups0"].set_data(75)  # degC
     mdl.make()
     mdl.calc()
 

--- a/Ska/engarchive/derived/mups_valve.py
+++ b/Ska/engarchive/derived/mups_valve.py
@@ -84,10 +84,29 @@ def c2f(degc):
 
 
 # Define MUPS valve thermistor point pair calibration table (from TDB).
-pp_counts = np.array([0, 27, 36, 44, 55, 70, 90, 118, 175, 195, 210, 219, 226, 231, 235, 255])
-pp_temps = np.array([369.5305, 263.32577, 239.03652, 222.30608, 203.6944, 183.2642, 161.0796,
-                     134.93818, 85.65725, 65.6537, 47.3176, 33.50622, 19.9373, 7.42435, -5.79635,
-                     -111.77265])
+pp_counts = np.array(
+    [0, 27, 36, 44, 55, 70, 90, 118, 175, 195, 210, 219, 226, 231, 235, 255]
+)
+pp_temps = np.array(
+    [
+        369.5305,
+        263.32577,
+        239.03652,
+        222.30608,
+        203.6944,
+        183.2642,
+        161.0796,
+        134.93818,
+        85.65725,
+        65.6537,
+        47.3176,
+        33.50622,
+        19.9373,
+        7.42435,
+        -5.79635,
+        -111.77265,
+    ]
+)
 
 count_to_degf = interp1d(pp_counts, pp_temps)
 degf_to_counts = interp1d(pp_temps, pp_counts)
@@ -104,16 +123,39 @@ def volts_to_counts(volts):
 
 # Voltage and Temperature, with and without resistor (see flight note 447 for
 # the source of these numbers).
-volt_with_resistor = [4.153325779, 3.676396578, 3.175100371, 2.587948965, 2.435, 2.025223702,
-                      1.538506813, 1.148359251, 0.63128179, 0.354868907, 0.208375569]
-volt_without_resistor = [28.223, 15, 9.1231, 5.5228, 4.87, 3.467, 2.249,
-                         1.5027, 0.7253, 0.38276, 0.21769]
-volt_without_resistor_to_volt_with_resistor = interp1d(volt_without_resistor,
-                                                       volt_with_resistor)
+volt_with_resistor = [
+    4.153325779,
+    3.676396578,
+    3.175100371,
+    2.587948965,
+    2.435,
+    2.025223702,
+    1.538506813,
+    1.148359251,
+    0.63128179,
+    0.354868907,
+    0.208375569,
+]
+volt_without_resistor = [
+    28.223,
+    15,
+    9.1231,
+    5.5228,
+    4.87,
+    3.467,
+    2.249,
+    1.5027,
+    0.7253,
+    0.38276,
+    0.21769,
+]
+volt_without_resistor_to_volt_with_resistor = interp1d(
+    volt_without_resistor, volt_with_resistor
+)
 
 
 def get_corr_mups_temp(temp):
-    """ Calculate a MUPS valve thermistor corrected temperature.
+    """Calculate a MUPS valve thermistor corrected temperature.
     Args:
         temp (float, int): Temperature in Fahrenheit to which a correction will be applied.
 
@@ -162,7 +204,7 @@ def select_using_model(data1, data2, model, dt_thresh, out, source):
             model_prop_ii = model[0]
         else:
             # Propagate model using last point + delta-model
-            model_prop_ii = out[ii-1] + (model[ii] - model[ii-1])  # noqa
+            model_prop_ii = out[ii - 1] + (model[ii] - model[ii - 1])  # noqa
 
         if abs(data1[ii] - model_prop_ii) < dt_thresh:
             out[ii] = data1[ii]
@@ -176,8 +218,9 @@ def select_using_model(data1, data2, model, dt_thresh, out, source):
             source[ii] = 0
 
 
-def fetch_clean_msid(msid, start, stop=None, dt_thresh=5.0, median=7, model_spec=None,
-                     version=None):
+def fetch_clean_msid(
+    msid, start, stop=None, dt_thresh=5.0, median=7, model_spec=None, version=None
+):
     """Fetch a cleaned version of telemetry for ``msid``.
 
      If not supplied the model spec will come from
@@ -221,9 +264,9 @@ def fetch_clean_msid(msid, start, stop=None, dt_thresh=5.0, median=7, model_spec
     t_corr = get_corr_mups_temp(t_obs)
 
     # Model is computed in degC
-    mdl = XijaModel(model_spec=model_spec,
-                    start=dat.times[0] - 400000,
-                    stop=dat.times[-1])
+    mdl = XijaModel(
+        model_spec=model_spec, start=dat.times[0] - 400000, stop=dat.times[-1]
+    )
     mdl.comp['mups0'].set_data(75)  # degC
     mdl.make()
     mdl.calc()
@@ -240,14 +283,16 @@ def fetch_clean_msid(msid, start, stop=None, dt_thresh=5.0, median=7, model_spec
         out[ok] = data[ok]
         source[ok] = source_id
 
-    select_using_model(t_obs, t_corr, t_model, dt_thresh=dt_thresh, out=out, source=source)
+    select_using_model(
+        t_obs, t_corr, t_model, dt_thresh=dt_thresh, out=out, source=source
+    )
 
     dat.vals_raw = dat.vals
 
     dat.vals = out
     dat.vals_nan = out.copy()
 
-    dat.bads = (source == 0)
+    dat.bads = source == 0
     dat.vals_nan[dat.bads] = np.nan
 
     dat.source = source

--- a/Ska/engarchive/derived/orbit.py
+++ b/Ska/engarchive/derived/orbit.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
 
 """
 Orbital elements based on the position and velocity of Chandra at each 5 minute predictive
@@ -33,10 +33,9 @@ Example::
 The relevant equations were taken from http://www.castor2.ca/05_OD/01_Gauss/14_Kepler/index.html.
 """
 import numpy as np
+from Chandra.Time import DateTime
 
 from . import base
-
-from Chandra.Time import DateTime
 
 ELEMENTS_CACHE = {}
 R_E = 6378.137e3  # Earth Equatorial Radius (m)
@@ -65,7 +64,7 @@ def calc_orbital_elements(x, y, z, vx, vy, vz):
       perigee_radius      m
       ================ ====
     """
-    from numpy import sin, cos, arccos, sqrt, degrees, pi
+    from numpy import arccos, cos, degrees, pi, sin, sqrt
 
     def arccos_2pi(arg, reflect):
         """

--- a/Ska/engarchive/derived/orbit.py
+++ b/Ska/engarchive/derived/orbit.py
@@ -94,17 +94,17 @@ def calc_orbital_elements(x, y, z, vx, vy, vz):
         return out
 
     # Semi major axis
-    r = np.sqrt(x ** 2 + y ** 2 + z ** 2)
-    v2 = vx ** 2 + vy ** 2 + vz ** 2
+    r = np.sqrt(x**2 + y**2 + z**2)
+    v2 = vx**2 + vy**2 + vz**2
     a = 1 / (2 / r - v2 / M_G)
     # a_alt = a - R_E
 
     # Period
-    T = 2 * pi * sqrt(a ** 3 / M_G)
+    T = 2 * pi * sqrt(a**3 / M_G)
     # n = 1 / T
 
     # Eccentricity
-    f1 = (1 / r - 1 / a)
+    f1 = 1 / r - 1 / a
     f2 = (x * vx + y * vy + z * vz) / M_G
     ei = f1 * x - f2 * vx
     ej = f1 * y - f2 * vy
@@ -115,13 +115,13 @@ def calc_orbital_elements(x, y, z, vx, vy, vz):
     hi = y * vz - z * vy
     hj = z * vx - x * vz
     hk = x * vy - y * vx
-    h = sqrt(hi ** 2 + hj ** 2 + hk ** 2)
+    h = sqrt(hi**2 + hj**2 + hk**2)
     i = arccos(hk / h)  # radians
 
     # Ascending node
     Wi = -hj
     Wj = hi
-    W = sqrt(Wi ** 2 + Wj ** 2)
+    W = sqrt(Wi**2 + Wj**2)
     aw = arccos_2pi(Wi / W, Wj < 0)
 
     # Argument of perigee
@@ -144,21 +144,29 @@ def calc_orbital_elements(x, y, z, vx, vy, vz):
     perigee = a * (1 - e)
     apogee = a * (1 + e)
 
-    return {'semi_major_axis': a,
-            'orbit_period': T,
-            'eccentricity': e,
-            'inclination': i,
-            'ascending_node': aw,
-            'argument_perigee': w,
-            'mean_anomaly': M,
-            'perigee_radius': perigee,
-            'apogee_radius': apogee}
+    return {
+        'semi_major_axis': a,
+        'orbit_period': T,
+        'eccentricity': e,
+        'inclination': i,
+        'ascending_node': aw,
+        'argument_perigee': w,
+        'mean_anomaly': M,
+        'perigee_radius': perigee,
+        'apogee_radius': apogee,
+    }
 
 
 class DerivedParameterOrbit(base.DerivedParameter):
     content_root = 'orbit'
-    rootparams = ['orbitephem0_x', 'orbitephem0_y', 'orbitephem0_z',
-                  'orbitephem0_vx', 'orbitephem0_vy', 'orbitephem0_vz']
+    rootparams = [
+        'orbitephem0_x',
+        'orbitephem0_y',
+        'orbitephem0_z',
+        'orbitephem0_vx',
+        'orbitephem0_vy',
+        'orbitephem0_vz',
+    ]
     time_step = 328.0
     max_gap = 1000.0
 

--- a/Ska/engarchive/derived/orbit.py
+++ b/Ska/engarchive/derived/orbit.py
@@ -74,11 +74,11 @@ def calc_orbital_elements(x, y, z, vx, vy, vz):
         :param reflect: bool, np.ndarray of bool: use reflected value
         """
         np_err_handling = np.geterr()
-        np.seterr(all='raise')
+        np.seterr(all="raise")
         try:
             out = arccos(arg)
         except FloatingPointError:
-            print('Bad argccos arg={}'.format(arg))
+            print("Bad argccos arg={}".format(arg))
             raise
         np.seterr(**np_err_handling)
 
@@ -145,27 +145,27 @@ def calc_orbital_elements(x, y, z, vx, vy, vz):
     apogee = a * (1 + e)
 
     return {
-        'semi_major_axis': a,
-        'orbit_period': T,
-        'eccentricity': e,
-        'inclination': i,
-        'ascending_node': aw,
-        'argument_perigee': w,
-        'mean_anomaly': M,
-        'perigee_radius': perigee,
-        'apogee_radius': apogee,
+        "semi_major_axis": a,
+        "orbit_period": T,
+        "eccentricity": e,
+        "inclination": i,
+        "ascending_node": aw,
+        "argument_perigee": w,
+        "mean_anomaly": M,
+        "perigee_radius": perigee,
+        "apogee_radius": apogee,
     }
 
 
 class DerivedParameterOrbit(base.DerivedParameter):
-    content_root = 'orbit'
+    content_root = "orbit"
     rootparams = [
-        'orbitephem0_x',
-        'orbitephem0_y',
-        'orbitephem0_z',
-        'orbitephem0_vx',
-        'orbitephem0_vy',
-        'orbitephem0_vz',
+        "orbitephem0_x",
+        "orbitephem0_y",
+        "orbitephem0_z",
+        "orbitephem0_vx",
+        "orbitephem0_vy",
+        "orbitephem0_vz",
     ]
     time_step = 328.0
     max_gap = 1000.0
@@ -180,12 +180,12 @@ class DerivedParameterOrbit(base.DerivedParameter):
             return ELEMENTS_CACHE[start, stop][param]
 
         # Get values in km and km/sec
-        x = data['orbitephem0_x'].vals
-        y = data['orbitephem0_y'].vals
-        z = data['orbitephem0_z'].vals
-        vx = data['orbitephem0_vx'].vals
-        vy = data['orbitephem0_vy'].vals
-        vz = data['orbitephem0_vz'].vals
+        x = data["orbitephem0_x"].vals
+        y = data["orbitephem0_y"].vals
+        z = data["orbitephem0_z"].vals
+        vx = data["orbitephem0_vx"].vals
+        vy = data["orbitephem0_vy"].vals
+        vz = data["orbitephem0_vz"].vals
 
         elements = calc_orbital_elements(x, y, z, vx, vy, vz)
         ELEMENTS_CACHE[start, stop] = elements

--- a/Ska/engarchive/derived/pcad.py
+++ b/Ska/engarchive/derived/pcad.py
@@ -31,13 +31,13 @@ class DP_CSS1_NPM_SUN(DerivedParameterPcad):
     (AOSAILLM==1).  Otherwise, "Bads" flag is set equal to one.
 
     """
+
     rootparams = ['aocssi1', 'aopcadmd', 'aosaillm']
     time_step = 1.025
     max_gap = 10.0
 
     def calc(self, data):
-        npm_sun = ((data['aopcadmd'].vals == 'NPNT') &
-                   (data['aosaillm'].vals == 'ILLM'))
+        npm_sun = (data['aopcadmd'].vals == 'NPNT') & (data['aosaillm'].vals == 'ILLM')
         data.bads = data.bads | ~npm_sun
         css1_npm_sun = data['aocssi1'].vals * 4095 / 5.49549
         return css1_npm_sun
@@ -52,13 +52,13 @@ class DP_CSS2_NPM_SUN(DerivedParameterPcad):
     (AOSAILLM==1).  Otherwise, "Bads" flag is set equal to one.
 
     """
+
     rootparams = ['aocssi2', 'aopcadmd', 'aosaillm']
     time_step = 1.025
     max_gap = 10.0
 
     def calc(self, data):
-        npm_sun = ((data['aopcadmd'].vals == 'NPNT') &
-                   (data['aosaillm'].vals == 'ILLM'))
+        npm_sun = (data['aopcadmd'].vals == 'NPNT') & (data['aosaillm'].vals == 'ILLM')
         data.bads = data.bads | ~npm_sun
         css2_npm_sun = data['aocssi2'].vals * 4095 / 5.49549
         return css2_npm_sun
@@ -73,13 +73,13 @@ class DP_CSS3_NPM_SUN(DerivedParameterPcad):
     (AOSAILLM==1).  Otherwise, "Bads" flag is set equal to one.
 
     """
+
     rootparams = ['aocssi3', 'aopcadmd', 'aosaillm']
     time_step = 1.025
     max_gap = 10.0
 
     def calc(self, data):
-        npm_sun = ((data['aopcadmd'].vals == 'NPNT') &
-                   (data['aosaillm'].vals == 'ILLM'))
+        npm_sun = (data['aopcadmd'].vals == 'NPNT') & (data['aosaillm'].vals == 'ILLM')
         data.bads = data.bads | ~npm_sun
         css3_npm_sun = data['aocssi3'].vals * 4095 / 5.49549
         return css3_npm_sun
@@ -94,13 +94,13 @@ class DP_CSS4_NPM_SUN(DerivedParameterPcad):
     (AOSAILLM==1).  Otherwise, "Bads" flag is set equal to one.
 
     """
+
     rootparams = ['aocssi4', 'aopcadmd', 'aosaillm']
     time_step = 1.025
     max_gap = 10.0
 
     def calc(self, data):
-        npm_sun = ((data['aopcadmd'].vals == 'NPNT') &
-                   (data['aosaillm'].vals == 'ILLM'))
+        npm_sun = (data['aopcadmd'].vals == 'NPNT') & (data['aosaillm'].vals == 'ILLM')
         data.bads = data.bads | ~npm_sun
         css4_npm_sun = data['aocssi4'].vals * 4095 / 5.49549
         return css4_npm_sun
@@ -117,28 +117,39 @@ class DP_FSS_CSS_ANGLE_DIFF(DerivedParameterPcad):
     "Bads" flag is set equal to one when not in the FSS FOV.
 
     """
-    rootparams = ['aosunsa1', 'aosunsa2', 'aosunsa3',
-                  'aosunac1', 'aosunac2', 'aosunac3',
-                  'aosares1', 'aosares2', 'aosunprs']
+
+    rootparams = [
+        'aosunsa1',
+        'aosunsa2',
+        'aosunsa3',
+        'aosunac1',
+        'aosunac2',
+        'aosunac3',
+        'aosares1',
+        'aosares2',
+        'aosunprs',
+    ]
     time_step = 1.025
     max_gap = 18.0
     dtype = np.float32
 
     def calc(self, data):
-        in_fss_fov = (data['aosunprs'].vals == 'SUN ')
+        in_fss_fov = data['aosunprs'].vals == 'SUN '
         data.bads |= ~in_fss_fov
         sa_ang_avg = (data['aosares1'].vals + data['aosares2'].vals) / 2
         sinang = sin(radians(sa_ang_avg))
         cosang = cos(radians(sa_ang_avg))
-        fss_aca = np.array([data['aosunac1'].vals,
-                            data['aosunac2'].vals,
-                            data['aosunac3'].vals])
+        fss_aca = np.array(
+            [data['aosunac1'].vals, data['aosunac2'].vals, data['aosunac3'].vals]
+        )
         # Rotate CSS sun vector from SA to ACA frame
-        css_aca = np.array([sinang * data['aosunsa1'].vals -
-                            cosang * data['aosunsa3'].vals,
-                            data['aosunsa2'].vals * 1.0,
-                            cosang * data['aosunsa1'].vals +
-                            sinang * data['aosunsa3'].vals])
+        css_aca = np.array(
+            [
+                sinang * data['aosunsa1'].vals - cosang * data['aosunsa3'].vals,
+                data['aosunsa2'].vals * 1.0,
+                cosang * data['aosunsa1'].vals + sinang * data['aosunsa3'].vals,
+            ]
+        )
         # Normalize the vectors (again)
         magnitude = sqrt((fss_aca * fss_aca).sum(axis=0))
         data.bads |= magnitude == 0.0
@@ -168,24 +179,43 @@ class DP_MAN_ANG(DerivedParameterPcad):
     (AOMANEND = NEND), otherwise equal to zero.
 
     """
-    rootparams = ['aoattqt1', 'aoattqt2', 'aoattqt3', 'aoattqt4',
-                  'aotarqt1', 'aotarqt2', 'aotarqt3', 'aomanend']
+
+    rootparams = [
+        'aoattqt1',
+        'aoattqt2',
+        'aoattqt3',
+        'aoattqt4',
+        'aotarqt1',
+        'aotarqt2',
+        'aotarqt3',
+        'aomanend',
+    ]
     time_step = 1.025
     dtype = np.float32
 
     def calc(self, data):
-        qt4_sqr = 1.0 - (data['aotarqt1'].vals ** 2 +
-                         data['aotarqt2'].vals ** 2 +
-                         data['aotarqt3'].vals ** 2)
+        qt4_sqr = 1.0 - (
+            data['aotarqt1'].vals ** 2
+            + data['aotarqt2'].vals ** 2
+            + data['aotarqt3'].vals ** 2
+        )
         aotarqt4 = sqrt(np.clip(qt4_sqr, 0, 1))
-        est_quat_inv = np.array([-1 * data['aoattqt1'].vals,
-                                 -1 * data['aoattqt2'].vals,
-                                 -1 * data['aoattqt3'].vals,
-                                 data['aoattqt4'].vals])
-        tar_quat = np.array([data['aotarqt1'].vals,
-                             data['aotarqt2'].vals,
-                             data['aotarqt3'].vals,
-                             aotarqt4])
+        est_quat_inv = np.array(
+            [
+                -1 * data['aoattqt1'].vals,
+                -1 * data['aoattqt2'].vals,
+                -1 * data['aoattqt3'].vals,
+                data['aoattqt4'].vals,
+            ]
+        )
+        tar_quat = np.array(
+            [
+                data['aotarqt1'].vals,
+                data['aotarqt2'].vals,
+                data['aotarqt3'].vals,
+                aotarqt4,
+            ]
+        )
         delta_quat = qmult(est_quat_inv, tar_quat)
         # Normalize delta_quat due to roundoff errors.
         magnitude = sqrt((delta_quat * delta_quat).sum(axis=0))
@@ -194,7 +224,7 @@ class DP_MAN_ANG(DerivedParameterPcad):
         delta_quat3 = np.abs(delta_quat[3, :] / magnitude)
         man_ang = 2.0 * degrees(arccos_clip(delta_quat3))
 
-        man = (data['aomanend'].vals == 'NEND')
+        man = data['aomanend'].vals == 'NEND'
         man_ang[~man] = 0
         return man_ang
 
@@ -207,15 +237,18 @@ class DP_ONE_SHOT(DerivedParameterPcad):
     other PCAD modes.
 
     """
+
     rootparams = ['aoatter2', 'aoatter3', 'aopcadmd']
     time_step = 1.025
     max_gap = 4.0
     dtype = np.float32
 
     def calc(self, data):
-        one_shot = degrees(sqrt(data['aoatter2'].vals ** 2 +
-                                data['aoatter3'].vals ** 2)) * 3600
-        npm = (data['aopcadmd'].vals == 'NPNT')
+        one_shot = (
+            degrees(sqrt(data['aoatter2'].vals ** 2 + data['aoatter3'].vals ** 2))
+            * 3600
+        )
+        npm = data['aopcadmd'].vals == 'NPNT'
         one_shot[~npm] = 0.0
         return one_shot
 
@@ -232,10 +265,19 @@ class DP_PITCH(DerivedParameterPcad):
     estimated quaternion [AOATTQT<n>].
 
     """
-    rootparams = ['orbitephem0_x', 'orbitephem0_y', 'orbitephem0_z',
-                  'solarephem0_x', 'solarephem0_y', 'solarephem0_z',
-                  'aoattqt1', 'aoattqt2', 'aoattqt3',
-                  'aoattqt4']
+
+    rootparams = [
+        'orbitephem0_x',
+        'orbitephem0_y',
+        'orbitephem0_z',
+        'solarephem0_x',
+        'solarephem0_y',
+        'solarephem0_z',
+        'aoattqt1',
+        'aoattqt2',
+        'aoattqt3',
+        'aoattqt4',
+    ]
     time_step = 1.025
     max_gap = 4.0
     max_gaps = {msid: 602.0 for msid in rootparams if 'ephem' in msid}
@@ -257,22 +299,24 @@ class DP_PITCH_CSS(DerivedParameterPcad):
     based on the solar array angles AOSARES1 and AOSARES2.
 
     """
+
     rootparams = ['aosares1', 'aosares2', 'aosunsa1', 'aosunsa2', 'aosunsa3']
     time_step = 4.1
     max_gap = 18.0
     dtype = np.float32
 
     def calc(self, data):
-        sa_ang_avg = (1.0 * data['aosares1'].vals +
-                      1.0 * data['aosares2'].vals) / 2
+        sa_ang_avg = (1.0 * data['aosares1'].vals + 1.0 * data['aosares2'].vals) / 2
         sinang = sin(radians(sa_ang_avg))
         cosang = cos(radians(sa_ang_avg))
         # Rotate CSS sun vector from SA to ACA frame
-        css_aca = np.array([sinang * data['aosunsa1'].vals -
-                            cosang * data['aosunsa3'].vals,
-                            data['aosunsa2'].vals * 1.0,
-                            cosang * data['aosunsa1'].vals +
-                            sinang * data['aosunsa3'].vals])
+        css_aca = np.array(
+            [
+                sinang * data['aosunsa1'].vals - cosang * data['aosunsa3'].vals,
+                data['aosunsa2'].vals * 1.0,
+                cosang * data['aosunsa1'].vals + sinang * data['aosunsa3'].vals,
+            ]
+        )
         # Normalize sun vec (again) and compute pitch
         magnitude = sqrt((css_aca * css_aca).sum(axis=0))
         data.bads |= magnitude == 0.0
@@ -292,6 +336,7 @@ class DP_PITCH_CSS_SA(DerivedParameterPcad):
     Calculated as 90.0 - ARCCOS(AOSUNSA1).
 
     """
+
     rootparams = ['aosunsa1']
     time_step = 8.2
     max_gap = 18.0
@@ -317,24 +362,23 @@ class DP_PITCH_FSS(DerivedParameterPcad):
     When NOT in FSS FOV per AOSUNPRS:
     <data>.bads = 1
     """
+
     rootparams = ['aoalpang', 'aobetang', 'aosunprs']
     time_step = 1.025
     max_gap = 10.0
     dtype = np.float32
 
     def calc(self, data):
-        in_fss_fov = (data['aosunprs'].vals == 'SUN ')
+        in_fss_fov = data['aosunprs'].vals == 'SUN '
         data.bads = data.bads | ~in_fss_fov
         # rotation matrix from FSS to ACA frame
-        A_AF = np.array([[9.999990450374580e-01,
-                          0.0,
-                          -1.382000062241829e-03],
-                         [-5.327615067743422e-07,
-                          9.999999256947376e-01,
-                          -3.854999811959735e-04],
-                         [1.381999959551952e-03,
-                          3.855003493343671e-04,
-                          9.999989707322665e-01]])
+        A_AF = np.array(
+            [
+                [9.999990450374580e-01, 0.0, -1.382000062241829e-03],
+                [-5.327615067743422e-07, 9.999999256947376e-01, -3.854999811959735e-04],
+                [1.381999959551952e-03, 3.855003493343671e-04, 9.999989707322665e-01],
+            ]
+        )
         # FSS's sun vector in FSS frame
         alpha = radians(data['aoalpang'].vals)
         beta = radians(data['aobetang'].vals)
@@ -362,9 +406,19 @@ class DP_ROLL(DerivedParameterPcad):
 
     http://occweb.cfa.harvard.edu/twiki/pub/Aspect/WebHome/ROLLDEV3.pdf
     """
-    rootparams = ['orbitephem0_x', 'orbitephem0_y', 'orbitephem0_z',
-                  'solarephem0_x', 'solarephem0_y', 'solarephem0_z',
-                  'aoattqt1', 'aoattqt2', 'aoattqt3', 'aoattqt4']
+
+    rootparams = [
+        'orbitephem0_x',
+        'orbitephem0_y',
+        'orbitephem0_z',
+        'solarephem0_x',
+        'solarephem0_y',
+        'solarephem0_z',
+        'aoattqt1',
+        'aoattqt2',
+        'aoattqt3',
+        'aoattqt4',
+    ]
     time_step = 1.025
     max_gap = 4.0
     max_gaps = {msid: 602.0 for msid in rootparams if 'ephem' in msid}
@@ -387,6 +441,7 @@ class DP_ROLL_CSS(DerivedParameterPcad):
     based on the solar array angles AOSARES1 and AOSARES2.
 
     """
+
     rootparams = ['aosares1', 'aosares2', 'aosunsa1', 'aosunsa2', 'aosunsa3']
     time_step = 4.1
     max_gap = 18.0
@@ -397,11 +452,13 @@ class DP_ROLL_CSS(DerivedParameterPcad):
         sinang = sin(radians(sa_ang_avg))
         cosang = cos(radians(sa_ang_avg))
         # Rotate CSS sun vector from SA to ACA frame
-        css_aca = np.array([sinang * data['aosunsa1'].vals -
-                            cosang * data['aosunsa3'].vals,
-                            data['aosunsa2'].vals,
-                            cosang * data['aosunsa1'].vals +
-                            sinang * data['aosunsa3'].vals])
+        css_aca = np.array(
+            [
+                sinang * data['aosunsa1'].vals - cosang * data['aosunsa3'].vals,
+                data['aosunsa2'].vals,
+                cosang * data['aosunsa1'].vals + sinang * data['aosunsa3'].vals,
+            ]
+        )
         # Normalize sun vec (again) and compute pitch
         magnitude = sqrt((css_aca * css_aca).sum(axis=0))
         data.bads |= magnitude == 0.0
@@ -422,14 +479,14 @@ class DP_ROLL_CSS_SA(DerivedParameterPcad):
     four-quadrant version of ARCTAN.
 
     """
+
     rootparams = ['aosunsa2', 'aosunsa3']
     time_step = 8.2
     max_gap = 18.0
     dtype = np.float32
 
     def calc(self, data):
-        roll_css_sa = degrees(arctan2(-data['aosunsa2'].vals,
-                                      -data['aosunsa3'].vals))
+        roll_css_sa = degrees(arctan2(-data['aosunsa2'].vals, -data['aosunsa3'].vals))
         return roll_css_sa
 
 
@@ -449,24 +506,23 @@ class DP_ROLL_FSS(DerivedParameterPcad):
     When NOT in FSS FOV per AOSUNPRS:
     <data>.bads = 1
     """
+
     rootparams = ['aoalpang', 'aobetang', 'aosunprs']
     time_step = 1.025
     max_gap = 10.0
     dtype = np.float32
 
     def calc(self, data):
-        in_fss_fov = (data['aosunprs'].vals == 'SUN ')
+        in_fss_fov = data['aosunprs'].vals == 'SUN '
         data.bads = data.bads | ~in_fss_fov
         # rotation matrix from FSS to ACA frame
-        A_AF = np.array([[9.999990450374580e-01,
-                          0.0,
-                          -1.382000062241829e-03],
-                         [-5.327615067743422e-07,
-                          9.999999256947376e-01,
-                          -3.854999811959735e-04],
-                         [1.381999959551952e-03,
-                          3.855003493343671e-04,
-                          9.999989707322665e-01]])
+        A_AF = np.array(
+            [
+                [9.999990450374580e-01, 0.0, -1.382000062241829e-03],
+                [-5.327615067743422e-07, 9.999999256947376e-01, -3.854999811959735e-04],
+                [1.381999959551952e-03, 3.855003493343671e-04, 9.999989707322665e-01],
+            ]
+        )
         # FSS's sun vector in FSS frame
         alpha = radians(data['aoalpang'].vals)
         beta = radians(data['aobetang'].vals)
@@ -487,14 +543,17 @@ class DP_RW_MOM_TOT(DerivedParameterPcad):
     Defined as the RSS of AORWMOM1, AORWMOM2, and AORWMOM3.
 
     """
+
     rootparams = ['aorwmom1', 'aorwmom2', 'aorwmom3']
     time_step = 8.2
     dtype = np.float32
 
     def calc(self, data):
-        rw_mom_tot = sqrt(data['aorwmom1'].vals ** 2 +
-                          data['aorwmom2'].vals ** 2 +
-                          data['aorwmom3'].vals ** 2)
+        rw_mom_tot = sqrt(
+            data['aorwmom1'].vals ** 2
+            + data['aorwmom2'].vals ** 2
+            + data['aorwmom3'].vals ** 2
+        )
         return rw_mom_tot
 
 
@@ -506,6 +565,7 @@ class DP_RW1_DELTA_TEMP(DerivedParameterPcad):
     Defined as TCYZ_RW1 - ARWA1BT.
 
     """
+
     rootparams = ['tcyz_rw1', 'arwa1bt']
     time_step = 0.25625
 
@@ -522,6 +582,7 @@ class DP_RW2_DELTA_TEMP(DerivedParameterPcad):
     Defined as TPCP_RW2 - ARWA2BT.
 
     """
+
     rootparams = ['tpcp_rw2', 'arwa2bt']
     time_step = 0.25625
 
@@ -538,6 +599,7 @@ class DP_RW3_DELTA_TEMP(DerivedParameterPcad):
     Defined as TPCP_RW3 - ARWA3BT.
 
     """
+
     rootparams = ['tpcp_rw3', 'arwa3bt']
     time_step = 0.25625
 
@@ -554,6 +616,7 @@ class DP_RW4_DELTA_TEMP(DerivedParameterPcad):
     Defined as TPCM_RW4 - ARWA4BT.
 
     """
+
     rootparams = ['tpcm_rw4', 'arwa4bt']
     time_step = 0.25625
 
@@ -570,6 +633,7 @@ class DP_RW5_DELTA_TEMP(DerivedParameterPcad):
     Defined as TPCM_RW5 - ARWA5BT.
 
     """
+
     rootparams = ['tpcm_rw5', 'arwa5bt']
     time_step = 0.25625
 
@@ -586,6 +650,7 @@ class DP_RW6_DELTA_TEMP(DerivedParameterPcad):
     Defined as TCYZ_RW6 - ARWA6BT.
 
     """
+
     rootparams = ['tcyz_rw6', 'arwa6bt']
     time_step = 0.25625
 
@@ -601,13 +666,13 @@ class DP_SA_ANG_AVG(DerivedParameterPcad):
     Defined as the mean of AOSARES1 and AOSARES2.
 
     """
+
     rootparams = ['aosares1', 'aosares2']
     time_step = 4.1
     max_gap = 10.0
 
     def calc(self, data):
-        sa_ang_avg = (1.0 * data['aosares1'].vals +
-                      1.0 * data['aosares2'].vals) / 2
+        sa_ang_avg = (1.0 * data['aosares1'].vals + 1.0 * data['aosares2'].vals) / 2
         return sa_ang_avg
 
 
@@ -624,9 +689,19 @@ class DP_SUN_XZ_ANGLE(DerivedParameterPcad):
 
     http://occweb.cfa.harvard.edu/twiki/pub/Aspect/WebHome/ROLLDEV3.pdf
     """
-    rootparams = ['orbitephem0_x', 'orbitephem0_y', 'orbitephem0_z',
-                  'solarephem0_x', 'solarephem0_y', 'solarephem0_z',
-                  'aoattqt1', 'aoattqt2', 'aoattqt3', 'aoattqt4']
+
+    rootparams = [
+        'orbitephem0_x',
+        'orbitephem0_y',
+        'orbitephem0_z',
+        'solarephem0_x',
+        'solarephem0_y',
+        'solarephem0_z',
+        'aoattqt1',
+        'aoattqt2',
+        'aoattqt3',
+        'aoattqt4',
+    ]
     time_step = 1.025
     max_gap = 4.0
     max_gaps = {msid: 602.0 for msid in rootparams if 'ephem' in msid}
@@ -634,9 +709,9 @@ class DP_SUN_XZ_ANGLE(DerivedParameterPcad):
 
     def calc(self, data):
         sun_vec_b = sun_vector_body(data)
-        sun_xz_angle = degrees(arctan2(sun_vec_b[1],
-                                       sqrt(sun_vec_b[0] ** 2 +
-                                            sun_vec_b[2] ** 2)))
+        sun_xz_angle = degrees(
+            arctan2(sun_vec_b[1], sqrt(sun_vec_b[0] ** 2 + sun_vec_b[2] ** 2))
+        )
         return sun_xz_angle
 
 
@@ -650,14 +725,17 @@ class DP_SYS_MOM_TOT(DerivedParameterPcad):
     Calculated as the RSS of AOSYMOM1, AOSYMOM2, and AOSYMOM3.
 
     """
+
     rootparams = ['aosymom1', 'aosymom2', 'aosymom3']
     time_step = 8.2
     max_gap = 18.0
 
     def calc(self, data):
-        sys_mom_tot = sqrt(data['aosymom1'].vals ** 2 +
-                           data['aosymom2'].vals ** 2 +
-                           data['aosymom3'].vals ** 2)
+        sys_mom_tot = sqrt(
+            data['aosymom1'].vals ** 2
+            + data['aosymom2'].vals ** 2
+            + data['aosymom3'].vals ** 2
+        )
         return sys_mom_tot
 
 
@@ -701,15 +779,21 @@ def qrotate(q, r):
     if r.shape[0] != 3:
         raise ValueError('Input vector must have shape (3,) or (3, N, ..).')
     rot = np.zeros_like(r)
-    rot[0] = (r[0] * (q[0] ** 2 - q[1] ** 2 - q[2] ** 2 + q[3] ** 2) +
-              r[1] * (q[0] * q[1] + q[2] * q[3]) * 2 +
-              r[2] * (q[0] * q[2] - q[1] * q[3]) * 2)
-    rot[1] = (r[0] * (q[0] * q[1] - q[2] * q[3]) * 2 -
-              r[1] * (q[0] ** 2 - q[1] ** 2 + q[2] ** 2 - q[3] ** 2) +
-              r[2] * (q[1] * q[2] + q[0] * q[3]) * 2)
-    rot[2] = (r[0] * (q[0] * q[2] + q[1] * q[3]) * 2 +
-              r[1] * (q[1] * q[2] - q[0] * q[3]) * 2 -
-              r[2] * (q[0] ** 2 + q[1] ** 2 - q[2] ** 2 - q[3] ** 2))
+    rot[0] = (
+        r[0] * (q[0] ** 2 - q[1] ** 2 - q[2] ** 2 + q[3] ** 2)
+        + r[1] * (q[0] * q[1] + q[2] * q[3]) * 2
+        + r[2] * (q[0] * q[2] - q[1] * q[3]) * 2
+    )
+    rot[1] = (
+        r[0] * (q[0] * q[1] - q[2] * q[3]) * 2
+        - r[1] * (q[0] ** 2 - q[1] ** 2 + q[2] ** 2 - q[3] ** 2)
+        + r[2] * (q[1] * q[2] + q[0] * q[3]) * 2
+    )
+    rot[2] = (
+        r[0] * (q[0] * q[2] + q[1] * q[3]) * 2
+        + r[1] * (q[1] * q[2] - q[0] * q[3]) * 2
+        - r[2] * (q[0] ** 2 + q[1] ** 2 - q[2] ** 2 - q[3] ** 2)
+    )
 
     return rot
 
@@ -728,20 +812,24 @@ def sun_vector_body(data, predictive=True):
     orbit = 'orbitephem{}_'.format('0' if predictive else '1')
     solar = 'solarephem{}_'.format('0' if predictive else '1')
 
-    chandra_eci = np.array([data[orbit + 'x'].vals,
-                            data[orbit + 'y'].vals,
-                            data[orbit + 'z'].vals])
-    sun_eci = np.array([data[solar + 'x'].vals,
-                        data[solar + 'y'].vals,
-                        data[solar + 'z'].vals])
+    chandra_eci = np.array(
+        [data[orbit + 'x'].vals, data[orbit + 'y'].vals, data[orbit + 'z'].vals]
+    )
+    sun_eci = np.array(
+        [data[solar + 'x'].vals, data[solar + 'y'].vals, data[solar + 'z'].vals]
+    )
     sun_vec = -chandra_eci + sun_eci
-    est_quat = np.array([data['aoattqt1'].vals,
-                         data['aoattqt2'].vals,
-                         data['aoattqt3'].vals,
-                         data['aoattqt4'].vals])
+    est_quat = np.array(
+        [
+            data['aoattqt1'].vals,
+            data['aoattqt2'].vals,
+            data['aoattqt3'].vals,
+            data['aoattqt4'].vals,
+        ]
+    )
 
     sun_vec_b = qrotate(est_quat, sun_vec)  # Rotate into body frame
-    magnitude = sqrt((sun_vec_b ** 2).sum(axis=0))
+    magnitude = sqrt((sun_vec_b**2).sum(axis=0))
     data.bads |= magnitude == 0.0
     magnitude[data.bads] = 1.0
     sun_vec_b = sun_vec_b / magnitude  # Normalize

--- a/Ska/engarchive/derived/pcad.py
+++ b/Ska/engarchive/derived/pcad.py
@@ -13,7 +13,8 @@ Revision History::
 """
 
 import numpy as np
-from numpy import sin, cos, tan, arctan2, sqrt, degrees, radians
+from numpy import arctan2, cos, degrees, radians, sin, sqrt, tan
+
 from . import base
 
 

--- a/Ska/engarchive/derived/pcad.py
+++ b/Ska/engarchive/derived/pcad.py
@@ -19,7 +19,7 @@ from . import base
 
 
 class DerivedParameterPcad(base.DerivedParameter):
-    content_root = 'pcad'
+    content_root = "pcad"
 
 
 # --------------------------------------------
@@ -32,14 +32,14 @@ class DP_CSS1_NPM_SUN(DerivedParameterPcad):
 
     """
 
-    rootparams = ['aocssi1', 'aopcadmd', 'aosaillm']
+    rootparams = ["aocssi1", "aopcadmd", "aosaillm"]
     time_step = 1.025
     max_gap = 10.0
 
     def calc(self, data):
-        npm_sun = (data['aopcadmd'].vals == 'NPNT') & (data['aosaillm'].vals == 'ILLM')
+        npm_sun = (data["aopcadmd"].vals == "NPNT") & (data["aosaillm"].vals == "ILLM")
         data.bads = data.bads | ~npm_sun
-        css1_npm_sun = data['aocssi1'].vals * 4095 / 5.49549
+        css1_npm_sun = data["aocssi1"].vals * 4095 / 5.49549
         return css1_npm_sun
 
 
@@ -53,14 +53,14 @@ class DP_CSS2_NPM_SUN(DerivedParameterPcad):
 
     """
 
-    rootparams = ['aocssi2', 'aopcadmd', 'aosaillm']
+    rootparams = ["aocssi2", "aopcadmd", "aosaillm"]
     time_step = 1.025
     max_gap = 10.0
 
     def calc(self, data):
-        npm_sun = (data['aopcadmd'].vals == 'NPNT') & (data['aosaillm'].vals == 'ILLM')
+        npm_sun = (data["aopcadmd"].vals == "NPNT") & (data["aosaillm"].vals == "ILLM")
         data.bads = data.bads | ~npm_sun
-        css2_npm_sun = data['aocssi2'].vals * 4095 / 5.49549
+        css2_npm_sun = data["aocssi2"].vals * 4095 / 5.49549
         return css2_npm_sun
 
 
@@ -74,14 +74,14 @@ class DP_CSS3_NPM_SUN(DerivedParameterPcad):
 
     """
 
-    rootparams = ['aocssi3', 'aopcadmd', 'aosaillm']
+    rootparams = ["aocssi3", "aopcadmd", "aosaillm"]
     time_step = 1.025
     max_gap = 10.0
 
     def calc(self, data):
-        npm_sun = (data['aopcadmd'].vals == 'NPNT') & (data['aosaillm'].vals == 'ILLM')
+        npm_sun = (data["aopcadmd"].vals == "NPNT") & (data["aosaillm"].vals == "ILLM")
         data.bads = data.bads | ~npm_sun
-        css3_npm_sun = data['aocssi3'].vals * 4095 / 5.49549
+        css3_npm_sun = data["aocssi3"].vals * 4095 / 5.49549
         return css3_npm_sun
 
 
@@ -95,14 +95,14 @@ class DP_CSS4_NPM_SUN(DerivedParameterPcad):
 
     """
 
-    rootparams = ['aocssi4', 'aopcadmd', 'aosaillm']
+    rootparams = ["aocssi4", "aopcadmd", "aosaillm"]
     time_step = 1.025
     max_gap = 10.0
 
     def calc(self, data):
-        npm_sun = (data['aopcadmd'].vals == 'NPNT') & (data['aosaillm'].vals == 'ILLM')
+        npm_sun = (data["aopcadmd"].vals == "NPNT") & (data["aosaillm"].vals == "ILLM")
         data.bads = data.bads | ~npm_sun
-        css4_npm_sun = data['aocssi4'].vals * 4095 / 5.49549
+        css4_npm_sun = data["aocssi4"].vals * 4095 / 5.49549
         return css4_npm_sun
 
 
@@ -119,35 +119,35 @@ class DP_FSS_CSS_ANGLE_DIFF(DerivedParameterPcad):
     """
 
     rootparams = [
-        'aosunsa1',
-        'aosunsa2',
-        'aosunsa3',
-        'aosunac1',
-        'aosunac2',
-        'aosunac3',
-        'aosares1',
-        'aosares2',
-        'aosunprs',
+        "aosunsa1",
+        "aosunsa2",
+        "aosunsa3",
+        "aosunac1",
+        "aosunac2",
+        "aosunac3",
+        "aosares1",
+        "aosares2",
+        "aosunprs",
     ]
     time_step = 1.025
     max_gap = 18.0
     dtype = np.float32
 
     def calc(self, data):
-        in_fss_fov = data['aosunprs'].vals == 'SUN '
+        in_fss_fov = data["aosunprs"].vals == "SUN "
         data.bads |= ~in_fss_fov
-        sa_ang_avg = (data['aosares1'].vals + data['aosares2'].vals) / 2
+        sa_ang_avg = (data["aosares1"].vals + data["aosares2"].vals) / 2
         sinang = sin(radians(sa_ang_avg))
         cosang = cos(radians(sa_ang_avg))
         fss_aca = np.array(
-            [data['aosunac1'].vals, data['aosunac2'].vals, data['aosunac3'].vals]
+            [data["aosunac1"].vals, data["aosunac2"].vals, data["aosunac3"].vals]
         )
         # Rotate CSS sun vector from SA to ACA frame
         css_aca = np.array(
             [
-                sinang * data['aosunsa1'].vals - cosang * data['aosunsa3'].vals,
-                data['aosunsa2'].vals * 1.0,
-                cosang * data['aosunsa1'].vals + sinang * data['aosunsa3'].vals,
+                sinang * data["aosunsa1"].vals - cosang * data["aosunsa3"].vals,
+                data["aosunsa2"].vals * 1.0,
+                cosang * data["aosunsa1"].vals + sinang * data["aosunsa3"].vals,
             ]
         )
         # Normalize the vectors (again)
@@ -181,38 +181,38 @@ class DP_MAN_ANG(DerivedParameterPcad):
     """
 
     rootparams = [
-        'aoattqt1',
-        'aoattqt2',
-        'aoattqt3',
-        'aoattqt4',
-        'aotarqt1',
-        'aotarqt2',
-        'aotarqt3',
-        'aomanend',
+        "aoattqt1",
+        "aoattqt2",
+        "aoattqt3",
+        "aoattqt4",
+        "aotarqt1",
+        "aotarqt2",
+        "aotarqt3",
+        "aomanend",
     ]
     time_step = 1.025
     dtype = np.float32
 
     def calc(self, data):
         qt4_sqr = 1.0 - (
-            data['aotarqt1'].vals ** 2
-            + data['aotarqt2'].vals ** 2
-            + data['aotarqt3'].vals ** 2
+            data["aotarqt1"].vals ** 2
+            + data["aotarqt2"].vals ** 2
+            + data["aotarqt3"].vals ** 2
         )
         aotarqt4 = sqrt(np.clip(qt4_sqr, 0, 1))
         est_quat_inv = np.array(
             [
-                -1 * data['aoattqt1'].vals,
-                -1 * data['aoattqt2'].vals,
-                -1 * data['aoattqt3'].vals,
-                data['aoattqt4'].vals,
+                -1 * data["aoattqt1"].vals,
+                -1 * data["aoattqt2"].vals,
+                -1 * data["aoattqt3"].vals,
+                data["aoattqt4"].vals,
             ]
         )
         tar_quat = np.array(
             [
-                data['aotarqt1'].vals,
-                data['aotarqt2'].vals,
-                data['aotarqt3'].vals,
+                data["aotarqt1"].vals,
+                data["aotarqt2"].vals,
+                data["aotarqt3"].vals,
                 aotarqt4,
             ]
         )
@@ -224,7 +224,7 @@ class DP_MAN_ANG(DerivedParameterPcad):
         delta_quat3 = np.abs(delta_quat[3, :] / magnitude)
         man_ang = 2.0 * degrees(arccos_clip(delta_quat3))
 
-        man = data['aomanend'].vals == 'NEND'
+        man = data["aomanend"].vals == "NEND"
         man_ang[~man] = 0
         return man_ang
 
@@ -238,17 +238,17 @@ class DP_ONE_SHOT(DerivedParameterPcad):
 
     """
 
-    rootparams = ['aoatter2', 'aoatter3', 'aopcadmd']
+    rootparams = ["aoatter2", "aoatter3", "aopcadmd"]
     time_step = 1.025
     max_gap = 4.0
     dtype = np.float32
 
     def calc(self, data):
         one_shot = (
-            degrees(sqrt(data['aoatter2'].vals ** 2 + data['aoatter3'].vals ** 2))
+            degrees(sqrt(data["aoatter2"].vals ** 2 + data["aoatter3"].vals ** 2))
             * 3600
         )
-        npm = data['aopcadmd'].vals == 'NPNT'
+        npm = data["aopcadmd"].vals == "NPNT"
         one_shot[~npm] = 0.0
         return one_shot
 
@@ -267,20 +267,20 @@ class DP_PITCH(DerivedParameterPcad):
     """
 
     rootparams = [
-        'orbitephem0_x',
-        'orbitephem0_y',
-        'orbitephem0_z',
-        'solarephem0_x',
-        'solarephem0_y',
-        'solarephem0_z',
-        'aoattqt1',
-        'aoattqt2',
-        'aoattqt3',
-        'aoattqt4',
+        "orbitephem0_x",
+        "orbitephem0_y",
+        "orbitephem0_z",
+        "solarephem0_x",
+        "solarephem0_y",
+        "solarephem0_z",
+        "aoattqt1",
+        "aoattqt2",
+        "aoattqt3",
+        "aoattqt4",
     ]
     time_step = 1.025
     max_gap = 4.0
-    max_gaps = {msid: 602.0 for msid in rootparams if 'ephem' in msid}
+    max_gaps = {msid: 602.0 for msid in rootparams if "ephem" in msid}
     dtype = np.float32
 
     def calc(self, data):
@@ -300,21 +300,21 @@ class DP_PITCH_CSS(DerivedParameterPcad):
 
     """
 
-    rootparams = ['aosares1', 'aosares2', 'aosunsa1', 'aosunsa2', 'aosunsa3']
+    rootparams = ["aosares1", "aosares2", "aosunsa1", "aosunsa2", "aosunsa3"]
     time_step = 4.1
     max_gap = 18.0
     dtype = np.float32
 
     def calc(self, data):
-        sa_ang_avg = (1.0 * data['aosares1'].vals + 1.0 * data['aosares2'].vals) / 2
+        sa_ang_avg = (1.0 * data["aosares1"].vals + 1.0 * data["aosares2"].vals) / 2
         sinang = sin(radians(sa_ang_avg))
         cosang = cos(radians(sa_ang_avg))
         # Rotate CSS sun vector from SA to ACA frame
         css_aca = np.array(
             [
-                sinang * data['aosunsa1'].vals - cosang * data['aosunsa3'].vals,
-                data['aosunsa2'].vals * 1.0,
-                cosang * data['aosunsa1'].vals + sinang * data['aosunsa3'].vals,
+                sinang * data["aosunsa1"].vals - cosang * data["aosunsa3"].vals,
+                data["aosunsa2"].vals * 1.0,
+                cosang * data["aosunsa1"].vals + sinang * data["aosunsa3"].vals,
             ]
         )
         # Normalize sun vec (again) and compute pitch
@@ -337,13 +337,13 @@ class DP_PITCH_CSS_SA(DerivedParameterPcad):
 
     """
 
-    rootparams = ['aosunsa1']
+    rootparams = ["aosunsa1"]
     time_step = 8.2
     max_gap = 18.0
     dtype = np.float32
 
     def calc(self, data):
-        pitch_css_sa = 90.0 - degrees(arccos_clip(data['aosunsa1'].vals))
+        pitch_css_sa = 90.0 - degrees(arccos_clip(data["aosunsa1"].vals))
         return pitch_css_sa
 
 
@@ -363,13 +363,13 @@ class DP_PITCH_FSS(DerivedParameterPcad):
     <data>.bads = 1
     """
 
-    rootparams = ['aoalpang', 'aobetang', 'aosunprs']
+    rootparams = ["aoalpang", "aobetang", "aosunprs"]
     time_step = 1.025
     max_gap = 10.0
     dtype = np.float32
 
     def calc(self, data):
-        in_fss_fov = data['aosunprs'].vals == 'SUN '
+        in_fss_fov = data["aosunprs"].vals == "SUN "
         data.bads = data.bads | ~in_fss_fov
         # rotation matrix from FSS to ACA frame
         A_AF = np.array(
@@ -380,8 +380,8 @@ class DP_PITCH_FSS(DerivedParameterPcad):
             ]
         )
         # FSS's sun vector in FSS frame
-        alpha = radians(data['aoalpang'].vals)
-        beta = radians(data['aobetang'].vals)
+        alpha = radians(data["aoalpang"].vals)
+        beta = radians(data["aobetang"].vals)
         sun_fss = np.array([tan(beta), tan(alpha), -np.ones(len(alpha))])
         sun_aca = A_AF.dot(sun_fss)
         magnitude = sqrt((sun_aca * sun_aca).sum(axis=0))
@@ -408,20 +408,20 @@ class DP_ROLL(DerivedParameterPcad):
     """
 
     rootparams = [
-        'orbitephem0_x',
-        'orbitephem0_y',
-        'orbitephem0_z',
-        'solarephem0_x',
-        'solarephem0_y',
-        'solarephem0_z',
-        'aoattqt1',
-        'aoattqt2',
-        'aoattqt3',
-        'aoattqt4',
+        "orbitephem0_x",
+        "orbitephem0_y",
+        "orbitephem0_z",
+        "solarephem0_x",
+        "solarephem0_y",
+        "solarephem0_z",
+        "aoattqt1",
+        "aoattqt2",
+        "aoattqt3",
+        "aoattqt4",
     ]
     time_step = 1.025
     max_gap = 4.0
-    max_gaps = {msid: 602.0 for msid in rootparams if 'ephem' in msid}
+    max_gaps = {msid: 602.0 for msid in rootparams if "ephem" in msid}
     dtype = np.float32
 
     def calc(self, data):
@@ -442,21 +442,21 @@ class DP_ROLL_CSS(DerivedParameterPcad):
 
     """
 
-    rootparams = ['aosares1', 'aosares2', 'aosunsa1', 'aosunsa2', 'aosunsa3']
+    rootparams = ["aosares1", "aosares2", "aosunsa1", "aosunsa2", "aosunsa3"]
     time_step = 4.1
     max_gap = 18.0
     dtype = np.float32
 
     def calc(self, data):
-        sa_ang_avg = (data['aosares1'].vals + data['aosares2'].vals) / 2
+        sa_ang_avg = (data["aosares1"].vals + data["aosares2"].vals) / 2
         sinang = sin(radians(sa_ang_avg))
         cosang = cos(radians(sa_ang_avg))
         # Rotate CSS sun vector from SA to ACA frame
         css_aca = np.array(
             [
-                sinang * data['aosunsa1'].vals - cosang * data['aosunsa3'].vals,
-                data['aosunsa2'].vals,
-                cosang * data['aosunsa1'].vals + sinang * data['aosunsa3'].vals,
+                sinang * data["aosunsa1"].vals - cosang * data["aosunsa3"].vals,
+                data["aosunsa2"].vals,
+                cosang * data["aosunsa1"].vals + sinang * data["aosunsa3"].vals,
             ]
         )
         # Normalize sun vec (again) and compute pitch
@@ -480,13 +480,13 @@ class DP_ROLL_CSS_SA(DerivedParameterPcad):
 
     """
 
-    rootparams = ['aosunsa2', 'aosunsa3']
+    rootparams = ["aosunsa2", "aosunsa3"]
     time_step = 8.2
     max_gap = 18.0
     dtype = np.float32
 
     def calc(self, data):
-        roll_css_sa = degrees(arctan2(-data['aosunsa2'].vals, -data['aosunsa3'].vals))
+        roll_css_sa = degrees(arctan2(-data["aosunsa2"].vals, -data["aosunsa3"].vals))
         return roll_css_sa
 
 
@@ -507,13 +507,13 @@ class DP_ROLL_FSS(DerivedParameterPcad):
     <data>.bads = 1
     """
 
-    rootparams = ['aoalpang', 'aobetang', 'aosunprs']
+    rootparams = ["aoalpang", "aobetang", "aosunprs"]
     time_step = 1.025
     max_gap = 10.0
     dtype = np.float32
 
     def calc(self, data):
-        in_fss_fov = data['aosunprs'].vals == 'SUN '
+        in_fss_fov = data["aosunprs"].vals == "SUN "
         data.bads = data.bads | ~in_fss_fov
         # rotation matrix from FSS to ACA frame
         A_AF = np.array(
@@ -524,8 +524,8 @@ class DP_ROLL_FSS(DerivedParameterPcad):
             ]
         )
         # FSS's sun vector in FSS frame
-        alpha = radians(data['aoalpang'].vals)
-        beta = radians(data['aobetang'].vals)
+        alpha = radians(data["aoalpang"].vals)
+        beta = radians(data["aobetang"].vals)
         sun_fss = np.array([tan(beta), tan(alpha), -np.ones(len(alpha))])
         sun_aca = A_AF.dot(sun_fss)
         magnitude = sqrt((sun_aca * sun_aca).sum(axis=0))
@@ -544,15 +544,15 @@ class DP_RW_MOM_TOT(DerivedParameterPcad):
 
     """
 
-    rootparams = ['aorwmom1', 'aorwmom2', 'aorwmom3']
+    rootparams = ["aorwmom1", "aorwmom2", "aorwmom3"]
     time_step = 8.2
     dtype = np.float32
 
     def calc(self, data):
         rw_mom_tot = sqrt(
-            data['aorwmom1'].vals ** 2
-            + data['aorwmom2'].vals ** 2
-            + data['aorwmom3'].vals ** 2
+            data["aorwmom1"].vals ** 2
+            + data["aorwmom2"].vals ** 2
+            + data["aorwmom3"].vals ** 2
         )
         return rw_mom_tot
 
@@ -566,11 +566,11 @@ class DP_RW1_DELTA_TEMP(DerivedParameterPcad):
 
     """
 
-    rootparams = ['tcyz_rw1', 'arwa1bt']
+    rootparams = ["tcyz_rw1", "arwa1bt"]
     time_step = 0.25625
 
     def calc(self, data):
-        rw1_delta_temp = data['tcyz_rw1'].vals - data['arwa1bt'].vals
+        rw1_delta_temp = data["tcyz_rw1"].vals - data["arwa1bt"].vals
         return rw1_delta_temp
 
 
@@ -583,11 +583,11 @@ class DP_RW2_DELTA_TEMP(DerivedParameterPcad):
 
     """
 
-    rootparams = ['tpcp_rw2', 'arwa2bt']
+    rootparams = ["tpcp_rw2", "arwa2bt"]
     time_step = 0.25625
 
     def calc(self, data):
-        rw2_delta_temp = data['tpcp_rw2'].vals - data['arwa2bt'].vals
+        rw2_delta_temp = data["tpcp_rw2"].vals - data["arwa2bt"].vals
         return rw2_delta_temp
 
 
@@ -600,11 +600,11 @@ class DP_RW3_DELTA_TEMP(DerivedParameterPcad):
 
     """
 
-    rootparams = ['tpcp_rw3', 'arwa3bt']
+    rootparams = ["tpcp_rw3", "arwa3bt"]
     time_step = 0.25625
 
     def calc(self, data):
-        rw3_delta_temp = data['tpcp_rw3'].vals - data['arwa3bt'].vals
+        rw3_delta_temp = data["tpcp_rw3"].vals - data["arwa3bt"].vals
         return rw3_delta_temp
 
 
@@ -617,11 +617,11 @@ class DP_RW4_DELTA_TEMP(DerivedParameterPcad):
 
     """
 
-    rootparams = ['tpcm_rw4', 'arwa4bt']
+    rootparams = ["tpcm_rw4", "arwa4bt"]
     time_step = 0.25625
 
     def calc(self, data):
-        rw4_delta_temp = data['tpcm_rw4'].vals - data['arwa4bt'].vals
+        rw4_delta_temp = data["tpcm_rw4"].vals - data["arwa4bt"].vals
         return rw4_delta_temp
 
 
@@ -634,11 +634,11 @@ class DP_RW5_DELTA_TEMP(DerivedParameterPcad):
 
     """
 
-    rootparams = ['tpcm_rw5', 'arwa5bt']
+    rootparams = ["tpcm_rw5", "arwa5bt"]
     time_step = 0.25625
 
     def calc(self, data):
-        rw5_delta_temp = data['tpcm_rw5'].vals - data['arwa5bt'].vals
+        rw5_delta_temp = data["tpcm_rw5"].vals - data["arwa5bt"].vals
         return rw5_delta_temp
 
 
@@ -651,11 +651,11 @@ class DP_RW6_DELTA_TEMP(DerivedParameterPcad):
 
     """
 
-    rootparams = ['tcyz_rw6', 'arwa6bt']
+    rootparams = ["tcyz_rw6", "arwa6bt"]
     time_step = 0.25625
 
     def calc(self, data):
-        rw6_delta_temp = data['tcyz_rw6'].vals - data['arwa6bt'].vals
+        rw6_delta_temp = data["tcyz_rw6"].vals - data["arwa6bt"].vals
         return rw6_delta_temp
 
 
@@ -667,12 +667,12 @@ class DP_SA_ANG_AVG(DerivedParameterPcad):
 
     """
 
-    rootparams = ['aosares1', 'aosares2']
+    rootparams = ["aosares1", "aosares2"]
     time_step = 4.1
     max_gap = 10.0
 
     def calc(self, data):
-        sa_ang_avg = (1.0 * data['aosares1'].vals + 1.0 * data['aosares2'].vals) / 2
+        sa_ang_avg = (1.0 * data["aosares1"].vals + 1.0 * data["aosares2"].vals) / 2
         return sa_ang_avg
 
 
@@ -691,20 +691,20 @@ class DP_SUN_XZ_ANGLE(DerivedParameterPcad):
     """
 
     rootparams = [
-        'orbitephem0_x',
-        'orbitephem0_y',
-        'orbitephem0_z',
-        'solarephem0_x',
-        'solarephem0_y',
-        'solarephem0_z',
-        'aoattqt1',
-        'aoattqt2',
-        'aoattqt3',
-        'aoattqt4',
+        "orbitephem0_x",
+        "orbitephem0_y",
+        "orbitephem0_z",
+        "solarephem0_x",
+        "solarephem0_y",
+        "solarephem0_z",
+        "aoattqt1",
+        "aoattqt2",
+        "aoattqt3",
+        "aoattqt4",
     ]
     time_step = 1.025
     max_gap = 4.0
-    max_gaps = {msid: 602.0 for msid in rootparams if 'ephem' in msid}
+    max_gaps = {msid: 602.0 for msid in rootparams if "ephem" in msid}
     dtype = np.float32
 
     def calc(self, data):
@@ -726,15 +726,15 @@ class DP_SYS_MOM_TOT(DerivedParameterPcad):
 
     """
 
-    rootparams = ['aosymom1', 'aosymom2', 'aosymom3']
+    rootparams = ["aosymom1", "aosymom2", "aosymom3"]
     time_step = 8.2
     max_gap = 18.0
 
     def calc(self, data):
         sys_mom_tot = sqrt(
-            data['aosymom1'].vals ** 2
-            + data['aosymom2'].vals ** 2
-            + data['aosymom3'].vals ** 2
+            data["aosymom1"].vals ** 2
+            + data["aosymom2"].vals ** 2
+            + data["aosymom3"].vals ** 2
         )
         return sys_mom_tot
 
@@ -750,7 +750,7 @@ def qmult(q1, q2):
     :returns: q1*q2 as an array with same shape as q1 and q2
     """
     if q1.shape != q2.shape:
-        raise ValueError('Shapes must agree')
+        raise ValueError("Shapes must agree")
 
     mult = np.zeros_like(q1)
     mult[0] = q1[3] * q2[0] - q1[2] * q2[1] + q1[1] * q2[2] + q1[0] * q2[3]
@@ -775,9 +775,9 @@ def qrotate(q, r):
     :returns r rotated by q as an array with the same shape as r
     """
     if q.shape[0] != 4:
-        raise ValueError('Input quaternion must have shape (4,) or (4, N, ..)')
+        raise ValueError("Input quaternion must have shape (4,) or (4, N, ..)")
     if r.shape[0] != 3:
-        raise ValueError('Input vector must have shape (3,) or (3, N, ..).')
+        raise ValueError("Input vector must have shape (3,) or (3, N, ..).")
     rot = np.zeros_like(r)
     rot[0] = (
         r[0] * (q[0] ** 2 - q[1] ** 2 - q[2] ** 2 + q[3] ** 2)
@@ -809,22 +809,22 @@ def sun_vector_body(data, predictive=True):
     :param predictive: use predictive ephemeris
     :returns: 3 x N array of vectors
     """
-    orbit = 'orbitephem{}_'.format('0' if predictive else '1')
-    solar = 'solarephem{}_'.format('0' if predictive else '1')
+    orbit = "orbitephem{}_".format("0" if predictive else "1")
+    solar = "solarephem{}_".format("0" if predictive else "1")
 
     chandra_eci = np.array(
-        [data[orbit + 'x'].vals, data[orbit + 'y'].vals, data[orbit + 'z'].vals]
+        [data[orbit + "x"].vals, data[orbit + "y"].vals, data[orbit + "z"].vals]
     )
     sun_eci = np.array(
-        [data[solar + 'x'].vals, data[solar + 'y'].vals, data[solar + 'z'].vals]
+        [data[solar + "x"].vals, data[solar + "y"].vals, data[solar + "z"].vals]
     )
     sun_vec = -chandra_eci + sun_eci
     est_quat = np.array(
         [
-            data['aoattqt1'].vals,
-            data['aoattqt2'].vals,
-            data['aoattqt3'].vals,
-            data['aoattqt4'].vals,
+            data["aoattqt1"].vals,
+            data["aoattqt2"].vals,
+            data["aoattqt3"].vals,
+            data["aoattqt4"].vals,
         ]
     )
 

--- a/Ska/engarchive/derived/test.py
+++ b/Ska/engarchive/derived/test.py
@@ -5,6 +5,7 @@ from . import base
 class DerivedParameterTest(base.DerivedParameter):
     content_root = 'test'
 
+
 # --------------------------------------------
 
 

--- a/Ska/engarchive/derived/test.py
+++ b/Ska/engarchive/derived/test.py
@@ -3,31 +3,31 @@ from . import base
 
 
 class DerivedParameterTest(base.DerivedParameter):
-    content_root = 'test'
+    content_root = "test"
 
 
 # --------------------------------------------
 
 
 class DP_TEST1(DerivedParameterTest):
-    rootparams = ['TEPHIN']
+    rootparams = ["TEPHIN"]
     time_step = 32.8
 
     def calc(self, dataset):
-        return dataset['TEPHIN'].vals
+        return dataset["TEPHIN"].vals
 
 
 class DP_TEST2(DerivedParameterTest):
-    rootparams = ['TEPHIN']
+    rootparams = ["TEPHIN"]
     time_step = 65.6
 
     def calc(self, dataset):
-        return dataset['TEPHIN'].vals * 1.5
+        return dataset["TEPHIN"].vals * 1.5
 
 
 class DP_TEST3(DerivedParameterTest):
-    rootparams = ['TEPHIN']
+    rootparams = ["TEPHIN"]
     time_step = 65.6
 
     def calc(self, dataset):
-        return dataset['TEPHIN'].vals * 2.0
+        return dataset["TEPHIN"].vals * 2.0

--- a/Ska/engarchive/derived/thermal.py
+++ b/Ska/engarchive/derived/thermal.py
@@ -9,34 +9,34 @@ from . import base
 
 
 class DerivedParameterThermal(base.DerivedParameter):
-    content_root = 'thermal'
+    content_root = "thermal"
 
     def fix_bus_5_and_bus_6(self, data):
         # These zones cannot be commanded if Bus 5 or Bus 6 is disabled
         bus_5_and_6_zones = [
-            '4OHTRZ27',
-            '4OHTRZ28',
-            '4OHTRZ43',
-            '4OHTRZ45',
-            '4OHTRZ47',
-            '4OHTRZ49',
-            '4OHTRZ52',
-            '4OHTRZ53',
-            '4OHTRZ29',
-            '4OHTRZ35',
-            '4OHTRZ42',
-            '4OHTRZ44',
-            '4OHTRZ46',
-            '4OHTRZ48',
-            '4OHTRZ50',
-            '4OHTRZ54',
+            "4OHTRZ27",
+            "4OHTRZ28",
+            "4OHTRZ43",
+            "4OHTRZ45",
+            "4OHTRZ47",
+            "4OHTRZ49",
+            "4OHTRZ52",
+            "4OHTRZ53",
+            "4OHTRZ29",
+            "4OHTRZ35",
+            "4OHTRZ42",
+            "4OHTRZ44",
+            "4OHTRZ46",
+            "4OHTRZ48",
+            "4OHTRZ50",
+            "4OHTRZ54",
         ]
 
         for msid in bus_5_and_6_zones:
             if msid in data.keys():
                 # Heater must be off if either bus is disabled
-                disa = (data['4S1PWR05'].vals == 'DISA') | (
-                    data['4S1PWR06'].vals == 'DISA'
+                disa = (data["4S1PWR05"].vals == "DISA") | (
+                    data["4S1PWR06"].vals == "DISA"
                 )
                 data[msid].vals[disa] = 0
 
@@ -47,7 +47,7 @@ class DerivedParameterThermal(base.DerivedParameter):
         # Zone 50 became stuck again on day 2006:364.
         stuck2 = data.times > 283844996.184
         stuck = stuck1 | stuck2
-        data['4OHTRZ50'].vals[stuck] = 1
+        data["4OHTRZ50"].vals[stuck] = 1
 
 
 # --------------------------------------------
@@ -55,37 +55,37 @@ class DerivedParameterThermal(base.DerivedParameter):
 
 class DP_EE_AXIAL(DerivedParameterThermal):
     rootparams = [
-        'OHRTHR58',
-        'OHRTHR12',
-        'OHRTHR36',
-        'OHRTHR56',
-        'OHRTHR57',
-        'OHRTHR55',
-        'OHRTHR35',
-        'OHRTHR37',
-        'OHRTHR34',
-        'OHRTHR13',
-        'OHRTHR10',
-        'OHRTHR11',
+        "OHRTHR58",
+        "OHRTHR12",
+        "OHRTHR36",
+        "OHRTHR56",
+        "OHRTHR57",
+        "OHRTHR55",
+        "OHRTHR35",
+        "OHRTHR37",
+        "OHRTHR34",
+        "OHRTHR13",
+        "OHRTHR10",
+        "OHRTHR11",
     ]
     time_step = 32.8
 
     def calc(self, data):
         HYPAVE = (
-            data['OHRTHR12'].vals
-            + data['OHRTHR13'].vals
-            + data['OHRTHR36'].vals
-            + data['OHRTHR37'].vals
-            + data['OHRTHR57'].vals
-            + data['OHRTHR58'].vals
+            data["OHRTHR12"].vals
+            + data["OHRTHR13"].vals
+            + data["OHRTHR36"].vals
+            + data["OHRTHR37"].vals
+            + data["OHRTHR57"].vals
+            + data["OHRTHR58"].vals
         ) / 6
         PARAVE = (
-            data['OHRTHR10'].vals
-            + data['OHRTHR11'].vals
-            + data['OHRTHR34'].vals
-            + data['OHRTHR35'].vals
-            + data['OHRTHR55'].vals
-            + data['OHRTHR56'].vals
+            data["OHRTHR10"].vals
+            + data["OHRTHR11"].vals
+            + data["OHRTHR34"].vals
+            + data["OHRTHR35"].vals
+            + data["OHRTHR55"].vals
+            + data["OHRTHR56"].vals
         ) / 6
         HAAG = PARAVE - HYPAVE
         DTAXIAL = np.abs(1.0 * HAAG)
@@ -96,53 +96,53 @@ class DP_EE_AXIAL(DerivedParameterThermal):
 # --------------------------------------------
 class DP_EE_BULK(DerivedParameterThermal):
     rootparams = [
-        'OHRTHR10',
-        'OHRTHR58',
-        'OHRTHR52',
-        'OHRTHR53',
-        'OHRTHR56',
-        'OHRTHR57',
-        'OHRTHR54',
-        'OHRTHR55',
-        'OHRTHR12',
-        'OHRTHR35',
-        'OHRTHR11',
-        'OHRTHR08',
-        'OHRTHR09',
-        'OHRTHR31',
-        'OHRTHR33',
-        'OHRTHR34',
-        'OHRTHR13',
-        'OHRTHR36',
-        'OHRTHR37',
+        "OHRTHR10",
+        "OHRTHR58",
+        "OHRTHR52",
+        "OHRTHR53",
+        "OHRTHR56",
+        "OHRTHR57",
+        "OHRTHR54",
+        "OHRTHR55",
+        "OHRTHR12",
+        "OHRTHR35",
+        "OHRTHR11",
+        "OHRTHR08",
+        "OHRTHR09",
+        "OHRTHR31",
+        "OHRTHR33",
+        "OHRTHR34",
+        "OHRTHR13",
+        "OHRTHR36",
+        "OHRTHR37",
     ]
     time_step = 32.8
 
     def calc(self, data):
         P_SUM = (
-            data['OHRTHR10'].vals
-            + data['OHRTHR11'].vals
-            + data['OHRTHR34'].vals
-            + data['OHRTHR35'].vals
-            + data['OHRTHR55'].vals
-            + data['OHRTHR56'].vals
+            data["OHRTHR10"].vals
+            + data["OHRTHR11"].vals
+            + data["OHRTHR34"].vals
+            + data["OHRTHR35"].vals
+            + data["OHRTHR55"].vals
+            + data["OHRTHR56"].vals
         )
         H_SUM = (
-            data['OHRTHR12'].vals
-            + data['OHRTHR13'].vals
-            + data['OHRTHR36'].vals
-            + data['OHRTHR37'].vals
-            + data['OHRTHR57'].vals
-            + data['OHRTHR58'].vals
+            data["OHRTHR12"].vals
+            + data["OHRTHR13"].vals
+            + data["OHRTHR36"].vals
+            + data["OHRTHR37"].vals
+            + data["OHRTHR57"].vals
+            + data["OHRTHR58"].vals
         )
         CAP_SUM = (
-            data['OHRTHR08'].vals
-            + data['OHRTHR09'].vals
-            + data['OHRTHR31'].vals
-            + data['OHRTHR33'].vals
-            + data['OHRTHR52'].vals
-            + data['OHRTHR53'].vals
-            + data['OHRTHR54'].vals
+            data["OHRTHR08"].vals
+            + data["OHRTHR09"].vals
+            + data["OHRTHR31"].vals
+            + data["OHRTHR33"].vals
+            + data["OHRTHR52"].vals
+            + data["OHRTHR53"].vals
+            + data["OHRTHR54"].vals
         )
         HMCSAVE = (CAP_SUM + P_SUM + H_SUM) / 19.0
         DTBULK = np.abs(1.0 * HMCSAVE - 69.8)
@@ -155,12 +155,12 @@ class DP_EE_BULK(DerivedParameterThermal):
 class DP_EE_DIAM(DerivedParameterThermal):
     """Kodak diametrical encircled energy"""
 
-    rootparams = ['OHRMGRD6', 'OHRMGRD3']
+    rootparams = ["OHRMGRD6", "OHRMGRD3"]
     time_step = 32.8
 
     def calc(self, data):
-        VAL2 = np.abs(1.0 * data['OHRMGRD6'].vals)
-        VAL1 = np.abs(1.0 * data['OHRMGRD3'].vals)
+        VAL2 = np.abs(1.0 * data["OHRMGRD6"].vals)
+        VAL1 = np.abs(1.0 * data["OHRMGRD3"].vals)
         DTDIAM = np.max([VAL1, VAL2], axis=0)
         EE_DIAM = DTDIAM * 0.401
         return EE_DIAM
@@ -169,25 +169,25 @@ class DP_EE_DIAM(DerivedParameterThermal):
 # --------------------------------------------
 class DP_EE_RADIAL(DerivedParameterThermal):
     rootparams = [
-        'OHRTHR52',
-        'OHRTHR53',
-        'OHRTHR54',
-        'OHRTHR31',
-        'OHRTHR09',
-        'OHRTHR08',
-        'OHRTHR33',
+        "OHRTHR52",
+        "OHRTHR53",
+        "OHRTHR54",
+        "OHRTHR31",
+        "OHRTHR09",
+        "OHRTHR08",
+        "OHRTHR33",
     ]
     time_step = 32.8
 
     def calc(self, data):
         CAPIAVE = (
-            data['OHRTHR09'].vals + data['OHRTHR53'].vals + data['OHRTHR54'].vals
+            data["OHRTHR09"].vals + data["OHRTHR53"].vals + data["OHRTHR54"].vals
         ) / 3
         CAPOAVE = (
-            data['OHRTHR08'].vals
-            + data['OHRTHR31'].vals
-            + data['OHRTHR33'].vals
-            + data['OHRTHR52'].vals
+            data["OHRTHR08"].vals
+            + data["OHRTHR31"].vals
+            + data["OHRTHR33"].vals
+            + data["OHRTHR52"].vals
         ) / 4
         HARG = CAPOAVE - CAPIAVE
         DTRADIAL = np.abs(1.0 * HARG)
@@ -198,83 +198,83 @@ class DP_EE_RADIAL(DerivedParameterThermal):
 # --------------------------------------------
 class DP_EE_THERM(DerivedParameterThermal):
     rootparams = [
-        'OHRTHR37',
-        'OHRTHR58',
-        'OHRMGRD6',
-        'OHRMGRD3',
-        'OHRTHR35',
-        'OHRTHR52',
-        'OHRTHR53',
-        'OHRTHR56',
-        'OHRTHR57',
-        'OHRTHR54',
-        'OHRTHR55',
-        'OHRTHR12',
-        'OHRTHR36',
-        'OHRTHR08',
-        'OHRTHR09',
-        'OHRTHR31',
-        'OHRTHR33',
-        'OHRTHR34',
-        'OHRTHR13',
-        'OHRTHR10',
-        'OHRTHR11',
+        "OHRTHR37",
+        "OHRTHR58",
+        "OHRMGRD6",
+        "OHRMGRD3",
+        "OHRTHR35",
+        "OHRTHR52",
+        "OHRTHR53",
+        "OHRTHR56",
+        "OHRTHR57",
+        "OHRTHR54",
+        "OHRTHR55",
+        "OHRTHR12",
+        "OHRTHR36",
+        "OHRTHR08",
+        "OHRTHR09",
+        "OHRTHR31",
+        "OHRTHR33",
+        "OHRTHR34",
+        "OHRTHR13",
+        "OHRTHR10",
+        "OHRTHR11",
     ]
     time_step = 32.8
 
     def calc(self, data):
         CAP_SUM = (
-            data['OHRTHR08'].vals
-            + data['OHRTHR09'].vals
-            + data['OHRTHR31'].vals
-            + data['OHRTHR33'].vals
-            + data['OHRTHR52'].vals
-            + data['OHRTHR53'].vals
-            + data['OHRTHR54'].vals
+            data["OHRTHR08"].vals
+            + data["OHRTHR09"].vals
+            + data["OHRTHR31"].vals
+            + data["OHRTHR33"].vals
+            + data["OHRTHR52"].vals
+            + data["OHRTHR53"].vals
+            + data["OHRTHR54"].vals
         )
         CAPIAVE = (
-            data['OHRTHR09'].vals + data['OHRTHR53'].vals + data['OHRTHR54'].vals
+            data["OHRTHR09"].vals + data["OHRTHR53"].vals + data["OHRTHR54"].vals
         ) / 3
         P_SUM = (
-            data['OHRTHR10'].vals
-            + data['OHRTHR11'].vals
-            + data['OHRTHR34'].vals
-            + data['OHRTHR35'].vals
-            + data['OHRTHR55'].vals
-            + data['OHRTHR56'].vals
+            data["OHRTHR10"].vals
+            + data["OHRTHR11"].vals
+            + data["OHRTHR34"].vals
+            + data["OHRTHR35"].vals
+            + data["OHRTHR55"].vals
+            + data["OHRTHR56"].vals
         )
         CAPOAVE = (
-            data['OHRTHR08'].vals
-            + data['OHRTHR31'].vals
-            + data['OHRTHR33'].vals
-            + data['OHRTHR52'].vals
+            data["OHRTHR08"].vals
+            + data["OHRTHR31"].vals
+            + data["OHRTHR33"].vals
+            + data["OHRTHR52"].vals
         ) / 4
         H_SUM = (
-            data['OHRTHR12'].vals
-            + data['OHRTHR13'].vals
-            + data['OHRTHR36'].vals
-            + data['OHRTHR37'].vals
-            + data['OHRTHR57'].vals
-            + data['OHRTHR58'].vals
+            data["OHRTHR12"].vals
+            + data["OHRTHR13"].vals
+            + data["OHRTHR36"].vals
+            + data["OHRTHR37"].vals
+            + data["OHRTHR57"].vals
+            + data["OHRTHR58"].vals
         )
         PARAVE = (
-            data['OHRTHR10'].vals
-            + data['OHRTHR11'].vals
-            + data['OHRTHR34'].vals
-            + data['OHRTHR35'].vals
-            + data['OHRTHR55'].vals
-            + data['OHRTHR56'].vals
+            data["OHRTHR10"].vals
+            + data["OHRTHR11"].vals
+            + data["OHRTHR34"].vals
+            + data["OHRTHR35"].vals
+            + data["OHRTHR55"].vals
+            + data["OHRTHR56"].vals
         ) / 6
         HYPAVE = (
-            data['OHRTHR12'].vals
-            + data['OHRTHR13'].vals
-            + data['OHRTHR36'].vals
-            + data['OHRTHR37'].vals
-            + data['OHRTHR57'].vals
-            + data['OHRTHR58'].vals
+            data["OHRTHR12"].vals
+            + data["OHRTHR13"].vals
+            + data["OHRTHR36"].vals
+            + data["OHRTHR37"].vals
+            + data["OHRTHR57"].vals
+            + data["OHRTHR58"].vals
         ) / 6
-        VAL1 = np.abs(1.0 * data['OHRMGRD3'].vals)
-        VAL2 = np.abs(1.0 * data['OHRMGRD6'].vals)
+        VAL1 = np.abs(1.0 * data["OHRMGRD3"].vals)
+        VAL2 = np.abs(1.0 * data["OHRMGRD6"].vals)
 
         HAAG = PARAVE - HYPAVE
         HARG = CAPOAVE - CAPIAVE
@@ -297,37 +297,37 @@ class DP_EE_THERM(DerivedParameterThermal):
 # --------------------------------------------
 class DP_HAAG(DerivedParameterThermal):
     rootparams = [
-        'OHRTHR58',
-        'OHRTHR12',
-        'OHRTHR56',
-        'OHRTHR57',
-        'OHRTHR55',
-        'OHRTHR13',
-        'OHRTHR36',
-        'OHRTHR37',
-        'OHRTHR34',
-        'OHRTHR35',
-        'OHRTHR10',
-        'OHRTHR11',
+        "OHRTHR58",
+        "OHRTHR12",
+        "OHRTHR56",
+        "OHRTHR57",
+        "OHRTHR55",
+        "OHRTHR13",
+        "OHRTHR36",
+        "OHRTHR37",
+        "OHRTHR34",
+        "OHRTHR35",
+        "OHRTHR10",
+        "OHRTHR11",
     ]
     time_step = 32.8
 
     def calc(self, data):
         HYPAVE = (
-            data['OHRTHR12'].vals
-            + data['OHRTHR13'].vals
-            + data['OHRTHR36'].vals
-            + data['OHRTHR37'].vals
-            + data['OHRTHR57'].vals
-            + data['OHRTHR58'].vals
+            data["OHRTHR12"].vals
+            + data["OHRTHR13"].vals
+            + data["OHRTHR36"].vals
+            + data["OHRTHR37"].vals
+            + data["OHRTHR57"].vals
+            + data["OHRTHR58"].vals
         ) / 6
         PARAVE = (
-            data['OHRTHR10'].vals
-            + data['OHRTHR11'].vals
-            + data['OHRTHR34'].vals
-            + data['OHRTHR35'].vals
-            + data['OHRTHR55'].vals
-            + data['OHRTHR56'].vals
+            data["OHRTHR10"].vals
+            + data["OHRTHR11"].vals
+            + data["OHRTHR34"].vals
+            + data["OHRTHR35"].vals
+            + data["OHRTHR55"].vals
+            + data["OHRTHR56"].vals
         ) / 6
         HAAG = PARAVE - HYPAVE
         return HAAG
@@ -336,25 +336,25 @@ class DP_HAAG(DerivedParameterThermal):
 # --------------------------------------------
 class DP_HARG(DerivedParameterThermal):
     rootparams = [
-        'OHRTHR52',
-        'OHRTHR53',
-        'OHRTHR54',
-        'OHRTHR31',
-        'OHRTHR09',
-        'OHRTHR08',
-        'OHRTHR33',
+        "OHRTHR52",
+        "OHRTHR53",
+        "OHRTHR54",
+        "OHRTHR31",
+        "OHRTHR09",
+        "OHRTHR08",
+        "OHRTHR33",
     ]
     time_step = 32.8
 
     def calc(self, data):
         CAPIAVE = (
-            data['OHRTHR09'].vals + data['OHRTHR53'].vals + data['OHRTHR54'].vals
+            data["OHRTHR09"].vals + data["OHRTHR53"].vals + data["OHRTHR54"].vals
         ) / 3
         CAPOAVE = (
-            data['OHRTHR08'].vals
-            + data['OHRTHR31'].vals
-            + data['OHRTHR33'].vals
-            + data['OHRTHR52'].vals
+            data["OHRTHR08"].vals
+            + data["OHRTHR31"].vals
+            + data["OHRTHR33"].vals
+            + data["OHRTHR52"].vals
         ) / 4
         HARG = CAPOAVE - CAPIAVE
         return HARG
@@ -363,42 +363,42 @@ class DP_HARG(DerivedParameterThermal):
 # --------------------------------------------
 class DP_HMAX35(DerivedParameterThermal):
     rootparams = [
-        'OHRTHR52',
-        'OHRTHR53',
-        'OHRTHR50',
-        'OHRTHR51',
-        'OHRTHR56',
-        'OHRTHR55',
-        'OHRTHR23',
-        'OHRTHR22',
-        'OHRTHR30',
-        'OHRTHR33',
-        'OHRTHR12',
-        'OHRTHR13',
-        'OHRTHR10',
-        'OHRTHR11',
-        'OHRTHR36',
-        'OHRTHR37',
-        'OHRTHR49',
-        'OHRTHR45',
-        'OHRTHR44',
-        'OHRTHR47',
-        'OHRTHR46',
-        'OHRTHR42',
-        'OHRTHR29',
-        'OHRTHR02',
-        'OHRTHR05',
-        'OHRTHR04',
-        'OHRTHR07',
-        'OHRTHR06',
-        'OHRTHR09',
-        'OHRTHR08',
-        'OHRTHR21',
-        'OHRTHR27',
-        'OHRTHR26',
-        'OHRTHR25',
-        'OHRTHR24',
-        'OHRTHR03',
+        "OHRTHR52",
+        "OHRTHR53",
+        "OHRTHR50",
+        "OHRTHR51",
+        "OHRTHR56",
+        "OHRTHR55",
+        "OHRTHR23",
+        "OHRTHR22",
+        "OHRTHR30",
+        "OHRTHR33",
+        "OHRTHR12",
+        "OHRTHR13",
+        "OHRTHR10",
+        "OHRTHR11",
+        "OHRTHR36",
+        "OHRTHR37",
+        "OHRTHR49",
+        "OHRTHR45",
+        "OHRTHR44",
+        "OHRTHR47",
+        "OHRTHR46",
+        "OHRTHR42",
+        "OHRTHR29",
+        "OHRTHR02",
+        "OHRTHR05",
+        "OHRTHR04",
+        "OHRTHR07",
+        "OHRTHR06",
+        "OHRTHR09",
+        "OHRTHR08",
+        "OHRTHR21",
+        "OHRTHR27",
+        "OHRTHR26",
+        "OHRTHR25",
+        "OHRTHR24",
+        "OHRTHR03",
     ]
     time_step = 32.8
 
@@ -412,53 +412,53 @@ class DP_HMAX35(DerivedParameterThermal):
 # --------------------------------------------
 class DP_HMCSAVE(DerivedParameterThermal):
     rootparams = [
-        'OHRTHR10',
-        'OHRTHR58',
-        'OHRTHR52',
-        'OHRTHR53',
-        'OHRTHR56',
-        'OHRTHR57',
-        'OHRTHR54',
-        'OHRTHR55',
-        'OHRTHR12',
-        'OHRTHR35',
-        'OHRTHR11',
-        'OHRTHR08',
-        'OHRTHR09',
-        'OHRTHR31',
-        'OHRTHR33',
-        'OHRTHR34',
-        'OHRTHR13',
-        'OHRTHR36',
-        'OHRTHR37',
+        "OHRTHR10",
+        "OHRTHR58",
+        "OHRTHR52",
+        "OHRTHR53",
+        "OHRTHR56",
+        "OHRTHR57",
+        "OHRTHR54",
+        "OHRTHR55",
+        "OHRTHR12",
+        "OHRTHR35",
+        "OHRTHR11",
+        "OHRTHR08",
+        "OHRTHR09",
+        "OHRTHR31",
+        "OHRTHR33",
+        "OHRTHR34",
+        "OHRTHR13",
+        "OHRTHR36",
+        "OHRTHR37",
     ]
     time_step = 32.8
 
     def calc(self, data):
         P_SUM = (
-            data['OHRTHR10'].vals
-            + data['OHRTHR11'].vals
-            + data['OHRTHR34'].vals
-            + data['OHRTHR35'].vals
-            + data['OHRTHR55'].vals
-            + data['OHRTHR56'].vals
+            data["OHRTHR10"].vals
+            + data["OHRTHR11"].vals
+            + data["OHRTHR34"].vals
+            + data["OHRTHR35"].vals
+            + data["OHRTHR55"].vals
+            + data["OHRTHR56"].vals
         )
         H_SUM = (
-            data['OHRTHR12'].vals
-            + data['OHRTHR13'].vals
-            + data['OHRTHR36'].vals
-            + data['OHRTHR37'].vals
-            + data['OHRTHR57'].vals
-            + data['OHRTHR58'].vals
+            data["OHRTHR12"].vals
+            + data["OHRTHR13"].vals
+            + data["OHRTHR36"].vals
+            + data["OHRTHR37"].vals
+            + data["OHRTHR57"].vals
+            + data["OHRTHR58"].vals
         )
         CAP_SUM = (
-            data['OHRTHR08'].vals
-            + data['OHRTHR09'].vals
-            + data['OHRTHR31'].vals
-            + data['OHRTHR33'].vals
-            + data['OHRTHR52'].vals
-            + data['OHRTHR53'].vals
-            + data['OHRTHR54'].vals
+            data["OHRTHR08"].vals
+            + data["OHRTHR09"].vals
+            + data["OHRTHR31"].vals
+            + data["OHRTHR33"].vals
+            + data["OHRTHR52"].vals
+            + data["OHRTHR53"].vals
+            + data["OHRTHR54"].vals
         )
         HMCSAVE = (CAP_SUM + P_SUM + H_SUM) / 19.0
         return HMCSAVE
@@ -467,42 +467,42 @@ class DP_HMCSAVE(DerivedParameterThermal):
 # --------------------------------------------
 class DP_HMIN35(DerivedParameterThermal):
     rootparams = [
-        'OHRTHR52',
-        'OHRTHR53',
-        'OHRTHR50',
-        'OHRTHR51',
-        'OHRTHR56',
-        'OHRTHR55',
-        'OHRTHR23',
-        'OHRTHR08',
-        'OHRTHR30',
-        'OHRTHR33',
-        'OHRTHR12',
-        'OHRTHR13',
-        'OHRTHR36',
-        'OHRTHR11',
-        'OHRTHR10',
-        'OHRTHR37',
-        'OHRTHR49',
-        'OHRTHR45',
-        'OHRTHR44',
-        'OHRTHR47',
-        'OHRTHR46',
-        'OHRTHR42',
-        'OHRTHR29',
-        'OHRTHR02',
-        'OHRTHR05',
-        'OHRTHR04',
-        'OHRTHR07',
-        'OHRTHR06',
-        'OHRTHR09',
-        'OHRTHR22',
-        'OHRTHR21',
-        'OHRTHR27',
-        'OHRTHR26',
-        'OHRTHR25',
-        'OHRTHR24',
-        'OHRTHR03',
+        "OHRTHR52",
+        "OHRTHR53",
+        "OHRTHR50",
+        "OHRTHR51",
+        "OHRTHR56",
+        "OHRTHR55",
+        "OHRTHR23",
+        "OHRTHR08",
+        "OHRTHR30",
+        "OHRTHR33",
+        "OHRTHR12",
+        "OHRTHR13",
+        "OHRTHR36",
+        "OHRTHR11",
+        "OHRTHR10",
+        "OHRTHR37",
+        "OHRTHR49",
+        "OHRTHR45",
+        "OHRTHR44",
+        "OHRTHR47",
+        "OHRTHR46",
+        "OHRTHR42",
+        "OHRTHR29",
+        "OHRTHR02",
+        "OHRTHR05",
+        "OHRTHR04",
+        "OHRTHR07",
+        "OHRTHR06",
+        "OHRTHR09",
+        "OHRTHR22",
+        "OHRTHR21",
+        "OHRTHR27",
+        "OHRTHR26",
+        "OHRTHR25",
+        "OHRTHR24",
+        "OHRTHR03",
     ]
     time_step = 32.8
 
@@ -516,42 +516,42 @@ class DP_HMIN35(DerivedParameterThermal):
 # --------------------------------------------
 class DP_HRMA_AVE(DerivedParameterThermal):
     rootparams = [
-        'OHRTHR52',
-        'OHRTHR53',
-        'OHRTHR50',
-        'OHRTHR51',
-        'OHRTHR56',
-        'OHRTHR55',
-        'OHRTHR09',
-        'OHRTHR08',
-        'OHRTHR30',
-        'OHRTHR33',
-        'OHRTHR12',
-        'OHRTHR13',
-        'OHRTHR10',
-        'OHRTHR11',
-        'OHRTHR36',
-        'OHRTHR37',
-        'OHRTHR49',
-        'OHRTHR45',
-        'OHRTHR44',
-        'OHRTHR47',
-        'OHRTHR46',
-        'OHRTHR42',
-        'OHRTHR29',
-        'OHRTHR02',
-        'OHRTHR05',
-        'OHRTHR04',
-        'OHRTHR07',
-        'OHRTHR06',
-        'OHRTHR23',
-        'OHRTHR22',
-        'OHRTHR21',
-        'OHRTHR27',
-        'OHRTHR26',
-        'OHRTHR25',
-        'OHRTHR24',
-        'OHRTHR03',
+        "OHRTHR52",
+        "OHRTHR53",
+        "OHRTHR50",
+        "OHRTHR51",
+        "OHRTHR56",
+        "OHRTHR55",
+        "OHRTHR09",
+        "OHRTHR08",
+        "OHRTHR30",
+        "OHRTHR33",
+        "OHRTHR12",
+        "OHRTHR13",
+        "OHRTHR10",
+        "OHRTHR11",
+        "OHRTHR36",
+        "OHRTHR37",
+        "OHRTHR49",
+        "OHRTHR45",
+        "OHRTHR44",
+        "OHRTHR47",
+        "OHRTHR46",
+        "OHRTHR42",
+        "OHRTHR29",
+        "OHRTHR02",
+        "OHRTHR05",
+        "OHRTHR04",
+        "OHRTHR07",
+        "OHRTHR06",
+        "OHRTHR23",
+        "OHRTHR22",
+        "OHRTHR21",
+        "OHRTHR27",
+        "OHRTHR26",
+        "OHRTHR25",
+        "OHRTHR24",
+        "OHRTHR03",
     ]
     time_step = 32.8
 
@@ -566,42 +566,42 @@ class DP_HRMA_AVE(DerivedParameterThermal):
 # --------------------------------------------
 class DP_HRMHCHK(DerivedParameterThermal):
     rootparams = [
-        'OHRTHR52',
-        'OHRTHR53',
-        'OHRTHR50',
-        'OHRTHR51',
-        'OHRTHR56',
-        'OHRTHR55',
-        'OHRTHR09',
-        'OHRTHR08',
-        'OHRTHR30',
-        'OHRTHR33',
-        'OHRTHR12',
-        'OHRTHR13',
-        'OHRTHR10',
-        'OHRTHR11',
-        'OHRTHR36',
-        'OHRTHR37',
-        'OHRTHR49',
-        'OHRTHR45',
-        'OHRTHR44',
-        'OHRTHR47',
-        'OHRTHR46',
-        'OHRTHR42',
-        'OHRTHR03',
-        'OHRTHR02',
-        'OHRTHR05',
-        'OHRTHR04',
-        'OHRTHR07',
-        'OHRTHR06',
-        'OHRTHR23',
-        'OHRTHR22',
-        'OHRTHR21',
-        'OHRTHR27',
-        'OHRTHR26',
-        'OHRTHR25',
-        'OHRTHR24',
-        'OHRTHR29',
+        "OHRTHR52",
+        "OHRTHR53",
+        "OHRTHR50",
+        "OHRTHR51",
+        "OHRTHR56",
+        "OHRTHR55",
+        "OHRTHR09",
+        "OHRTHR08",
+        "OHRTHR30",
+        "OHRTHR33",
+        "OHRTHR12",
+        "OHRTHR13",
+        "OHRTHR10",
+        "OHRTHR11",
+        "OHRTHR36",
+        "OHRTHR37",
+        "OHRTHR49",
+        "OHRTHR45",
+        "OHRTHR44",
+        "OHRTHR47",
+        "OHRTHR46",
+        "OHRTHR42",
+        "OHRTHR03",
+        "OHRTHR02",
+        "OHRTHR05",
+        "OHRTHR04",
+        "OHRTHR07",
+        "OHRTHR06",
+        "OHRTHR23",
+        "OHRTHR22",
+        "OHRTHR21",
+        "OHRTHR27",
+        "OHRTHR26",
+        "OHRTHR25",
+        "OHRTHR24",
+        "OHRTHR29",
     ]
     time_step = 32.8
 
@@ -619,47 +619,47 @@ class DP_HRMHCHK(DerivedParameterThermal):
 # --------------------------------------------
 class DP_OBAAG(DerivedParameterThermal):
     rootparams = [
-        '4RT704T',
-        '4RT705T',
-        '4RT708T',
-        '4RT707T',
-        '4RT709T',
-        '4RT711T',
-        '4RT700T',
-        '4RT702T',
-        '4RT701T',
-        '4RT703T',
-        'OOBTHR34',
-        'OOBTHR33',
-        'OOBTHR31',
-        'OOBTHR62',
-        'OOBTHR63',
-        '4RT706T',
-        '4RT710T',
+        "4RT704T",
+        "4RT705T",
+        "4RT708T",
+        "4RT707T",
+        "4RT709T",
+        "4RT711T",
+        "4RT700T",
+        "4RT702T",
+        "4RT701T",
+        "4RT703T",
+        "OOBTHR34",
+        "OOBTHR33",
+        "OOBTHR31",
+        "OOBTHR62",
+        "OOBTHR63",
+        "4RT706T",
+        "4RT710T",
     ]
     time_step = 32.8
 
     def calc(self, data):
         AVE2 = (
-            data['4RT705T'].vals
-            + data['4RT706T'].vals
-            + data['4RT707T'].vals
-            + data['4RT708T'].vals
-            + data['4RT709T'].vals
-            + data['4RT710T'].vals
-            + data['4RT711T'].vals
+            data["4RT705T"].vals
+            + data["4RT706T"].vals
+            + data["4RT707T"].vals
+            + data["4RT708T"].vals
+            + data["4RT709T"].vals
+            + data["4RT710T"].vals
+            + data["4RT711T"].vals
         )
         AVE1 = (
-            data['OOBTHR62'].vals
-            + data['OOBTHR63'].vals
-            + data['4RT700T'].vals
-            + data['4RT701T'].vals
-            + data['4RT702T'].vals
-            + data['4RT703T'].vals
-            + data['4RT704T'].vals
+            data["OOBTHR62"].vals
+            + data["OOBTHR63"].vals
+            + data["4RT700T"].vals
+            + data["4RT701T"].vals
+            + data["4RT702T"].vals
+            + data["4RT703T"].vals
+            + data["4RT704T"].vals
         )
         DIAVE = (
-            data['OOBTHR31'].vals + data['OOBTHR33'].vals + data['OOBTHR34'].vals
+            data["OOBTHR31"].vals + data["OOBTHR33"].vals + data["OOBTHR34"].vals
         ) / 3
         AXAVE = (AVE1 + AVE2) / 14
         OBAAG = AXAVE - DIAVE
@@ -669,29 +669,29 @@ class DP_OBAAG(DerivedParameterThermal):
 # --------------------------------------------
 class DP_OBAAGW(DerivedParameterThermal):
     rootparams = [
-        '4RT705T',
-        '4RT707T',
-        '4RT709T',
-        '4RT711T',
-        '4RT701T',
-        '4RT703T',
-        'OOBTHR34',
-        'OOBTHR33',
-        'OOBTHR31',
+        "4RT705T",
+        "4RT707T",
+        "4RT709T",
+        "4RT711T",
+        "4RT701T",
+        "4RT703T",
+        "OOBTHR34",
+        "OOBTHR33",
+        "OOBTHR31",
     ]
     time_step = 32.8
 
     def calc(self, data):
         AFT_FIT = (
-            data['OOBTHR31'].vals + data['OOBTHR33'].vals + data['OOBTHR34'].vals
+            data["OOBTHR31"].vals + data["OOBTHR33"].vals + data["OOBTHR34"].vals
         ) / 3
         FWD_FIT = (
-            data['4RT701T'].vals
-            + data['4RT703T'].vals
-            + data['4RT705T'].vals
-            + data['4RT707T'].vals
-            + data['4RT709T'].vals
-            + data['4RT711T'].vals
+            data["4RT701T"].vals
+            + data["4RT703T"].vals
+            + data["4RT705T"].vals
+            + data["4RT707T"].vals
+            + data["4RT709T"].vals
+            + data["4RT711T"].vals
         ) / 6
         OBAAGW = FWD_FIT - AFT_FIT
         return OBAAGW
@@ -700,59 +700,59 @@ class DP_OBAAGW(DerivedParameterThermal):
 # --------------------------------------------
 class DP_OBACAVE(DerivedParameterThermal):
     rootparams = [
-        'OOBTHR19',
-        'OOBTHR18',
-        'OOBTHR15',
-        'OOBTHR14',
-        'OOBTHR17',
-        'OOBTHR11',
-        'OOBTHR10',
-        'OOBTHR13',
-        'OOBTHR12',
-        'OOBTHR30',
-        'OOBTHR08',
-        'OOBTHR09',
-        'OOBTHR24',
-        'OOBTHR25',
-        'OOBTHR26',
-        'OOBTHR27',
-        'OOBTHR20',
-        'OOBTHR21',
-        'OOBTHR22',
-        'OOBTHR23',
-        'OOBTHR28',
-        'OOBTHR29',
+        "OOBTHR19",
+        "OOBTHR18",
+        "OOBTHR15",
+        "OOBTHR14",
+        "OOBTHR17",
+        "OOBTHR11",
+        "OOBTHR10",
+        "OOBTHR13",
+        "OOBTHR12",
+        "OOBTHR30",
+        "OOBTHR08",
+        "OOBTHR09",
+        "OOBTHR24",
+        "OOBTHR25",
+        "OOBTHR26",
+        "OOBTHR27",
+        "OOBTHR20",
+        "OOBTHR21",
+        "OOBTHR22",
+        "OOBTHR23",
+        "OOBTHR28",
+        "OOBTHR29",
     ]
     time_step = 32.8
 
     def calc(self, data):
         MIDCONE = (
-            data['OOBTHR19'].vals
-            + data['OOBTHR20'].vals
-            + data['OOBTHR21'].vals
-            + data['OOBTHR22'].vals
-            + data['OOBTHR23'].vals
-            + data['OOBTHR24'].vals
-            + data['OOBTHR25'].vals
+            data["OOBTHR19"].vals
+            + data["OOBTHR20"].vals
+            + data["OOBTHR21"].vals
+            + data["OOBTHR22"].vals
+            + data["OOBTHR23"].vals
+            + data["OOBTHR24"].vals
+            + data["OOBTHR25"].vals
         )
         AFTCONE = (
-            data['OOBTHR26'].vals
-            + data['OOBTHR27'].vals
-            + data['OOBTHR28'].vals
-            + data['OOBTHR29'].vals
-            + data['OOBTHR30'].vals
+            data["OOBTHR26"].vals
+            + data["OOBTHR27"].vals
+            + data["OOBTHR28"].vals
+            + data["OOBTHR29"].vals
+            + data["OOBTHR30"].vals
         )
         FWDCONE = (
-            data['OOBTHR08'].vals
-            + data['OOBTHR09'].vals
-            + data['OOBTHR10'].vals
-            + data['OOBTHR11'].vals
-            + data['OOBTHR12'].vals
-            + data['OOBTHR13'].vals
-            + data['OOBTHR14'].vals
-            + data['OOBTHR15'].vals
-            + data['OOBTHR17'].vals
-            + data['OOBTHR18'].vals
+            data["OOBTHR08"].vals
+            + data["OOBTHR09"].vals
+            + data["OOBTHR10"].vals
+            + data["OOBTHR11"].vals
+            + data["OOBTHR12"].vals
+            + data["OOBTHR13"].vals
+            + data["OOBTHR14"].vals
+            + data["OOBTHR15"].vals
+            + data["OOBTHR17"].vals
+            + data["OOBTHR18"].vals
         )
         OBACAVE = (FWDCONE + MIDCONE + AFTCONE) / 22
         return OBACAVE
@@ -761,79 +761,79 @@ class DP_OBACAVE(DerivedParameterThermal):
 # --------------------------------------------
 class DP_OBACAVEW(DerivedParameterThermal):
     rootparams = [
-        '4RT705T',
-        'OOBTHR19',
-        '4RT707T',
-        'OOBTHR15',
-        'OOBTHR14',
-        '4RT711T',
-        'OOBTHR11',
-        'OOBTHR10',
-        'OOBTHR13',
-        '4RT701T',
-        'OOBTHR34',
-        'OOBTHR33',
-        'OOBTHR31',
-        'OOBTHR30',
-        'OOBTHR18',
-        '4RT709T',
-        '4RT703T',
-        'OOBTHR17',
-        'OOBTHR08',
-        'OOBTHR09',
-        'OOBTHR24',
-        'OOBTHR25',
-        'OOBTHR26',
-        'OOBTHR27',
-        'OOBTHR20',
-        'OOBTHR21',
-        'OOBTHR22',
-        'OOBTHR23',
-        'OOBTHR12',
-        'OOBTHR28',
-        'OOBTHR29',
+        "4RT705T",
+        "OOBTHR19",
+        "4RT707T",
+        "OOBTHR15",
+        "OOBTHR14",
+        "4RT711T",
+        "OOBTHR11",
+        "OOBTHR10",
+        "OOBTHR13",
+        "4RT701T",
+        "OOBTHR34",
+        "OOBTHR33",
+        "OOBTHR31",
+        "OOBTHR30",
+        "OOBTHR18",
+        "4RT709T",
+        "4RT703T",
+        "OOBTHR17",
+        "OOBTHR08",
+        "OOBTHR09",
+        "OOBTHR24",
+        "OOBTHR25",
+        "OOBTHR26",
+        "OOBTHR27",
+        "OOBTHR20",
+        "OOBTHR21",
+        "OOBTHR22",
+        "OOBTHR23",
+        "OOBTHR12",
+        "OOBTHR28",
+        "OOBTHR29",
     ]
     time_step = 32.8
 
     def calc(self, data):
         FWD_FIT = (
-            data['4RT701T'].vals
-            + data['4RT703T'].vals
-            + data['4RT705T'].vals
-            + data['4RT707T'].vals
-            + data['4RT709T'].vals
-            + data['4RT711T'].vals
+            data["4RT701T"].vals
+            + data["4RT703T"].vals
+            + data["4RT705T"].vals
+            + data["4RT707T"].vals
+            + data["4RT709T"].vals
+            + data["4RT711T"].vals
         ) / 6
         AFTCONE = (
-            data['OOBTHR26'].vals
-            + data['OOBTHR27'].vals
-            + data['OOBTHR28'].vals
-            + data['OOBTHR29'].vals
-            + data['OOBTHR30'].vals
+            data["OOBTHR26"].vals
+            + data["OOBTHR27"].vals
+            + data["OOBTHR28"].vals
+            + data["OOBTHR29"].vals
+            + data["OOBTHR30"].vals
         )
         AFT_FIT = (
-            data['OOBTHR31'].vals + data['OOBTHR33'].vals + data['OOBTHR34'].vals
+            data["OOBTHR31"].vals + data["OOBTHR33"].vals + data["OOBTHR34"].vals
         ) / 3
         MIDCONE = (
-            data['OOBTHR19'].vals
-            + data['OOBTHR20'].vals
-            + data['OOBTHR21'].vals
-            + data['OOBTHR22'].vals
-            + data['OOBTHR23'].vals
-            + data['OOBTHR24'].vals
-            + data['OOBTHR25'].vals
+            data["OOBTHR19"].vals
+            + data["OOBTHR20"].vals
+            + data["OOBTHR21"].vals
+            + data["OOBTHR22"].vals
+            + data["OOBTHR23"].vals
+            + data["OOBTHR24"].vals
+            + data["OOBTHR25"].vals
         )
         FWDCONE = (
-            data['OOBTHR08'].vals
-            + data['OOBTHR09'].vals
-            + data['OOBTHR10'].vals
-            + data['OOBTHR11'].vals
-            + data['OOBTHR12'].vals
-            + data['OOBTHR13'].vals
-            + data['OOBTHR14'].vals
-            + data['OOBTHR15'].vals
-            + data['OOBTHR17'].vals
-            + data['OOBTHR18'].vals
+            data["OOBTHR08"].vals
+            + data["OOBTHR09"].vals
+            + data["OOBTHR10"].vals
+            + data["OOBTHR11"].vals
+            + data["OOBTHR12"].vals
+            + data["OOBTHR13"].vals
+            + data["OOBTHR14"].vals
+            + data["OOBTHR15"].vals
+            + data["OOBTHR17"].vals
+            + data["OOBTHR18"].vals
         )
         OBACAVE = (FWDCONE + MIDCONE + AFTCONE) / 22
         OBACAVEW = (OBACAVE * 148.0 - FWD_FIT * 70.0 - AFT_FIT * 29.0) / 49.0
@@ -843,39 +843,39 @@ class DP_OBACAVEW(DerivedParameterThermal):
 # --------------------------------------------
 class DP_OBADIG(DerivedParameterThermal):
     rootparams = [
-        'OOBTHR08',
-        'OOBTHR19',
-        'OOBTHR31',
-        'OOBTHR13',
-        'OOBTHR26',
-        'OOBTHR34',
-        'OOBTHR33',
-        'OOBTHR22',
-        'OOBTHR23',
-        'OOBTHR60',
-        'OOBTHR61',
-        'OOBTHR28',
-        'OOBTHR29',
+        "OOBTHR08",
+        "OOBTHR19",
+        "OOBTHR31",
+        "OOBTHR13",
+        "OOBTHR26",
+        "OOBTHR34",
+        "OOBTHR33",
+        "OOBTHR22",
+        "OOBTHR23",
+        "OOBTHR60",
+        "OOBTHR61",
+        "OOBTHR28",
+        "OOBTHR29",
     ]
     time_step = 32.8
 
     def calc(self, data):
         MZSAVE = (
-            data['OOBTHR08'].vals
-            + data['OOBTHR19'].vals
-            + data['OOBTHR26'].vals
-            + data['OOBTHR31'].vals
-            + data['OOBTHR60'].vals
+            data["OOBTHR08"].vals
+            + data["OOBTHR19"].vals
+            + data["OOBTHR26"].vals
+            + data["OOBTHR31"].vals
+            + data["OOBTHR60"].vals
         ) / 5
         PZSAVE = (
-            data['OOBTHR13'].vals
-            + data['OOBTHR22'].vals
-            + data['OOBTHR23'].vals
-            + data['OOBTHR28'].vals
-            + data['OOBTHR29'].vals
-            + data['OOBTHR61'].vals
-            + data['OOBTHR33'].vals
-            + data['OOBTHR34'].vals
+            data["OOBTHR13"].vals
+            + data["OOBTHR22"].vals
+            + data["OOBTHR23"].vals
+            + data["OOBTHR28"].vals
+            + data["OOBTHR29"].vals
+            + data["OOBTHR61"].vals
+            + data["OOBTHR33"].vals
+            + data["OOBTHR34"].vals
         ) / 8
         OBADIG = MZSAVE - PZSAVE
         return OBADIG
@@ -884,48 +884,48 @@ class DP_OBADIG(DerivedParameterThermal):
 # --------------------------------------------
 class DP_OBADIGW(DerivedParameterThermal):
     rootparams = [
-        'OOBTHR08',
-        '4RT705T',
-        'OOBTHR19',
-        '4RT707T',
-        'OOBTHR22',
-        '4RT711T',
-        'OOBTHR13',
-        '4RT701T',
-        'OOBTHR26',
-        'OOBTHR34',
-        'OOBTHR33',
-        'OOBTHR31',
-        'OOBTHR23',
-        'OOBTHR60',
-        'OOBTHR61',
-        'OOBTHR28',
-        'OOBTHR29',
+        "OOBTHR08",
+        "4RT705T",
+        "OOBTHR19",
+        "4RT707T",
+        "OOBTHR22",
+        "4RT711T",
+        "OOBTHR13",
+        "4RT701T",
+        "OOBTHR26",
+        "OOBTHR34",
+        "OOBTHR33",
+        "OOBTHR31",
+        "OOBTHR23",
+        "OOBTHR60",
+        "OOBTHR61",
+        "OOBTHR28",
+        "OOBTHR29",
     ]
     time_step = 32.8
 
     def calc(self, data):
-        FWD_FIT_PZ = (data['4RT705T'].vals + data['4RT707T'].vals) / 2.0 * 70.0
-        AFT_FIT_MZ = data['OOBTHR31'].vals * 29.0
+        FWD_FIT_PZ = (data["4RT705T"].vals + data["4RT707T"].vals) / 2.0 * 70.0
+        AFT_FIT_MZ = data["OOBTHR31"].vals * 29.0
         PZSAVE = (
-            data['OOBTHR13'].vals
-            + data['OOBTHR22'].vals
-            + data['OOBTHR23'].vals
-            + data['OOBTHR28'].vals
-            + data['OOBTHR29'].vals
-            + data['OOBTHR61'].vals
-            + data['OOBTHR33'].vals
-            + data['OOBTHR34'].vals
+            data["OOBTHR13"].vals
+            + data["OOBTHR22"].vals
+            + data["OOBTHR23"].vals
+            + data["OOBTHR28"].vals
+            + data["OOBTHR29"].vals
+            + data["OOBTHR61"].vals
+            + data["OOBTHR33"].vals
+            + data["OOBTHR34"].vals
         ) / 8
         MZSAVE = (
-            data['OOBTHR08'].vals
-            + data['OOBTHR19'].vals
-            + data['OOBTHR26'].vals
-            + data['OOBTHR31'].vals
-            + data['OOBTHR60'].vals
+            data["OOBTHR08"].vals
+            + data["OOBTHR19"].vals
+            + data["OOBTHR26"].vals
+            + data["OOBTHR31"].vals
+            + data["OOBTHR60"].vals
         ) / 5
-        AFT_FIT_PZ = (data['OOBTHR33'].vals + data['OOBTHR34'].vals) / 2 * 29.0
-        FWD_FIT_MZ = (data['4RT701T'].vals + data['4RT711T'].vals) / 2.0 * 70.0
+        AFT_FIT_PZ = (data["OOBTHR33"].vals + data["OOBTHR34"].vals) / 2 * 29.0
+        FWD_FIT_MZ = (data["4RT701T"].vals + data["4RT711T"].vals) / 2.0 * 70.0
         OBADIG = MZSAVE - PZSAVE
         OBADIGW = (
             OBADIG * 148.0 - (FWD_FIT_MZ - FWD_FIT_PZ) - (AFT_FIT_MZ - AFT_FIT_PZ)
@@ -936,41 +936,41 @@ class DP_OBADIGW(DerivedParameterThermal):
 # --------------------------------------------
 class DP_OBA_AVE(DerivedParameterThermal):
     rootparams = [
-        'OOBTHR19',
-        'OOBTHR18',
-        'OOBTHR15',
-        'OOBTHR14',
-        'OOBTHR17',
-        'OOBTHR11',
-        'OOBTHR10',
-        'OOBTHR13',
-        'OOBTHR12',
-        'OOBTHR37',
-        'OOBTHR36',
-        'OOBTHR35',
-        'OOBTHR34',
-        'OOBTHR33',
-        'OOBTHR31',
-        'OOBTHR30',
-        'OOBTHR39',
-        'OOBTHR38',
-        'OOBTHR08',
-        'OOBTHR09',
-        'OOBTHR24',
-        'OOBTHR25',
-        'OOBTHR26',
-        'OOBTHR27',
-        'OOBTHR20',
-        'OOBTHR21',
-        'OOBTHR22',
-        'OOBTHR23',
-        'OOBTHR46',
-        'OOBTHR44',
-        'OOBTHR45',
-        'OOBTHR28',
-        'OOBTHR29',
-        'OOBTHR40',
-        'OOBTHR41',
+        "OOBTHR19",
+        "OOBTHR18",
+        "OOBTHR15",
+        "OOBTHR14",
+        "OOBTHR17",
+        "OOBTHR11",
+        "OOBTHR10",
+        "OOBTHR13",
+        "OOBTHR12",
+        "OOBTHR37",
+        "OOBTHR36",
+        "OOBTHR35",
+        "OOBTHR34",
+        "OOBTHR33",
+        "OOBTHR31",
+        "OOBTHR30",
+        "OOBTHR39",
+        "OOBTHR38",
+        "OOBTHR08",
+        "OOBTHR09",
+        "OOBTHR24",
+        "OOBTHR25",
+        "OOBTHR26",
+        "OOBTHR27",
+        "OOBTHR20",
+        "OOBTHR21",
+        "OOBTHR22",
+        "OOBTHR23",
+        "OOBTHR46",
+        "OOBTHR44",
+        "OOBTHR45",
+        "OOBTHR28",
+        "OOBTHR29",
+        "OOBTHR40",
+        "OOBTHR41",
     ]
     time_step = 32.8
 
@@ -985,41 +985,41 @@ class DP_OBA_AVE(DerivedParameterThermal):
 # --------------------------------------------
 class DP_OMAX34(DerivedParameterThermal):
     rootparams = [
-        'OOBTHR19',
-        'OOBTHR18',
-        'OOBTHR15',
-        'OOBTHR14',
-        'OOBTHR17',
-        'OOBTHR11',
-        'OOBTHR10',
-        'OOBTHR13',
-        'OOBTHR12',
-        'OOBTHR37',
-        'OOBTHR36',
-        'OOBTHR35',
-        'OOBTHR34',
-        'OOBTHR33',
-        'OOBTHR31',
-        'OOBTHR30',
-        'OOBTHR39',
-        'OOBTHR38',
-        'OOBTHR28',
-        'OOBTHR08',
-        'OOBTHR09',
-        'OOBTHR24',
-        'OOBTHR25',
-        'OOBTHR26',
-        'OOBTHR27',
-        'OOBTHR20',
-        'OOBTHR21',
-        'OOBTHR22',
-        'OOBTHR23',
-        'OOBTHR46',
-        'OOBTHR45',
-        'OOBTHR42',
-        'OOBTHR29',
-        'OOBTHR40',
-        'OOBTHR41',
+        "OOBTHR19",
+        "OOBTHR18",
+        "OOBTHR15",
+        "OOBTHR14",
+        "OOBTHR17",
+        "OOBTHR11",
+        "OOBTHR10",
+        "OOBTHR13",
+        "OOBTHR12",
+        "OOBTHR37",
+        "OOBTHR36",
+        "OOBTHR35",
+        "OOBTHR34",
+        "OOBTHR33",
+        "OOBTHR31",
+        "OOBTHR30",
+        "OOBTHR39",
+        "OOBTHR38",
+        "OOBTHR28",
+        "OOBTHR08",
+        "OOBTHR09",
+        "OOBTHR24",
+        "OOBTHR25",
+        "OOBTHR26",
+        "OOBTHR27",
+        "OOBTHR20",
+        "OOBTHR21",
+        "OOBTHR22",
+        "OOBTHR23",
+        "OOBTHR46",
+        "OOBTHR45",
+        "OOBTHR42",
+        "OOBTHR29",
+        "OOBTHR40",
+        "OOBTHR41",
     ]
     time_step = 32.8
 
@@ -1033,41 +1033,41 @@ class DP_OMAX34(DerivedParameterThermal):
 # --------------------------------------------
 class DP_OMIN34(DerivedParameterThermal):
     rootparams = [
-        'OOBTHR19',
-        'OOBTHR18',
-        'OOBTHR15',
-        'OOBTHR14',
-        'OOBTHR17',
-        'OOBTHR11',
-        'OOBTHR10',
-        'OOBTHR13',
-        'OOBTHR12',
-        'OOBTHR37',
-        'OOBTHR36',
-        'OOBTHR35',
-        'OOBTHR34',
-        'OOBTHR33',
-        'OOBTHR31',
-        'OOBTHR30',
-        'OOBTHR39',
-        'OOBTHR38',
-        'OOBTHR28',
-        'OOBTHR08',
-        'OOBTHR09',
-        'OOBTHR24',
-        'OOBTHR25',
-        'OOBTHR26',
-        'OOBTHR27',
-        'OOBTHR20',
-        'OOBTHR21',
-        'OOBTHR22',
-        'OOBTHR23',
-        'OOBTHR46',
-        'OOBTHR45',
-        'OOBTHR42',
-        'OOBTHR29',
-        'OOBTHR40',
-        'OOBTHR41',
+        "OOBTHR19",
+        "OOBTHR18",
+        "OOBTHR15",
+        "OOBTHR14",
+        "OOBTHR17",
+        "OOBTHR11",
+        "OOBTHR10",
+        "OOBTHR13",
+        "OOBTHR12",
+        "OOBTHR37",
+        "OOBTHR36",
+        "OOBTHR35",
+        "OOBTHR34",
+        "OOBTHR33",
+        "OOBTHR31",
+        "OOBTHR30",
+        "OOBTHR39",
+        "OOBTHR38",
+        "OOBTHR28",
+        "OOBTHR08",
+        "OOBTHR09",
+        "OOBTHR24",
+        "OOBTHR25",
+        "OOBTHR26",
+        "OOBTHR27",
+        "OOBTHR20",
+        "OOBTHR21",
+        "OOBTHR22",
+        "OOBTHR23",
+        "OOBTHR46",
+        "OOBTHR45",
+        "OOBTHR42",
+        "OOBTHR29",
+        "OOBTHR40",
+        "OOBTHR41",
     ]
     time_step = 32.8
 
@@ -1082,833 +1082,833 @@ class DP_OMIN34(DerivedParameterThermal):
 class DP_P01(DerivedParameterThermal):
     """Zone 1 heater power"""
 
-    rootparams = ['ELBV', '4OHTRZ01']
+    rootparams = ["ELBV", "4OHTRZ01"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P01 = data['4OHTRZ01'].vals * VSQUARED / 110.2
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P01 = data["4OHTRZ01"].vals * VSQUARED / 110.2
         return P01
 
 
 # --------------------------------------------
 class DP_P02(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ02']
+    rootparams = ["ELBV", "4OHTRZ02"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P02 = data['4OHTRZ02'].vals * VSQUARED / 109.7
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P02 = data["4OHTRZ02"].vals * VSQUARED / 109.7
         return P02
 
 
 # --------------------------------------------
 class DP_P03(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ03']
+    rootparams = ["ELBV", "4OHTRZ03"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P03 = data['4OHTRZ03'].vals * VSQUARED / 109.4
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P03 = data["4OHTRZ03"].vals * VSQUARED / 109.4
         return P03
 
 
 # --------------------------------------------
 class DP_P04(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ04']
+    rootparams = ["ELBV", "4OHTRZ04"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P04 = data['4OHTRZ04'].vals * VSQUARED / 175.9
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P04 = data["4OHTRZ04"].vals * VSQUARED / 175.9
         return P04
 
 
 # --------------------------------------------
 class DP_P05(DerivedParameterThermal):
-    rootparams = ['4OHTRZ05', 'ELBV']
+    rootparams = ["4OHTRZ05", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P05 = data['4OHTRZ05'].vals * VSQUARED / 175.7
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P05 = data["4OHTRZ05"].vals * VSQUARED / 175.7
         return P05
 
 
 # --------------------------------------------
 class DP_P06(DerivedParameterThermal):
-    rootparams = ['4OHTRZ06', 'ELBV']
+    rootparams = ["4OHTRZ06", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P06 = data['4OHTRZ06'].vals * VSQUARED / 175.6
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P06 = data["4OHTRZ06"].vals * VSQUARED / 175.6
         return P06
 
 
 # --------------------------------------------
 class DP_P07(DerivedParameterThermal):
-    rootparams = ['4OHTRZ07', 'ELBV']
+    rootparams = ["4OHTRZ07", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P07 = data['4OHTRZ07'].vals * VSQUARED / 135.8
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P07 = data["4OHTRZ07"].vals * VSQUARED / 135.8
         return P07
 
 
 # --------------------------------------------
 class DP_P08(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ08']
+    rootparams = ["ELBV", "4OHTRZ08"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P08 = data['4OHTRZ08'].vals * VSQUARED / 36.1
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P08 = data["4OHTRZ08"].vals * VSQUARED / 36.1
         return P08
 
 
 # --------------------------------------------
 class DP_P09(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ09']
+    rootparams = ["ELBV", "4OHTRZ09"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P09 = data['4OHTRZ09'].vals * VSQUARED / 32.6
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P09 = data["4OHTRZ09"].vals * VSQUARED / 32.6
         return P09
 
 
 # --------------------------------------------
 class DP_P10(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ10']
+    rootparams = ["ELBV", "4OHTRZ10"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P10 = data['4OHTRZ10'].vals * VSQUARED / 34.9
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P10 = data["4OHTRZ10"].vals * VSQUARED / 34.9
         return P10
 
 
 # --------------------------------------------
 class DP_P11(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ11']
+    rootparams = ["ELBV", "4OHTRZ11"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P11 = data['4OHTRZ11'].vals * VSQUARED / 39.4
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P11 = data["4OHTRZ11"].vals * VSQUARED / 39.4
         return P11
 
 
 # --------------------------------------------
 class DP_P12(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ12']
+    rootparams = ["ELBV", "4OHTRZ12"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P12 = data['4OHTRZ12'].vals * VSQUARED / 40.3
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P12 = data["4OHTRZ12"].vals * VSQUARED / 40.3
         return P12
 
 
 # --------------------------------------------
 class DP_P13(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ13']
+    rootparams = ["ELBV", "4OHTRZ13"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P13 = data['4OHTRZ13'].vals * VSQUARED / 39.7
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P13 = data["4OHTRZ13"].vals * VSQUARED / 39.7
         return P13
 
 
 # --------------------------------------------
 class DP_P14(DerivedParameterThermal):
-    rootparams = ['4OHTRZ14', 'ELBV']
+    rootparams = ["4OHTRZ14", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P14 = data['4OHTRZ14'].vals * VSQUARED / 41.2
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P14 = data["4OHTRZ14"].vals * VSQUARED / 41.2
         return P14
 
 
 # --------------------------------------------
 class DP_P15(DerivedParameterThermal):
-    rootparams = ['4OHTRZ15', 'ELBV']
+    rootparams = ["4OHTRZ15", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P15 = data['4OHTRZ15'].vals * VSQUARED / 40.5
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P15 = data["4OHTRZ15"].vals * VSQUARED / 40.5
         return P15
 
 
 # --------------------------------------------
 class DP_P16(DerivedParameterThermal):
-    rootparams = ['4OHTRZ16', 'ELBV']
+    rootparams = ["4OHTRZ16", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P16 = data['4OHTRZ16'].vals * VSQUARED / 41.3
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P16 = data["4OHTRZ16"].vals * VSQUARED / 41.3
         return P16
 
 
 # --------------------------------------------
 class DP_P17(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ17']
+    rootparams = ["ELBV", "4OHTRZ17"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P17 = data['4OHTRZ17'].vals * VSQUARED / 116.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P17 = data["4OHTRZ17"].vals * VSQUARED / 116.0
         return P17
 
 
 # --------------------------------------------
 class DP_P18(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ18']
+    rootparams = ["ELBV", "4OHTRZ18"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P18 = data['4OHTRZ18'].vals * VSQUARED / 115.7
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P18 = data["4OHTRZ18"].vals * VSQUARED / 115.7
         return P18
 
 
 # --------------------------------------------
 class DP_P19(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ19']
+    rootparams = ["ELBV", "4OHTRZ19"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P19 = data['4OHTRZ19'].vals * VSQUARED / 95.3
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P19 = data["4OHTRZ19"].vals * VSQUARED / 95.3
         return P19
 
 
 # --------------------------------------------
 class DP_P20(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ20']
+    rootparams = ["ELBV", "4OHTRZ20"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P20 = data['4OHTRZ20'].vals * VSQUARED / 379.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P20 = data["4OHTRZ20"].vals * VSQUARED / 379.0
         return P20
 
 
 # --------------------------------------------
 class DP_P23(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ23']
+    rootparams = ["ELBV", "4OHTRZ23"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P23 = data['4OHTRZ23'].vals * VSQUARED / 386.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P23 = data["4OHTRZ23"].vals * VSQUARED / 386.0
         return P23
 
 
 # --------------------------------------------
 class DP_P24(DerivedParameterThermal):
-    rootparams = ['4OHTRZ24', 'ELBV']
+    rootparams = ["4OHTRZ24", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P24 = data['4OHTRZ24'].vals * VSQUARED / 385.8
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P24 = data["4OHTRZ24"].vals * VSQUARED / 385.8
         return P24
 
 
 # --------------------------------------------
 class DP_P25(DerivedParameterThermal):
-    rootparams = ['4OHTRZ25', 'ELBV']
+    rootparams = ["4OHTRZ25", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P25 = data['4OHTRZ25'].vals * VSQUARED / 383.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P25 = data["4OHTRZ25"].vals * VSQUARED / 383.0
         return P25
 
 
 # --------------------------------------------
 class DP_P26(DerivedParameterThermal):
-    rootparams = ['4OHTRZ26', 'ELBV']
+    rootparams = ["4OHTRZ26", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P26 = data['4OHTRZ26'].vals * VSQUARED / 383.5
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P26 = data["4OHTRZ26"].vals * VSQUARED / 383.5
         return P26
 
 
 # --------------------------------------------
 class DP_P27(DerivedParameterThermal):
-    rootparams = ['4OHTRZ27', 'ELBV', '4S1PWR05', '4S1PWR06']
+    rootparams = ["4OHTRZ27", "ELBV", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P27 = data['4OHTRZ27'].vals * VSQUARED / 383.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P27 = data["4OHTRZ27"].vals * VSQUARED / 383.0
         return P27
 
 
 # --------------------------------------------
 class DP_P28(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ28', '4S1PWR05', '4S1PWR06']
+    rootparams = ["ELBV", "4OHTRZ28", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P28 = data['4OHTRZ28'].vals * VSQUARED / 382.3
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P28 = data["4OHTRZ28"].vals * VSQUARED / 382.3
         return P28
 
 
 # --------------------------------------------
 class DP_P29(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ29', '4S1PWR05', '4S1PWR06']
+    rootparams = ["ELBV", "4OHTRZ29", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P29 = data['4OHTRZ29'].vals * VSQUARED / 384.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P29 = data["4OHTRZ29"].vals * VSQUARED / 384.0
         return P29
 
 
 # --------------------------------------------
 class DP_P30(DerivedParameterThermal):
-    rootparams = ['4OHTRZ30', 'ELBV']
+    rootparams = ["4OHTRZ30", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P30 = data['4OHTRZ30'].vals * VSQUARED / 383.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P30 = data["4OHTRZ30"].vals * VSQUARED / 383.0
         return P30
 
 
 # --------------------------------------------
 class DP_P31(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ31']
+    rootparams = ["ELBV", "4OHTRZ31"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P31 = data['4OHTRZ31'].vals * VSQUARED / 32.2
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P31 = data["4OHTRZ31"].vals * VSQUARED / 32.2
         return P31
 
 
 # --------------------------------------------
 class DP_P32(DerivedParameterThermal):
-    rootparams = ['4OHTRZ32', 'ELBV']
+    rootparams = ["4OHTRZ32", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P32 = data['4OHTRZ32'].vals * VSQUARED / 28.6
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P32 = data["4OHTRZ32"].vals * VSQUARED / 28.6
         return P32
 
 
 # --------------------------------------------
 class DP_P33(DerivedParameterThermal):
-    rootparams = ['4OHTRZ33', 'ELBV']
+    rootparams = ["4OHTRZ33", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P33 = data['4OHTRZ33'].vals * VSQUARED / 36.9
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P33 = data["4OHTRZ33"].vals * VSQUARED / 36.9
         return P33
 
 
 # --------------------------------------------
 class DP_P34(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ34']
+    rootparams = ["ELBV", "4OHTRZ34"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P34 = data['4OHTRZ34'].vals * VSQUARED / 28.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P34 = data["4OHTRZ34"].vals * VSQUARED / 28.0
         return P34
 
 
 # --------------------------------------------
 class DP_P35(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ35', '4S1PWR05', '4S1PWR06']
+    rootparams = ["ELBV", "4OHTRZ35", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P35 = data['4OHTRZ35'].vals * VSQUARED / 32.2
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P35 = data["4OHTRZ35"].vals * VSQUARED / 32.2
         return P35
 
 
 # --------------------------------------------
 class DP_P36(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ36']
+    rootparams = ["ELBV", "4OHTRZ36"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P36 = data['4OHTRZ36'].vals * VSQUARED / 44.3
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P36 = data["4OHTRZ36"].vals * VSQUARED / 44.3
         return P36
 
 
 # --------------------------------------------
 class DP_P37(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ37']
+    rootparams = ["ELBV", "4OHTRZ37"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P37 = data['4OHTRZ37'].vals * VSQUARED / 32.1
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P37 = data["4OHTRZ37"].vals * VSQUARED / 32.1
         return P37
 
 
 # --------------------------------------------
 class DP_P38(DerivedParameterThermal):
-    rootparams = ['4OHTRZ38', 'ELBV']
+    rootparams = ["4OHTRZ38", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P38 = data['4OHTRZ38'].vals * VSQUARED / 27.8
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P38 = data["4OHTRZ38"].vals * VSQUARED / 27.8
         return P38
 
 
 # --------------------------------------------
 class DP_P39(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ39']
+    rootparams = ["ELBV", "4OHTRZ39"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P39 = data['4OHTRZ39'].vals * VSQUARED / 36.8
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P39 = data["4OHTRZ39"].vals * VSQUARED / 36.8
         return P39
 
 
 # --------------------------------------------
 class DP_P40(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ40']
+    rootparams = ["ELBV", "4OHTRZ40"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P40 = data['4OHTRZ40'].vals * VSQUARED / 28.3
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P40 = data["4OHTRZ40"].vals * VSQUARED / 28.3
         return P40
 
 
 # --------------------------------------------
 class DP_P41(DerivedParameterThermal):
-    rootparams = ['4OHTRZ41', 'ELBV']
+    rootparams = ["4OHTRZ41", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P41 = data['4OHTRZ41'].vals * VSQUARED / 61.7
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P41 = data["4OHTRZ41"].vals * VSQUARED / 61.7
         return P41
 
 
 # --------------------------------------------
 class DP_P42(DerivedParameterThermal):
-    rootparams = ['4OHTRZ42', 'ELBV', '4S1PWR05', '4S1PWR06']
+    rootparams = ["4OHTRZ42", "ELBV", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P42 = data['4OHTRZ42'].vals * VSQUARED / 51.7
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P42 = data["4OHTRZ42"].vals * VSQUARED / 51.7
         return P42
 
 
 # --------------------------------------------
 class DP_P43(DerivedParameterThermal):
-    rootparams = ['4OHTRZ43', 'ELBV', '4S1PWR05', '4S1PWR06']
+    rootparams = ["4OHTRZ43", "ELBV", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P43 = data['4OHTRZ43'].vals * VSQUARED / 36.8
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P43 = data["4OHTRZ43"].vals * VSQUARED / 36.8
         return P43
 
 
 # --------------------------------------------
 class DP_P44(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ44', '4S1PWR05', '4S1PWR06']
+    rootparams = ["ELBV", "4OHTRZ44", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P44 = data['4OHTRZ44'].vals * VSQUARED / 36.9
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P44 = data["4OHTRZ44"].vals * VSQUARED / 36.9
         return P44
 
 
 # --------------------------------------------
 class DP_P45(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ45', '4S1PWR05', '4S1PWR06']
+    rootparams = ["ELBV", "4OHTRZ45", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P45 = data['4OHTRZ45'].vals * VSQUARED / 36.8
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P45 = data["4OHTRZ45"].vals * VSQUARED / 36.8
         return P45
 
 
 # --------------------------------------------
 class DP_P46(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ46', '4S1PWR05', '4S1PWR06']
+    rootparams = ["ELBV", "4OHTRZ46", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P46 = data['4OHTRZ46'].vals * VSQUARED / 36.5
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P46 = data["4OHTRZ46"].vals * VSQUARED / 36.5
         return P46
 
 
 # --------------------------------------------
 class DP_P47(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ47', '4S1PWR05', '4S1PWR06']
+    rootparams = ["ELBV", "4OHTRZ47", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P47 = data['4OHTRZ47'].vals * VSQUARED / 52.3
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P47 = data["4OHTRZ47"].vals * VSQUARED / 52.3
         return P47
 
 
 # --------------------------------------------
 class DP_P48(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ48', '4S1PWR05', '4S1PWR06']
+    rootparams = ["ELBV", "4OHTRZ48", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P48 = data['4OHTRZ48'].vals * VSQUARED / 79.5
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P48 = data["4OHTRZ48"].vals * VSQUARED / 79.5
         return P48
 
 
 # --------------------------------------------
 class DP_P49(DerivedParameterThermal):
-    rootparams = ['4OHTRZ49', 'ELBV', '4S1PWR05', '4S1PWR06']
+    rootparams = ["4OHTRZ49", "ELBV", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P49 = data['4OHTRZ49'].vals * VSQUARED / 34.8
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P49 = data["4OHTRZ49"].vals * VSQUARED / 34.8
         return P49
 
 
 # --------------------------------------------
 class DP_P50(DerivedParameterThermal):
-    rootparams = ['4OHTRZ50', 'ELBV', '4S1PWR05', '4S1PWR06']
+    rootparams = ["4OHTRZ50", "ELBV", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_4OHTRZ50(data)
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P50 = data['4OHTRZ50'].vals * VSQUARED / 35.2
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P50 = data["4OHTRZ50"].vals * VSQUARED / 35.2
         return P50
 
 
 # --------------------------------------------
 class DP_P51(DerivedParameterThermal):
-    rootparams = ['4OHTRZ51', 'ELBV']
+    rootparams = ["4OHTRZ51", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P51 = data['4OHTRZ51'].vals * VSQUARED / 35.4
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P51 = data["4OHTRZ51"].vals * VSQUARED / 35.4
         return P51
 
 
 # --------------------------------------------
 class DP_P52(DerivedParameterThermal):
-    rootparams = ['4OHTRZ52', 'ELBV', '4S1PWR05', '4S1PWR06']
+    rootparams = ["4OHTRZ52", "ELBV", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P52 = data['4OHTRZ52'].vals * VSQUARED / 34.4
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P52 = data["4OHTRZ52"].vals * VSQUARED / 34.4
         return P52
 
 
 # --------------------------------------------
 class DP_P53(DerivedParameterThermal):
-    rootparams = ['4OHTRZ53', 'ELBV', '4S1PWR05', '4S1PWR06']
+    rootparams = ["4OHTRZ53", "ELBV", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P53 = data['4OHTRZ53'].vals * VSQUARED / 94.1
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P53 = data["4OHTRZ53"].vals * VSQUARED / 94.1
         return P53
 
 
 # --------------------------------------------
 class DP_P54(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ54', '4S1PWR05', '4S1PWR06']
+    rootparams = ["ELBV", "4OHTRZ54", "4S1PWR05", "4S1PWR06"]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P54 = data['4OHTRZ54'].vals * VSQUARED / 124.4
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P54 = data["4OHTRZ54"].vals * VSQUARED / 124.4
         return P54
 
 
 # --------------------------------------------
 class DP_P55(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ55']
+    rootparams = ["ELBV", "4OHTRZ55"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P55 = data['4OHTRZ55'].vals * VSQUARED / 126.8
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P55 = data["4OHTRZ55"].vals * VSQUARED / 126.8
         return P55
 
 
 # --------------------------------------------
 class DP_P57(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ57']
+    rootparams = ["ELBV", "4OHTRZ57"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P57 = data['4OHTRZ57'].vals * VSQUARED / 142.3
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P57 = data["4OHTRZ57"].vals * VSQUARED / 142.3
         return P57
 
 
 # --------------------------------------------
 class DP_P58(DerivedParameterThermal):
-    rootparams = ['4OHTRZ58', 'ELBV']
+    rootparams = ["4OHTRZ58", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P58 = data['4OHTRZ58'].vals * VSQUARED / 83.7
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P58 = data["4OHTRZ58"].vals * VSQUARED / 83.7
         return P58
 
 
 # --------------------------------------------
 class DP_P59(DerivedParameterThermal):
-    rootparams = ['4OHTRZ59', 'ELBV']
+    rootparams = ["4OHTRZ59", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P59 = data['4OHTRZ59'].vals * VSQUARED / 29.7
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P59 = data["4OHTRZ59"].vals * VSQUARED / 29.7
         return P59
 
 
 # --------------------------------------------
 class DP_P60(DerivedParameterThermal):
-    rootparams = ['4OHTRZ60', 'ELBV']
+    rootparams = ["4OHTRZ60", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P60 = data['4OHTRZ60'].vals * VSQUARED / 30.7
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P60 = data["4OHTRZ60"].vals * VSQUARED / 30.7
         return P60
 
 
 # --------------------------------------------
 class DP_P61(DerivedParameterThermal):
-    rootparams = ['4OHTRZ61', 'ELBV']
+    rootparams = ["4OHTRZ61", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P61 = data['4OHTRZ61'].vals * VSQUARED / 33.7
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P61 = data["4OHTRZ61"].vals * VSQUARED / 33.7
         return P61
 
 
 # --------------------------------------------
 class DP_P62(DerivedParameterThermal):
-    rootparams = ['4OHTRZ62', 'ELBV']
+    rootparams = ["4OHTRZ62", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P62 = data['4OHTRZ62'].vals * VSQUARED / 36.1
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P62 = data["4OHTRZ62"].vals * VSQUARED / 36.1
         return P62
 
 
 # --------------------------------------------
 class DP_P63(DerivedParameterThermal):
-    rootparams = ['4OHTRZ63', 'ELBV']
+    rootparams = ["4OHTRZ63", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P63 = data['4OHTRZ63'].vals * VSQUARED / 36.1
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P63 = data["4OHTRZ63"].vals * VSQUARED / 36.1
         return P63
 
 
 # --------------------------------------------
 class DP_P64(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ64']
+    rootparams = ["ELBV", "4OHTRZ64"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P64 = data['4OHTRZ64'].vals * VSQUARED / 44.1
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P64 = data["4OHTRZ64"].vals * VSQUARED / 44.1
         return P64
 
 
 # --------------------------------------------
 class DP_P65(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ65']
+    rootparams = ["ELBV", "4OHTRZ65"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P65 = data['4OHTRZ65'].vals * VSQUARED / 37.5
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P65 = data["4OHTRZ65"].vals * VSQUARED / 37.5
         return P65
 
 
 # --------------------------------------------
 class DP_P66(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ66']
+    rootparams = ["ELBV", "4OHTRZ66"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P66 = data['4OHTRZ66'].vals * VSQUARED / 29.8
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P66 = data["4OHTRZ66"].vals * VSQUARED / 29.8
         return P66
 
 
 # --------------------------------------------
 class DP_P67(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ67']
+    rootparams = ["ELBV", "4OHTRZ67"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P67 = data['4OHTRZ67'].vals * VSQUARED / 52.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P67 = data["4OHTRZ67"].vals * VSQUARED / 52.0
         return P67
 
 
 # --------------------------------------------
 class DP_P68(DerivedParameterThermal):
-    rootparams = ['4OHTRZ68', 'ELBV']
+    rootparams = ["4OHTRZ68", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P68 = data['4OHTRZ68'].vals * VSQUARED / 29.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P68 = data["4OHTRZ68"].vals * VSQUARED / 29.0
         return P68
 
 
 # --------------------------------------------
 class DP_P69(DerivedParameterThermal):
-    rootparams = ['4OHTRZ69', 'ELBV']
+    rootparams = ["4OHTRZ69", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P69 = data['4OHTRZ69'].vals * VSQUARED / 37.5
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P69 = data["4OHTRZ69"].vals * VSQUARED / 37.5
         return P69
 
 
 # --------------------------------------------
 class DP_P75(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ75']
+    rootparams = ["ELBV", "4OHTRZ75"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P75 = data['4OHTRZ75'].vals * VSQUARED / 130.2
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P75 = data["4OHTRZ75"].vals * VSQUARED / 130.2
         return P75
 
 
 # --------------------------------------------
 class DP_P76(DerivedParameterThermal):
-    rootparams = ['4OHTRZ76', 'ELBV']
+    rootparams = ["4OHTRZ76", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P76 = data['4OHTRZ76'].vals * VSQUARED / 133.4
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P76 = data["4OHTRZ76"].vals * VSQUARED / 133.4
         return P76
 
 
 # --------------------------------------------
 class DP_P77(DerivedParameterThermal):
-    rootparams = ['4OHTRZ77', 'ELBV']
+    rootparams = ["4OHTRZ77", "ELBV"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P77 = data['4OHTRZ77'].vals * VSQUARED / 131.5
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P77 = data["4OHTRZ77"].vals * VSQUARED / 131.5
         return P77
 
 
 # --------------------------------------------
 class DP_P78(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ78']
+    rootparams = ["ELBV", "4OHTRZ78"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P78 = data['4OHTRZ78'].vals * VSQUARED / 133.2
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P78 = data["4OHTRZ78"].vals * VSQUARED / 133.2
         return P78
 
 
 # --------------------------------------------
 class DP_P79(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ79']
+    rootparams = ["ELBV", "4OHTRZ79"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P79 = data['4OHTRZ79'].vals * VSQUARED / 133.1
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P79 = data["4OHTRZ79"].vals * VSQUARED / 133.1
         return P79
 
 
 # --------------------------------------------
 class DP_P80(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ80']
+    rootparams = ["ELBV", "4OHTRZ80"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P80 = data['4OHTRZ80'].vals * VSQUARED / 133.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P80 = data["4OHTRZ80"].vals * VSQUARED / 133.0
         return P80
 
 
 # --------------------------------------------
 class DP_PABH(DerivedParameterThermal):
     rootparams = [
-        'ELBV',
-        '4OHTRZ53',
-        '4OHTRZ54',
-        '4OHTRZ55',
-        '4OHTRZ57',
-        '4S1PWR05',
-        '4S1PWR06',
+        "ELBV",
+        "4OHTRZ53",
+        "4OHTRZ54",
+        "4OHTRZ55",
+        "4OHTRZ57",
+        "4S1PWR05",
+        "4S1PWR06",
     ]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P53 = data['4OHTRZ53'].vals * VSQUARED / 94.1
-        P54 = data['4OHTRZ54'].vals * VSQUARED / 124.4
-        P55 = data['4OHTRZ55'].vals * VSQUARED / 126.8
-        P57 = data['4OHTRZ57'].vals * VSQUARED / 142.3
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P53 = data["4OHTRZ53"].vals * VSQUARED / 94.1
+        P54 = data["4OHTRZ54"].vals * VSQUARED / 124.4
+        P55 = data["4OHTRZ55"].vals * VSQUARED / 126.8
+        P57 = data["4OHTRZ57"].vals * VSQUARED / 142.3
         PABH = P53 + P54 + P55 + P57
         return PABH
 
@@ -1916,68 +1916,68 @@ class DP_PABH(DerivedParameterThermal):
 # --------------------------------------------
 class DP_PAFTCONE(DerivedParameterThermal):
     rootparams = [
-        'ELBV',
-        '4OHTRZ48',
-        '4OHTRZ49',
-        '4OHTRZ50',
-        '4OHTRZ51',
-        '4OHTRZ52',
-        '4S1PWR05',
-        '4S1PWR06',
+        "ELBV",
+        "4OHTRZ48",
+        "4OHTRZ49",
+        "4OHTRZ50",
+        "4OHTRZ51",
+        "4OHTRZ52",
+        "4S1PWR05",
+        "4S1PWR06",
     ]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_4OHTRZ50(data)
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P48 = data['4OHTRZ48'].vals * VSQUARED / 79.5
-        P49 = data['4OHTRZ49'].vals * VSQUARED / 34.8
-        P50 = data['4OHTRZ50'].vals * VSQUARED / 35.2
-        P51 = data['4OHTRZ51'].vals * VSQUARED / 35.4
-        P52 = data['4OHTRZ52'].vals * VSQUARED / 34.4
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P48 = data["4OHTRZ48"].vals * VSQUARED / 79.5
+        P49 = data["4OHTRZ49"].vals * VSQUARED / 34.8
+        P50 = data["4OHTRZ50"].vals * VSQUARED / 35.2
+        P51 = data["4OHTRZ51"].vals * VSQUARED / 35.4
+        P52 = data["4OHTRZ52"].vals * VSQUARED / 34.4
         PAFTCONE = P48 + P49 + P50 + P51 + P52
         return PAFTCONE
 
 
 # --------------------------------------------
 class DP_PAFTCYL(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ66', '4OHTRZ67', '4OHTRZ68']
+    rootparams = ["ELBV", "4OHTRZ66", "4OHTRZ67", "4OHTRZ68"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P66 = data['4OHTRZ66'].vals * VSQUARED / 29.8
-        P67 = data['4OHTRZ67'].vals * VSQUARED / 52.0
-        P68 = data['4OHTRZ68'].vals * VSQUARED / 29.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P66 = data["4OHTRZ66"].vals * VSQUARED / 29.8
+        P67 = data["4OHTRZ67"].vals * VSQUARED / 52.0
+        P68 = data["4OHTRZ68"].vals * VSQUARED / 29.0
         PAFTCYL = P66 + P67 + P68
         return PAFTCYL
 
 
 # --------------------------------------------
 class DP_PAHP(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ11', '4OHTRZ12', '4OHTRZ13']
+    rootparams = ["ELBV", "4OHTRZ11", "4OHTRZ12", "4OHTRZ13"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P11 = data['4OHTRZ11'].vals * VSQUARED / 39.4
-        P12 = data['4OHTRZ12'].vals * VSQUARED / 40.3
-        P13 = data['4OHTRZ13'].vals * VSQUARED / 39.7
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P11 = data["4OHTRZ11"].vals * VSQUARED / 39.4
+        P12 = data["4OHTRZ12"].vals * VSQUARED / 40.3
+        P13 = data["4OHTRZ13"].vals * VSQUARED / 39.7
         PAHP = P11 + P12 + P13
         return PAHP
 
 
 # --------------------------------------------
 class DP_PCONE(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ61', '4OHTRZ62', '4OHTRZ63']
+    rootparams = ["ELBV", "4OHTRZ61", "4OHTRZ62", "4OHTRZ63"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P61 = data['4OHTRZ61'].vals * VSQUARED / 33.7
-        P62 = data['4OHTRZ62'].vals * VSQUARED / 36.1
-        P63 = data['4OHTRZ63'].vals * VSQUARED / 36.1
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P61 = data["4OHTRZ61"].vals * VSQUARED / 33.7
+        P62 = data["4OHTRZ62"].vals * VSQUARED / 36.1
+        P63 = data["4OHTRZ63"].vals * VSQUARED / 36.1
         PCONE = P61 + P62 + P63
         return PCONE
 
@@ -1985,26 +1985,26 @@ class DP_PCONE(DerivedParameterThermal):
 # --------------------------------------------
 class DP_PFAP(DerivedParameterThermal):
     rootparams = [
-        'ELBV',
-        '4OHTRZ01',
-        '4OHTRZ02',
-        '4OHTRZ03',
-        '4OHTRZ04',
-        '4OHTRZ05',
-        '4OHTRZ06',
-        '4OHTRZ07',
+        "ELBV",
+        "4OHTRZ01",
+        "4OHTRZ02",
+        "4OHTRZ03",
+        "4OHTRZ04",
+        "4OHTRZ05",
+        "4OHTRZ06",
+        "4OHTRZ07",
     ]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P01 = data['4OHTRZ01'].vals * VSQUARED / 110.2
-        P02 = data['4OHTRZ02'].vals * VSQUARED / 109.7
-        P03 = data['4OHTRZ03'].vals * VSQUARED / 109.4
-        P04 = data['4OHTRZ04'].vals * VSQUARED / 175.9
-        P05 = data['4OHTRZ05'].vals * VSQUARED / 175.7
-        P06 = data['4OHTRZ06'].vals * VSQUARED / 175.6
-        P07 = data['4OHTRZ07'].vals * VSQUARED / 135.8
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P01 = data["4OHTRZ01"].vals * VSQUARED / 110.2
+        P02 = data["4OHTRZ02"].vals * VSQUARED / 109.7
+        P03 = data["4OHTRZ03"].vals * VSQUARED / 109.4
+        P04 = data["4OHTRZ04"].vals * VSQUARED / 175.9
+        P05 = data["4OHTRZ05"].vals * VSQUARED / 175.7
+        P06 = data["4OHTRZ06"].vals * VSQUARED / 175.6
+        P07 = data["4OHTRZ07"].vals * VSQUARED / 135.8
         PFAP = P01 + P02 + P03 + P04 + P05 + P06 + P07
         return PFAP
 
@@ -2012,49 +2012,49 @@ class DP_PFAP(DerivedParameterThermal):
 # --------------------------------------------
 class DP_PFWDCONE(DerivedParameterThermal):
     rootparams = [
-        'ELBV',
-        '4OHTRZ31',
-        '4OHTRZ32',
-        '4OHTRZ33',
-        '4OHTRZ34',
-        '4OHTRZ35',
-        '4OHTRZ36',
-        '4OHTRZ37',
-        '4OHTRZ38',
-        '4OHTRZ39',
-        '4OHTRZ40',
-        '4S1PWR05',
-        '4S1PWR06',
+        "ELBV",
+        "4OHTRZ31",
+        "4OHTRZ32",
+        "4OHTRZ33",
+        "4OHTRZ34",
+        "4OHTRZ35",
+        "4OHTRZ36",
+        "4OHTRZ37",
+        "4OHTRZ38",
+        "4OHTRZ39",
+        "4OHTRZ40",
+        "4S1PWR05",
+        "4S1PWR06",
     ]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P31 = data['4OHTRZ31'].vals * VSQUARED / 32.2
-        P32 = data['4OHTRZ32'].vals * VSQUARED / 28.6
-        P33 = data['4OHTRZ33'].vals * VSQUARED / 36.9
-        P34 = data['4OHTRZ34'].vals * VSQUARED / 28.0
-        P35 = data['4OHTRZ35'].vals * VSQUARED / 32.2
-        P36 = data['4OHTRZ36'].vals * VSQUARED / 44.3
-        P37 = data['4OHTRZ37'].vals * VSQUARED / 32.1
-        P38 = data['4OHTRZ38'].vals * VSQUARED / 27.8
-        P39 = data['4OHTRZ39'].vals * VSQUARED / 36.8
-        P40 = data['4OHTRZ40'].vals * VSQUARED / 28.3
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P31 = data["4OHTRZ31"].vals * VSQUARED / 32.2
+        P32 = data["4OHTRZ32"].vals * VSQUARED / 28.6
+        P33 = data["4OHTRZ33"].vals * VSQUARED / 36.9
+        P34 = data["4OHTRZ34"].vals * VSQUARED / 28.0
+        P35 = data["4OHTRZ35"].vals * VSQUARED / 32.2
+        P36 = data["4OHTRZ36"].vals * VSQUARED / 44.3
+        P37 = data["4OHTRZ37"].vals * VSQUARED / 32.1
+        P38 = data["4OHTRZ38"].vals * VSQUARED / 27.8
+        P39 = data["4OHTRZ39"].vals * VSQUARED / 36.8
+        P40 = data["4OHTRZ40"].vals * VSQUARED / 28.3
         PFWDCONE = P31 + P32 + P33 + P34 + P35 + P36 + P37 + P38 + P39 + P40
         return PFWDCONE
 
 
 # --------------------------------------------
 class DP_PFWDCYL(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ58', '4OHTRZ59', '4OHTRZ60']
+    rootparams = ["ELBV", "4OHTRZ58", "4OHTRZ59", "4OHTRZ60"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P58 = data['4OHTRZ58'].vals * VSQUARED / 83.7
-        P59 = data['4OHTRZ59'].vals * VSQUARED / 29.7
-        P60 = data['4OHTRZ60'].vals * VSQUARED / 30.7
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P58 = data["4OHTRZ58"].vals * VSQUARED / 83.7
+        P59 = data["4OHTRZ59"].vals * VSQUARED / 29.7
+        P60 = data["4OHTRZ60"].vals * VSQUARED / 30.7
         PFWDCYL = P58 + P59 + P60
         return PFWDCYL
 
@@ -2062,56 +2062,56 @@ class DP_PFWDCYL(DerivedParameterThermal):
 # --------------------------------------------
 class DP_PHRMA(DerivedParameterThermal):
     rootparams = [
-        'ELBV',
-        '4OHTRZ01',
-        '4OHTRZ02',
-        '4OHTRZ03',
-        '4OHTRZ04',
-        '4OHTRZ05',
-        '4OHTRZ06',
-        '4OHTRZ07',
-        '4OHTRZ08',
-        '4OHTRZ09',
-        '4OHTRZ10',
-        '4OHTRZ11',
-        '4OHTRZ12',
-        '4OHTRZ13',
-        '4OHTRZ14',
-        '4OHTRZ15',
-        '4OHTRZ16',
-        '4OHTRZ17',
-        '4OHTRZ18',
-        '4OHTRZ19',
-        '4OHTRZ20',
-        '4OHTRZ23',
-        '4OHTRZ24',
+        "ELBV",
+        "4OHTRZ01",
+        "4OHTRZ02",
+        "4OHTRZ03",
+        "4OHTRZ04",
+        "4OHTRZ05",
+        "4OHTRZ06",
+        "4OHTRZ07",
+        "4OHTRZ08",
+        "4OHTRZ09",
+        "4OHTRZ10",
+        "4OHTRZ11",
+        "4OHTRZ12",
+        "4OHTRZ13",
+        "4OHTRZ14",
+        "4OHTRZ15",
+        "4OHTRZ16",
+        "4OHTRZ17",
+        "4OHTRZ18",
+        "4OHTRZ19",
+        "4OHTRZ20",
+        "4OHTRZ23",
+        "4OHTRZ24",
     ]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P01 = data['4OHTRZ01'].vals * VSQUARED / 110.2
-        P02 = data['4OHTRZ02'].vals * VSQUARED / 109.7
-        P03 = data['4OHTRZ03'].vals * VSQUARED / 109.4
-        P04 = data['4OHTRZ04'].vals * VSQUARED / 175.9
-        P05 = data['4OHTRZ05'].vals * VSQUARED / 175.7
-        P06 = data['4OHTRZ06'].vals * VSQUARED / 175.6
-        P07 = data['4OHTRZ07'].vals * VSQUARED / 135.8
-        P08 = data['4OHTRZ08'].vals * VSQUARED / 36.1
-        P09 = data['4OHTRZ09'].vals * VSQUARED / 32.6
-        P10 = data['4OHTRZ10'].vals * VSQUARED / 34.9
-        P11 = data['4OHTRZ11'].vals * VSQUARED / 39.4
-        P12 = data['4OHTRZ12'].vals * VSQUARED / 40.3
-        P13 = data['4OHTRZ13'].vals * VSQUARED / 39.7
-        P14 = data['4OHTRZ14'].vals * VSQUARED / 41.2
-        P15 = data['4OHTRZ15'].vals * VSQUARED / 40.5
-        P16 = data['4OHTRZ16'].vals * VSQUARED / 41.3
-        P17 = data['4OHTRZ17'].vals * VSQUARED / 116.0
-        P18 = data['4OHTRZ18'].vals * VSQUARED / 115.7
-        P19 = data['4OHTRZ19'].vals * VSQUARED / 95.3
-        P20 = data['4OHTRZ20'].vals * VSQUARED / 379.0
-        P23 = data['4OHTRZ23'].vals * VSQUARED / 386.0
-        P24 = data['4OHTRZ24'].vals * VSQUARED / 385.8
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P01 = data["4OHTRZ01"].vals * VSQUARED / 110.2
+        P02 = data["4OHTRZ02"].vals * VSQUARED / 109.7
+        P03 = data["4OHTRZ03"].vals * VSQUARED / 109.4
+        P04 = data["4OHTRZ04"].vals * VSQUARED / 175.9
+        P05 = data["4OHTRZ05"].vals * VSQUARED / 175.7
+        P06 = data["4OHTRZ06"].vals * VSQUARED / 175.6
+        P07 = data["4OHTRZ07"].vals * VSQUARED / 135.8
+        P08 = data["4OHTRZ08"].vals * VSQUARED / 36.1
+        P09 = data["4OHTRZ09"].vals * VSQUARED / 32.6
+        P10 = data["4OHTRZ10"].vals * VSQUARED / 34.9
+        P11 = data["4OHTRZ11"].vals * VSQUARED / 39.4
+        P12 = data["4OHTRZ12"].vals * VSQUARED / 40.3
+        P13 = data["4OHTRZ13"].vals * VSQUARED / 39.7
+        P14 = data["4OHTRZ14"].vals * VSQUARED / 41.2
+        P15 = data["4OHTRZ15"].vals * VSQUARED / 40.5
+        P16 = data["4OHTRZ16"].vals * VSQUARED / 41.3
+        P17 = data["4OHTRZ17"].vals * VSQUARED / 116.0
+        P18 = data["4OHTRZ18"].vals * VSQUARED / 115.7
+        P19 = data["4OHTRZ19"].vals * VSQUARED / 95.3
+        P20 = data["4OHTRZ20"].vals * VSQUARED / 379.0
+        P23 = data["4OHTRZ23"].vals * VSQUARED / 386.0
+        P24 = data["4OHTRZ24"].vals * VSQUARED / 385.8
         PHRMA = (
             P01
             + P02
@@ -2142,40 +2142,40 @@ class DP_PHRMA(DerivedParameterThermal):
 # --------------------------------------------
 class DP_PHRMASTRUTS(DerivedParameterThermal):
     rootparams = [
-        'ELBV',
-        '4OHTRZ25',
-        '4OHTRZ26',
-        '4OHTRZ27',
-        '4OHTRZ28',
-        '4OHTRZ29',
-        '4OHTRZ30',
-        '4S1PWR05',
-        '4S1PWR06',
+        "ELBV",
+        "4OHTRZ25",
+        "4OHTRZ26",
+        "4OHTRZ27",
+        "4OHTRZ28",
+        "4OHTRZ29",
+        "4OHTRZ30",
+        "4S1PWR05",
+        "4S1PWR06",
     ]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P25 = data['4OHTRZ25'].vals * VSQUARED / 383.0
-        P26 = data['4OHTRZ26'].vals * VSQUARED / 383.5
-        P27 = data['4OHTRZ27'].vals * VSQUARED / 383.0
-        P28 = data['4OHTRZ28'].vals * VSQUARED / 382.3
-        P29 = data['4OHTRZ29'].vals * VSQUARED / 384.0
-        P30 = data['4OHTRZ30'].vals * VSQUARED / 383.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P25 = data["4OHTRZ25"].vals * VSQUARED / 383.0
+        P26 = data["4OHTRZ26"].vals * VSQUARED / 383.5
+        P27 = data["4OHTRZ27"].vals * VSQUARED / 383.0
+        P28 = data["4OHTRZ28"].vals * VSQUARED / 382.3
+        P29 = data["4OHTRZ29"].vals * VSQUARED / 384.0
+        P30 = data["4OHTRZ30"].vals * VSQUARED / 383.0
         PHRMASTRUTS = P25 + P26 + P27 + P28 + P29 + P30
         return PHRMASTRUTS
 
 
 # --------------------------------------------
 class DP_PIC(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ23', '4OHTRZ24']
+    rootparams = ["ELBV", "4OHTRZ23", "4OHTRZ24"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P23 = data['4OHTRZ23'].vals * VSQUARED / 386.0
-        P24 = data['4OHTRZ24'].vals * VSQUARED / 385.8
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P23 = data["4OHTRZ23"].vals * VSQUARED / 386.0
+        P24 = data["4OHTRZ24"].vals * VSQUARED / 385.8
         PIC = P23 + P24
         return PIC
 
@@ -2183,43 +2183,43 @@ class DP_PIC(DerivedParameterThermal):
 # --------------------------------------------
 class DP_PMIDCONE(DerivedParameterThermal):
     rootparams = [
-        'ELBV',
-        '4OHTRZ41',
-        '4OHTRZ42',
-        '4OHTRZ43',
-        '4OHTRZ44',
-        '4OHTRZ45',
-        '4OHTRZ46',
-        '4OHTRZ47',
-        '4S1PWR05',
-        '4S1PWR06',
+        "ELBV",
+        "4OHTRZ41",
+        "4OHTRZ42",
+        "4OHTRZ43",
+        "4OHTRZ44",
+        "4OHTRZ45",
+        "4OHTRZ46",
+        "4OHTRZ47",
+        "4S1PWR05",
+        "4S1PWR06",
     ]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P41 = data['4OHTRZ41'].vals * VSQUARED / 61.7
-        P42 = data['4OHTRZ42'].vals * VSQUARED / 51.7
-        P43 = data['4OHTRZ43'].vals * VSQUARED / 36.8
-        P44 = data['4OHTRZ44'].vals * VSQUARED / 36.9
-        P45 = data['4OHTRZ45'].vals * VSQUARED / 36.8
-        P46 = data['4OHTRZ46'].vals * VSQUARED / 36.5
-        P47 = data['4OHTRZ47'].vals * VSQUARED / 52.3
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P41 = data["4OHTRZ41"].vals * VSQUARED / 61.7
+        P42 = data["4OHTRZ42"].vals * VSQUARED / 51.7
+        P43 = data["4OHTRZ43"].vals * VSQUARED / 36.8
+        P44 = data["4OHTRZ44"].vals * VSQUARED / 36.9
+        P45 = data["4OHTRZ45"].vals * VSQUARED / 36.8
+        P46 = data["4OHTRZ46"].vals * VSQUARED / 36.5
+        P47 = data["4OHTRZ47"].vals * VSQUARED / 52.3
         PMIDCONE = P41 + P42 + P43 + P44 + P45 + P46 + P47
         return PMIDCONE
 
 
 # --------------------------------------------
 class DP_PMNT(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ14', '4OHTRZ15', '4OHTRZ16']
+    rootparams = ["ELBV", "4OHTRZ14", "4OHTRZ15", "4OHTRZ16"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P14 = data['4OHTRZ14'].vals * VSQUARED / 41.2
-        P15 = data['4OHTRZ15'].vals * VSQUARED / 40.5
-        P16 = data['4OHTRZ16'].vals * VSQUARED / 41.3
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P14 = data["4OHTRZ14"].vals * VSQUARED / 41.2
+        P15 = data["4OHTRZ15"].vals * VSQUARED / 40.5
+        P16 = data["4OHTRZ16"].vals * VSQUARED / 41.3
         PMNT = P14 + P15 + P16
         return PMNT
 
@@ -2227,93 +2227,93 @@ class DP_PMNT(DerivedParameterThermal):
 # --------------------------------------------
 class DP_POBAT(DerivedParameterThermal):
     rootparams = [
-        'ELBV',
-        '4OHTRZ25',
-        '4OHTRZ26',
-        '4OHTRZ27',
-        '4OHTRZ28',
-        '4OHTRZ29',
-        '4OHTRZ30',
-        '4OHTRZ31',
-        '4OHTRZ32',
-        '4OHTRZ33',
-        '4OHTRZ34',
-        '4OHTRZ35',
-        '4OHTRZ36',
-        '4OHTRZ37',
-        '4OHTRZ38',
-        '4OHTRZ39',
-        '4OHTRZ40',
-        '4OHTRZ41',
-        '4OHTRZ42',
-        '4OHTRZ43',
-        '4OHTRZ44',
-        '4OHTRZ45',
-        '4OHTRZ46',
-        '4OHTRZ47',
-        '4OHTRZ48',
-        '4OHTRZ49',
-        '4OHTRZ50',
-        '4OHTRZ51',
-        '4OHTRZ52',
-        '4OHTRZ53',
-        '4OHTRZ54',
-        '4OHTRZ55',
-        '4OHTRZ57',
-        '4OHTRZ75',
-        '4OHTRZ76',
-        '4OHTRZ77',
-        '4OHTRZ78',
-        '4OHTRZ79',
-        '4OHTRZ80',
-        '4S1PWR05',
-        '4S1PWR06',
+        "ELBV",
+        "4OHTRZ25",
+        "4OHTRZ26",
+        "4OHTRZ27",
+        "4OHTRZ28",
+        "4OHTRZ29",
+        "4OHTRZ30",
+        "4OHTRZ31",
+        "4OHTRZ32",
+        "4OHTRZ33",
+        "4OHTRZ34",
+        "4OHTRZ35",
+        "4OHTRZ36",
+        "4OHTRZ37",
+        "4OHTRZ38",
+        "4OHTRZ39",
+        "4OHTRZ40",
+        "4OHTRZ41",
+        "4OHTRZ42",
+        "4OHTRZ43",
+        "4OHTRZ44",
+        "4OHTRZ45",
+        "4OHTRZ46",
+        "4OHTRZ47",
+        "4OHTRZ48",
+        "4OHTRZ49",
+        "4OHTRZ50",
+        "4OHTRZ51",
+        "4OHTRZ52",
+        "4OHTRZ53",
+        "4OHTRZ54",
+        "4OHTRZ55",
+        "4OHTRZ57",
+        "4OHTRZ75",
+        "4OHTRZ76",
+        "4OHTRZ77",
+        "4OHTRZ78",
+        "4OHTRZ79",
+        "4OHTRZ80",
+        "4S1PWR05",
+        "4S1PWR06",
     ]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_4OHTRZ50(data)
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P75 = data['4OHTRZ75'].vals * VSQUARED / 130.2
-        P76 = data['4OHTRZ76'].vals * VSQUARED / 133.4
-        P77 = data['4OHTRZ77'].vals * VSQUARED / 131.5
-        P78 = data['4OHTRZ78'].vals * VSQUARED / 133.2
-        P79 = data['4OHTRZ79'].vals * VSQUARED / 133.1
-        P80 = data['4OHTRZ80'].vals * VSQUARED / 133.0
-        P25 = data['4OHTRZ25'].vals * VSQUARED / 383.0
-        P26 = data['4OHTRZ26'].vals * VSQUARED / 383.5
-        P27 = data['4OHTRZ27'].vals * VSQUARED / 383.0
-        P28 = data['4OHTRZ28'].vals * VSQUARED / 382.3
-        P29 = data['4OHTRZ29'].vals * VSQUARED / 384.0
-        P30 = data['4OHTRZ30'].vals * VSQUARED / 383.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P75 = data["4OHTRZ75"].vals * VSQUARED / 130.2
+        P76 = data["4OHTRZ76"].vals * VSQUARED / 133.4
+        P77 = data["4OHTRZ77"].vals * VSQUARED / 131.5
+        P78 = data["4OHTRZ78"].vals * VSQUARED / 133.2
+        P79 = data["4OHTRZ79"].vals * VSQUARED / 133.1
+        P80 = data["4OHTRZ80"].vals * VSQUARED / 133.0
+        P25 = data["4OHTRZ25"].vals * VSQUARED / 383.0
+        P26 = data["4OHTRZ26"].vals * VSQUARED / 383.5
+        P27 = data["4OHTRZ27"].vals * VSQUARED / 383.0
+        P28 = data["4OHTRZ28"].vals * VSQUARED / 382.3
+        P29 = data["4OHTRZ29"].vals * VSQUARED / 384.0
+        P30 = data["4OHTRZ30"].vals * VSQUARED / 383.0
 
-        P31 = data['4OHTRZ31'].vals * VSQUARED / 32.2
-        P32 = data['4OHTRZ32'].vals * VSQUARED / 28.6
-        P33 = data['4OHTRZ33'].vals * VSQUARED / 36.9
-        P34 = data['4OHTRZ34'].vals * VSQUARED / 28.0
-        P35 = data['4OHTRZ35'].vals * VSQUARED / 32.2
-        P36 = data['4OHTRZ36'].vals * VSQUARED / 44.3
-        P37 = data['4OHTRZ37'].vals * VSQUARED / 32.1
-        P38 = data['4OHTRZ38'].vals * VSQUARED / 27.8
-        P39 = data['4OHTRZ39'].vals * VSQUARED / 36.8
-        P40 = data['4OHTRZ40'].vals * VSQUARED / 28.3
-        P41 = data['4OHTRZ41'].vals * VSQUARED / 61.7
-        P42 = data['4OHTRZ42'].vals * VSQUARED / 51.7
-        P43 = data['4OHTRZ43'].vals * VSQUARED / 36.8
-        P44 = data['4OHTRZ44'].vals * VSQUARED / 36.9
-        P45 = data['4OHTRZ45'].vals * VSQUARED / 36.8
-        P46 = data['4OHTRZ46'].vals * VSQUARED / 36.5
-        P47 = data['4OHTRZ47'].vals * VSQUARED / 52.3
-        P48 = data['4OHTRZ48'].vals * VSQUARED / 79.5
-        P49 = data['4OHTRZ49'].vals * VSQUARED / 34.8
-        P50 = data['4OHTRZ50'].vals * VSQUARED / 35.2
-        P51 = data['4OHTRZ51'].vals * VSQUARED / 35.4
-        P52 = data['4OHTRZ52'].vals * VSQUARED / 34.4
-        P53 = data['4OHTRZ53'].vals * VSQUARED / 94.1
-        P54 = data['4OHTRZ54'].vals * VSQUARED / 124.4
-        P55 = data['4OHTRZ55'].vals * VSQUARED / 126.8
-        P57 = data['4OHTRZ57'].vals * VSQUARED / 142.3
+        P31 = data["4OHTRZ31"].vals * VSQUARED / 32.2
+        P32 = data["4OHTRZ32"].vals * VSQUARED / 28.6
+        P33 = data["4OHTRZ33"].vals * VSQUARED / 36.9
+        P34 = data["4OHTRZ34"].vals * VSQUARED / 28.0
+        P35 = data["4OHTRZ35"].vals * VSQUARED / 32.2
+        P36 = data["4OHTRZ36"].vals * VSQUARED / 44.3
+        P37 = data["4OHTRZ37"].vals * VSQUARED / 32.1
+        P38 = data["4OHTRZ38"].vals * VSQUARED / 27.8
+        P39 = data["4OHTRZ39"].vals * VSQUARED / 36.8
+        P40 = data["4OHTRZ40"].vals * VSQUARED / 28.3
+        P41 = data["4OHTRZ41"].vals * VSQUARED / 61.7
+        P42 = data["4OHTRZ42"].vals * VSQUARED / 51.7
+        P43 = data["4OHTRZ43"].vals * VSQUARED / 36.8
+        P44 = data["4OHTRZ44"].vals * VSQUARED / 36.9
+        P45 = data["4OHTRZ45"].vals * VSQUARED / 36.8
+        P46 = data["4OHTRZ46"].vals * VSQUARED / 36.5
+        P47 = data["4OHTRZ47"].vals * VSQUARED / 52.3
+        P48 = data["4OHTRZ48"].vals * VSQUARED / 79.5
+        P49 = data["4OHTRZ49"].vals * VSQUARED / 34.8
+        P50 = data["4OHTRZ50"].vals * VSQUARED / 35.2
+        P51 = data["4OHTRZ51"].vals * VSQUARED / 35.4
+        P52 = data["4OHTRZ52"].vals * VSQUARED / 34.4
+        P53 = data["4OHTRZ53"].vals * VSQUARED / 94.1
+        P54 = data["4OHTRZ54"].vals * VSQUARED / 124.4
+        P55 = data["4OHTRZ55"].vals * VSQUARED / 126.8
+        P57 = data["4OHTRZ57"].vals * VSQUARED / 142.3
 
         PSTRUTS = P75 + P76 + P77 + P78 + P79 + P80 + P25 + P26 + P27 + P28 + P29 + P30
         POBACONE = (
@@ -2350,42 +2350,42 @@ class DP_POBAT(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_POC(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ17', '4OHTRZ18', '4OHTRZ19']
+    rootparams = ["ELBV", "4OHTRZ17", "4OHTRZ18", "4OHTRZ19"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P17 = data['4OHTRZ17'].vals * VSQUARED / 116.0
-        P18 = data['4OHTRZ18'].vals * VSQUARED / 115.7
-        P19 = data['4OHTRZ19'].vals * VSQUARED / 95.3
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P17 = data["4OHTRZ17"].vals * VSQUARED / 116.0
+        P18 = data["4OHTRZ18"].vals * VSQUARED / 115.7
+        P19 = data["4OHTRZ19"].vals * VSQUARED / 95.3
         POC = P17 + P18 + P19
         return POC
 
 
 # --------------------------------------------
 class DP_PPL10(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ08', '4OHTRZ09', '4OHTRZ10']
+    rootparams = ["ELBV", "4OHTRZ08", "4OHTRZ09", "4OHTRZ10"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P08 = data['4OHTRZ08'].vals * VSQUARED / 36.1
-        P09 = data['4OHTRZ09'].vals * VSQUARED / 32.6
-        P10 = data['4OHTRZ10'].vals * VSQUARED / 34.9
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P08 = data["4OHTRZ08"].vals * VSQUARED / 36.1
+        P09 = data["4OHTRZ09"].vals * VSQUARED / 32.6
+        P10 = data["4OHTRZ10"].vals * VSQUARED / 34.9
         PPL10 = P08 + P09 + P10
         return PPL10
 
 
 # --------------------------------------------
 class DP_PRADVNT(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ64', '4OHTRZ65', '4OHTRZ69']
+    rootparams = ["ELBV", "4OHTRZ64", "4OHTRZ65", "4OHTRZ69"]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P64 = data['4OHTRZ64'].vals * VSQUARED / 44.1
-        P65 = data['4OHTRZ65'].vals * VSQUARED / 37.5
-        P69 = data['4OHTRZ69'].vals * VSQUARED / 37.5
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P64 = data["4OHTRZ64"].vals * VSQUARED / 44.1
+        P65 = data["4OHTRZ65"].vals * VSQUARED / 37.5
+        P69 = data["4OHTRZ69"].vals * VSQUARED / 37.5
         PRADVNT = P64 + P65 + P69
         return PRADVNT
 
@@ -2393,24 +2393,24 @@ class DP_PRADVNT(DerivedParameterThermal):
 # --------------------------------------------
 class DP_PSCSTRUTS(DerivedParameterThermal):
     rootparams = [
-        'ELBV',
-        '4OHTRZ75',
-        '4OHTRZ76',
-        '4OHTRZ77',
-        '4OHTRZ78',
-        '4OHTRZ79',
-        '4OHTRZ80',
+        "ELBV",
+        "4OHTRZ75",
+        "4OHTRZ76",
+        "4OHTRZ77",
+        "4OHTRZ78",
+        "4OHTRZ79",
+        "4OHTRZ80",
     ]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P75 = data['4OHTRZ75'].vals * VSQUARED / 130.2
-        P76 = data['4OHTRZ76'].vals * VSQUARED / 133.4
-        P77 = data['4OHTRZ77'].vals * VSQUARED / 131.5
-        P78 = data['4OHTRZ78'].vals * VSQUARED / 133.2
-        P79 = data['4OHTRZ79'].vals * VSQUARED / 133.1
-        P80 = data['4OHTRZ80'].vals * VSQUARED / 133.0
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P75 = data["4OHTRZ75"].vals * VSQUARED / 130.2
+        P76 = data["4OHTRZ76"].vals * VSQUARED / 133.4
+        P77 = data["4OHTRZ77"].vals * VSQUARED / 131.5
+        P78 = data["4OHTRZ78"].vals * VSQUARED / 133.2
+        P79 = data["4OHTRZ79"].vals * VSQUARED / 133.1
+        P80 = data["4OHTRZ80"].vals * VSQUARED / 133.0
         PSCSTRUTS = P75 + P76 + P77 + P78 + P79 + P80
         return PSCSTRUTS
 
@@ -2418,36 +2418,36 @@ class DP_PSCSTRUTS(DerivedParameterThermal):
 # --------------------------------------------
 class DP_PTFTE(DerivedParameterThermal):
     rootparams = [
-        'ELBV',
-        '4OHTRZ58',
-        '4OHTRZ59',
-        '4OHTRZ60',
-        '4OHTRZ61',
-        '4OHTRZ62',
-        '4OHTRZ63',
-        '4OHTRZ64',
-        '4OHTRZ65',
-        '4OHTRZ66',
-        '4OHTRZ67',
-        '4OHTRZ68',
-        '4OHTRZ69',
+        "ELBV",
+        "4OHTRZ58",
+        "4OHTRZ59",
+        "4OHTRZ60",
+        "4OHTRZ61",
+        "4OHTRZ62",
+        "4OHTRZ63",
+        "4OHTRZ64",
+        "4OHTRZ65",
+        "4OHTRZ66",
+        "4OHTRZ67",
+        "4OHTRZ68",
+        "4OHTRZ69",
     ]
     time_step = 0.25625
 
     def calc(self, data):
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P58 = data['4OHTRZ58'].vals * VSQUARED / 83.7
-        P59 = data['4OHTRZ59'].vals * VSQUARED / 29.7
-        P60 = data['4OHTRZ60'].vals * VSQUARED / 30.7
-        P61 = data['4OHTRZ61'].vals * VSQUARED / 33.7
-        P62 = data['4OHTRZ62'].vals * VSQUARED / 36.1
-        P63 = data['4OHTRZ63'].vals * VSQUARED / 36.1
-        P64 = data['4OHTRZ64'].vals * VSQUARED / 44.1
-        P65 = data['4OHTRZ65'].vals * VSQUARED / 37.5
-        P66 = data['4OHTRZ66'].vals * VSQUARED / 29.8
-        P67 = data['4OHTRZ67'].vals * VSQUARED / 52.0
-        P68 = data['4OHTRZ68'].vals * VSQUARED / 29.0
-        P69 = data['4OHTRZ69'].vals * VSQUARED / 37.5
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P58 = data["4OHTRZ58"].vals * VSQUARED / 83.7
+        P59 = data["4OHTRZ59"].vals * VSQUARED / 29.7
+        P60 = data["4OHTRZ60"].vals * VSQUARED / 30.7
+        P61 = data["4OHTRZ61"].vals * VSQUARED / 33.7
+        P62 = data["4OHTRZ62"].vals * VSQUARED / 36.1
+        P63 = data["4OHTRZ63"].vals * VSQUARED / 36.1
+        P64 = data["4OHTRZ64"].vals * VSQUARED / 44.1
+        P65 = data["4OHTRZ65"].vals * VSQUARED / 37.5
+        P66 = data["4OHTRZ66"].vals * VSQUARED / 29.8
+        P67 = data["4OHTRZ67"].vals * VSQUARED / 52.0
+        P68 = data["4OHTRZ68"].vals * VSQUARED / 29.0
+        P69 = data["4OHTRZ69"].vals * VSQUARED / 37.5
 
         PTFTE = P58 + P59 + P60 + P61 + P62 + P63 + P64 + P65 + P66 + P67 + P68 + P69
         return PTFTE
@@ -2456,163 +2456,163 @@ class DP_PTFTE(DerivedParameterThermal):
 # --------------------------------------------
 class DP_PTOTAL(DerivedParameterThermal):
     rootparams = [
-        'ELBV',
-        '4OHTRZ01',
-        '4OHTRZ02',
-        '4OHTRZ03',
-        '4OHTRZ04',
-        '4OHTRZ05',
-        '4OHTRZ06',
-        '4OHTRZ07',
-        '4OHTRZ08',
-        '4OHTRZ09',
-        '4OHTRZ10',
-        '4OHTRZ11',
-        '4OHTRZ12',
-        '4OHTRZ13',
-        '4OHTRZ14',
-        '4OHTRZ15',
-        '4OHTRZ16',
-        '4OHTRZ17',
-        '4OHTRZ18',
-        '4OHTRZ19',
-        '4OHTRZ20',
-        '4OHTRZ23',
-        '4OHTRZ24',
-        '4OHTRZ25',
-        '4OHTRZ26',
-        '4OHTRZ27',
-        '4OHTRZ28',
-        '4OHTRZ29',
-        '4OHTRZ30',
-        '4OHTRZ31',
-        '4OHTRZ32',
-        '4OHTRZ33',
-        '4OHTRZ34',
-        '4OHTRZ35',
-        '4OHTRZ36',
-        '4OHTRZ37',
-        '4OHTRZ38',
-        '4OHTRZ39',
-        '4OHTRZ40',
-        '4OHTRZ41',
-        '4OHTRZ42',
-        '4OHTRZ43',
-        '4OHTRZ44',
-        '4OHTRZ45',
-        '4OHTRZ46',
-        '4OHTRZ47',
-        '4OHTRZ48',
-        '4OHTRZ49',
-        '4OHTRZ50',
-        '4OHTRZ51',
-        '4OHTRZ52',
-        '4OHTRZ53',
-        '4OHTRZ54',
-        '4OHTRZ55',
-        '4OHTRZ57',
-        '4OHTRZ58',
-        '4OHTRZ59',
-        '4OHTRZ60',
-        '4OHTRZ61',
-        '4OHTRZ62',
-        '4OHTRZ63',
-        '4OHTRZ64',
-        '4OHTRZ65',
-        '4OHTRZ66',
-        '4OHTRZ67',
-        '4OHTRZ68',
-        '4OHTRZ69',
-        '4OHTRZ75',
-        '4OHTRZ76',
-        '4OHTRZ77',
-        '4OHTRZ78',
-        '4OHTRZ79',
-        '4OHTRZ80',
-        '4S1PWR05',
-        '4S1PWR06',
+        "ELBV",
+        "4OHTRZ01",
+        "4OHTRZ02",
+        "4OHTRZ03",
+        "4OHTRZ04",
+        "4OHTRZ05",
+        "4OHTRZ06",
+        "4OHTRZ07",
+        "4OHTRZ08",
+        "4OHTRZ09",
+        "4OHTRZ10",
+        "4OHTRZ11",
+        "4OHTRZ12",
+        "4OHTRZ13",
+        "4OHTRZ14",
+        "4OHTRZ15",
+        "4OHTRZ16",
+        "4OHTRZ17",
+        "4OHTRZ18",
+        "4OHTRZ19",
+        "4OHTRZ20",
+        "4OHTRZ23",
+        "4OHTRZ24",
+        "4OHTRZ25",
+        "4OHTRZ26",
+        "4OHTRZ27",
+        "4OHTRZ28",
+        "4OHTRZ29",
+        "4OHTRZ30",
+        "4OHTRZ31",
+        "4OHTRZ32",
+        "4OHTRZ33",
+        "4OHTRZ34",
+        "4OHTRZ35",
+        "4OHTRZ36",
+        "4OHTRZ37",
+        "4OHTRZ38",
+        "4OHTRZ39",
+        "4OHTRZ40",
+        "4OHTRZ41",
+        "4OHTRZ42",
+        "4OHTRZ43",
+        "4OHTRZ44",
+        "4OHTRZ45",
+        "4OHTRZ46",
+        "4OHTRZ47",
+        "4OHTRZ48",
+        "4OHTRZ49",
+        "4OHTRZ50",
+        "4OHTRZ51",
+        "4OHTRZ52",
+        "4OHTRZ53",
+        "4OHTRZ54",
+        "4OHTRZ55",
+        "4OHTRZ57",
+        "4OHTRZ58",
+        "4OHTRZ59",
+        "4OHTRZ60",
+        "4OHTRZ61",
+        "4OHTRZ62",
+        "4OHTRZ63",
+        "4OHTRZ64",
+        "4OHTRZ65",
+        "4OHTRZ66",
+        "4OHTRZ67",
+        "4OHTRZ68",
+        "4OHTRZ69",
+        "4OHTRZ75",
+        "4OHTRZ76",
+        "4OHTRZ77",
+        "4OHTRZ78",
+        "4OHTRZ79",
+        "4OHTRZ80",
+        "4S1PWR05",
+        "4S1PWR06",
     ]
     time_step = 0.25625
 
     def calc(self, data):
         self.fix_4OHTRZ50(data)
         self.fix_bus_5_and_bus_6(data)
-        VSQUARED = data['ELBV'].vals * data['ELBV'].vals
-        P01 = data['4OHTRZ01'].vals * VSQUARED / 110.2
-        P02 = data['4OHTRZ02'].vals * VSQUARED / 109.7
-        P03 = data['4OHTRZ03'].vals * VSQUARED / 109.4
-        P04 = data['4OHTRZ04'].vals * VSQUARED / 175.9
-        P05 = data['4OHTRZ05'].vals * VSQUARED / 175.7
-        P06 = data['4OHTRZ06'].vals * VSQUARED / 175.6
-        P07 = data['4OHTRZ07'].vals * VSQUARED / 135.8
-        P08 = data['4OHTRZ08'].vals * VSQUARED / 36.1
-        P09 = data['4OHTRZ09'].vals * VSQUARED / 32.6
-        P10 = data['4OHTRZ10'].vals * VSQUARED / 34.9
-        P11 = data['4OHTRZ11'].vals * VSQUARED / 39.4
-        P12 = data['4OHTRZ12'].vals * VSQUARED / 40.3
-        P13 = data['4OHTRZ13'].vals * VSQUARED / 39.7
-        P14 = data['4OHTRZ14'].vals * VSQUARED / 41.2
-        P15 = data['4OHTRZ15'].vals * VSQUARED / 40.5
-        P16 = data['4OHTRZ16'].vals * VSQUARED / 41.3
-        P17 = data['4OHTRZ17'].vals * VSQUARED / 116.0
-        P18 = data['4OHTRZ18'].vals * VSQUARED / 115.7
-        P19 = data['4OHTRZ19'].vals * VSQUARED / 95.3
-        P20 = data['4OHTRZ20'].vals * VSQUARED / 379.0
-        P23 = data['4OHTRZ23'].vals * VSQUARED / 386.0
-        P24 = data['4OHTRZ24'].vals * VSQUARED / 385.8
+        VSQUARED = data["ELBV"].vals * data["ELBV"].vals
+        P01 = data["4OHTRZ01"].vals * VSQUARED / 110.2
+        P02 = data["4OHTRZ02"].vals * VSQUARED / 109.7
+        P03 = data["4OHTRZ03"].vals * VSQUARED / 109.4
+        P04 = data["4OHTRZ04"].vals * VSQUARED / 175.9
+        P05 = data["4OHTRZ05"].vals * VSQUARED / 175.7
+        P06 = data["4OHTRZ06"].vals * VSQUARED / 175.6
+        P07 = data["4OHTRZ07"].vals * VSQUARED / 135.8
+        P08 = data["4OHTRZ08"].vals * VSQUARED / 36.1
+        P09 = data["4OHTRZ09"].vals * VSQUARED / 32.6
+        P10 = data["4OHTRZ10"].vals * VSQUARED / 34.9
+        P11 = data["4OHTRZ11"].vals * VSQUARED / 39.4
+        P12 = data["4OHTRZ12"].vals * VSQUARED / 40.3
+        P13 = data["4OHTRZ13"].vals * VSQUARED / 39.7
+        P14 = data["4OHTRZ14"].vals * VSQUARED / 41.2
+        P15 = data["4OHTRZ15"].vals * VSQUARED / 40.5
+        P16 = data["4OHTRZ16"].vals * VSQUARED / 41.3
+        P17 = data["4OHTRZ17"].vals * VSQUARED / 116.0
+        P18 = data["4OHTRZ18"].vals * VSQUARED / 115.7
+        P19 = data["4OHTRZ19"].vals * VSQUARED / 95.3
+        P20 = data["4OHTRZ20"].vals * VSQUARED / 379.0
+        P23 = data["4OHTRZ23"].vals * VSQUARED / 386.0
+        P24 = data["4OHTRZ24"].vals * VSQUARED / 385.8
 
-        P31 = data['4OHTRZ31'].vals * VSQUARED / 32.2
-        P32 = data['4OHTRZ32'].vals * VSQUARED / 28.6
-        P33 = data['4OHTRZ33'].vals * VSQUARED / 36.9
-        P34 = data['4OHTRZ34'].vals * VSQUARED / 28.0
-        P35 = data['4OHTRZ35'].vals * VSQUARED / 32.2
-        P36 = data['4OHTRZ36'].vals * VSQUARED / 44.3
-        P37 = data['4OHTRZ37'].vals * VSQUARED / 32.1
-        P38 = data['4OHTRZ38'].vals * VSQUARED / 27.8
-        P39 = data['4OHTRZ39'].vals * VSQUARED / 36.8
-        P40 = data['4OHTRZ40'].vals * VSQUARED / 28.3
-        P41 = data['4OHTRZ41'].vals * VSQUARED / 61.7
-        P42 = data['4OHTRZ42'].vals * VSQUARED / 51.7
-        P43 = data['4OHTRZ43'].vals * VSQUARED / 36.8
-        P44 = data['4OHTRZ44'].vals * VSQUARED / 36.9
-        P45 = data['4OHTRZ45'].vals * VSQUARED / 36.8
-        P46 = data['4OHTRZ46'].vals * VSQUARED / 36.5
-        P47 = data['4OHTRZ47'].vals * VSQUARED / 52.3
-        P48 = data['4OHTRZ48'].vals * VSQUARED / 79.5
-        P49 = data['4OHTRZ49'].vals * VSQUARED / 34.8
-        P50 = data['4OHTRZ50'].vals * VSQUARED / 35.2
-        P51 = data['4OHTRZ51'].vals * VSQUARED / 35.4
-        P52 = data['4OHTRZ52'].vals * VSQUARED / 34.4
-        P53 = data['4OHTRZ53'].vals * VSQUARED / 94.1
-        P54 = data['4OHTRZ54'].vals * VSQUARED / 124.4
-        P55 = data['4OHTRZ55'].vals * VSQUARED / 126.8
-        P57 = data['4OHTRZ57'].vals * VSQUARED / 142.3
+        P31 = data["4OHTRZ31"].vals * VSQUARED / 32.2
+        P32 = data["4OHTRZ32"].vals * VSQUARED / 28.6
+        P33 = data["4OHTRZ33"].vals * VSQUARED / 36.9
+        P34 = data["4OHTRZ34"].vals * VSQUARED / 28.0
+        P35 = data["4OHTRZ35"].vals * VSQUARED / 32.2
+        P36 = data["4OHTRZ36"].vals * VSQUARED / 44.3
+        P37 = data["4OHTRZ37"].vals * VSQUARED / 32.1
+        P38 = data["4OHTRZ38"].vals * VSQUARED / 27.8
+        P39 = data["4OHTRZ39"].vals * VSQUARED / 36.8
+        P40 = data["4OHTRZ40"].vals * VSQUARED / 28.3
+        P41 = data["4OHTRZ41"].vals * VSQUARED / 61.7
+        P42 = data["4OHTRZ42"].vals * VSQUARED / 51.7
+        P43 = data["4OHTRZ43"].vals * VSQUARED / 36.8
+        P44 = data["4OHTRZ44"].vals * VSQUARED / 36.9
+        P45 = data["4OHTRZ45"].vals * VSQUARED / 36.8
+        P46 = data["4OHTRZ46"].vals * VSQUARED / 36.5
+        P47 = data["4OHTRZ47"].vals * VSQUARED / 52.3
+        P48 = data["4OHTRZ48"].vals * VSQUARED / 79.5
+        P49 = data["4OHTRZ49"].vals * VSQUARED / 34.8
+        P50 = data["4OHTRZ50"].vals * VSQUARED / 35.2
+        P51 = data["4OHTRZ51"].vals * VSQUARED / 35.4
+        P52 = data["4OHTRZ52"].vals * VSQUARED / 34.4
+        P53 = data["4OHTRZ53"].vals * VSQUARED / 94.1
+        P54 = data["4OHTRZ54"].vals * VSQUARED / 124.4
+        P55 = data["4OHTRZ55"].vals * VSQUARED / 126.8
+        P57 = data["4OHTRZ57"].vals * VSQUARED / 142.3
 
-        P58 = data['4OHTRZ58'].vals * VSQUARED / 83.7
-        P59 = data['4OHTRZ59'].vals * VSQUARED / 29.7
-        P60 = data['4OHTRZ60'].vals * VSQUARED / 30.7
-        P61 = data['4OHTRZ61'].vals * VSQUARED / 33.7
-        P62 = data['4OHTRZ62'].vals * VSQUARED / 36.1
-        P63 = data['4OHTRZ63'].vals * VSQUARED / 36.1
-        P64 = data['4OHTRZ64'].vals * VSQUARED / 44.1
-        P65 = data['4OHTRZ65'].vals * VSQUARED / 37.5
-        P66 = data['4OHTRZ66'].vals * VSQUARED / 29.8
-        P67 = data['4OHTRZ67'].vals * VSQUARED / 52.0
-        P68 = data['4OHTRZ68'].vals * VSQUARED / 29.0
-        P69 = data['4OHTRZ69'].vals * VSQUARED / 37.5
+        P58 = data["4OHTRZ58"].vals * VSQUARED / 83.7
+        P59 = data["4OHTRZ59"].vals * VSQUARED / 29.7
+        P60 = data["4OHTRZ60"].vals * VSQUARED / 30.7
+        P61 = data["4OHTRZ61"].vals * VSQUARED / 33.7
+        P62 = data["4OHTRZ62"].vals * VSQUARED / 36.1
+        P63 = data["4OHTRZ63"].vals * VSQUARED / 36.1
+        P64 = data["4OHTRZ64"].vals * VSQUARED / 44.1
+        P65 = data["4OHTRZ65"].vals * VSQUARED / 37.5
+        P66 = data["4OHTRZ66"].vals * VSQUARED / 29.8
+        P67 = data["4OHTRZ67"].vals * VSQUARED / 52.0
+        P68 = data["4OHTRZ68"].vals * VSQUARED / 29.0
+        P69 = data["4OHTRZ69"].vals * VSQUARED / 37.5
 
-        P75 = data['4OHTRZ75'].vals * VSQUARED / 130.2
-        P76 = data['4OHTRZ76'].vals * VSQUARED / 133.4
-        P77 = data['4OHTRZ77'].vals * VSQUARED / 131.5
-        P78 = data['4OHTRZ78'].vals * VSQUARED / 133.2
-        P79 = data['4OHTRZ79'].vals * VSQUARED / 133.1
-        P80 = data['4OHTRZ80'].vals * VSQUARED / 133.0
-        P25 = data['4OHTRZ25'].vals * VSQUARED / 383.0
-        P26 = data['4OHTRZ26'].vals * VSQUARED / 383.5
-        P27 = data['4OHTRZ27'].vals * VSQUARED / 383.0
-        P28 = data['4OHTRZ28'].vals * VSQUARED / 382.3
-        P29 = data['4OHTRZ29'].vals * VSQUARED / 384.0
-        P30 = data['4OHTRZ30'].vals * VSQUARED / 383.0
+        P75 = data["4OHTRZ75"].vals * VSQUARED / 130.2
+        P76 = data["4OHTRZ76"].vals * VSQUARED / 133.4
+        P77 = data["4OHTRZ77"].vals * VSQUARED / 131.5
+        P78 = data["4OHTRZ78"].vals * VSQUARED / 133.2
+        P79 = data["4OHTRZ79"].vals * VSQUARED / 133.1
+        P80 = data["4OHTRZ80"].vals * VSQUARED / 133.0
+        P25 = data["4OHTRZ25"].vals * VSQUARED / 383.0
+        P26 = data["4OHTRZ26"].vals * VSQUARED / 383.5
+        P27 = data["4OHTRZ27"].vals * VSQUARED / 383.0
+        P28 = data["4OHTRZ28"].vals * VSQUARED / 382.3
+        P29 = data["4OHTRZ29"].vals * VSQUARED / 384.0
+        P30 = data["4OHTRZ30"].vals * VSQUARED / 383.0
 
         PHRMA = (
             P01
@@ -2676,22 +2676,22 @@ class DP_PTOTAL(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_SUNANGLE(DerivedParameterThermal):
-    rootparams = ['AOSARES1']
+    rootparams = ["AOSARES1"]
     time_step = 0.25625
 
     def calc(self, data):
-        SUNANGLE = 90 - data['AOSARES1'].vals
+        SUNANGLE = 90 - data["AOSARES1"].vals
         return SUNANGLE
 
 
 # --------------------------------------------
 class DP_TABMAX(DerivedParameterThermal):
-    rootparams = ['OOBTHR47', 'OOBTHR42', 'OOBTHR43']
+    rootparams = ["OOBTHR47", "OOBTHR42", "OOBTHR43"]
     time_step = 32.8
 
     def calc(self, data):
         TABMAX = np.max(
-            [data['OOBTHR42'].vals, data['OOBTHR43'].vals, data['OOBTHR47'].vals],
+            [data["OOBTHR42"].vals, data["OOBTHR43"].vals, data["OOBTHR47"].vals],
             axis=0,
         )
         return TABMAX
@@ -2699,12 +2699,12 @@ class DP_TABMAX(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_TABMIN(DerivedParameterThermal):
-    rootparams = ['OOBTHR47', 'OOBTHR42', 'OOBTHR43']
+    rootparams = ["OOBTHR47", "OOBTHR42", "OOBTHR43"]
     time_step = 32.8
 
     def calc(self, data):
         TABMIN = np.min(
-            [data['OOBTHR42'].vals, data['OOBTHR43'].vals, data['OOBTHR47'].vals],
+            [data["OOBTHR42"].vals, data["OOBTHR43"].vals, data["OOBTHR47"].vals],
             axis=0,
         )
         return TABMIN
@@ -2712,12 +2712,12 @@ class DP_TABMIN(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_TELAB_AVE(DerivedParameterThermal):
-    rootparams = ['OOBTHR47', 'OOBTHR42', 'OOBTHR43']
+    rootparams = ["OOBTHR47", "OOBTHR42", "OOBTHR43"]
     time_step = 32.8
 
     def calc(self, data):
         TELAB_AVE = (
-            data['OOBTHR42'].vals + data['OOBTHR43'].vals + data['OOBTHR47'].vals
+            data["OOBTHR42"].vals + data["OOBTHR43"].vals + data["OOBTHR47"].vals
         ) / 3
         return TELAB_AVE
 
@@ -2725,23 +2725,23 @@ class DP_TELAB_AVE(DerivedParameterThermal):
 # --------------------------------------------
 class DP_TELHS_AVE(DerivedParameterThermal):
     rootparams = [
-        'OOBTHR02',
-        'OOBTHR03',
-        'OOBTHR06',
-        'OOBTHR07',
-        'OOBTHR04',
-        'OOBTHR05',
+        "OOBTHR02",
+        "OOBTHR03",
+        "OOBTHR06",
+        "OOBTHR07",
+        "OOBTHR04",
+        "OOBTHR05",
     ]
     time_step = 32.8
 
     def calc(self, data):
         TELHS_AVE = (
-            data['OOBTHR02'].vals
-            + data['OOBTHR03'].vals
-            + data['OOBTHR04'].vals
-            + data['OOBTHR05'].vals
-            + data['OOBTHR06'].vals
-            + data['OOBTHR07'].vals
+            data["OOBTHR02"].vals
+            + data["OOBTHR03"].vals
+            + data["OOBTHR04"].vals
+            + data["OOBTHR05"].vals
+            + data["OOBTHR06"].vals
+            + data["OOBTHR07"].vals
         ) / 6
         return TELHS_AVE
 
@@ -2749,23 +2749,23 @@ class DP_TELHS_AVE(DerivedParameterThermal):
 # --------------------------------------------
 class DP_TELSS_AVE(DerivedParameterThermal):
     rootparams = [
-        'OOBTHR51',
-        'OOBTHR50',
-        'OOBTHR53',
-        'OOBTHR52',
-        'OOBTHR54',
-        'OOBTHR49',
+        "OOBTHR51",
+        "OOBTHR50",
+        "OOBTHR53",
+        "OOBTHR52",
+        "OOBTHR54",
+        "OOBTHR49",
     ]
     time_step = 32.8
 
     def calc(self, data):
         TELSS_AVE = (
-            data['OOBTHR49'].vals
-            + data['OOBTHR50'].vals
-            + data['OOBTHR51'].vals
-            + data['OOBTHR52'].vals
-            + data['OOBTHR53'].vals
-            + data['OOBTHR54'].vals
+            data["OOBTHR49"].vals
+            + data["OOBTHR50"].vals
+            + data["OOBTHR51"].vals
+            + data["OOBTHR52"].vals
+            + data["OOBTHR53"].vals
+            + data["OOBTHR54"].vals
         ) / 6
         return TELSS_AVE
 
@@ -2773,12 +2773,12 @@ class DP_TELSS_AVE(DerivedParameterThermal):
 # --------------------------------------------
 class DP_THSMAX(DerivedParameterThermal):
     rootparams = [
-        'OOBTHR02',
-        'OOBTHR03',
-        'OOBTHR06',
-        'OOBTHR07',
-        'OOBTHR04',
-        'OOBTHR05',
+        "OOBTHR02",
+        "OOBTHR03",
+        "OOBTHR06",
+        "OOBTHR07",
+        "OOBTHR04",
+        "OOBTHR05",
     ]
     time_step = 32.8
 
@@ -2792,12 +2792,12 @@ class DP_THSMAX(DerivedParameterThermal):
 # --------------------------------------------
 class DP_THSMIN(DerivedParameterThermal):
     rootparams = [
-        'OOBTHR02',
-        'OOBTHR03',
-        'OOBTHR06',
-        'OOBTHR07',
-        'OOBTHR04',
-        'OOBTHR05',
+        "OOBTHR02",
+        "OOBTHR03",
+        "OOBTHR06",
+        "OOBTHR07",
+        "OOBTHR04",
+        "OOBTHR05",
     ]
     time_step = 32.8
 
@@ -2810,22 +2810,22 @@ class DP_THSMIN(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_TILT_AXIAL(DerivedParameterThermal):
-    rootparams = ['OOBAGRD3']
+    rootparams = ["OOBAGRD3"]
     time_step = 32.8
 
     def calc(self, data):
-        TILT_AXIAL = np.abs(data['OOBAGRD3'].vals) * 0.1084
+        TILT_AXIAL = np.abs(data["OOBAGRD3"].vals) * 0.1084
         return TILT_AXIAL
 
 
 # --------------------------------------------
 class DP_TILT_BULK(DerivedParameterThermal):
-    rootparams = ['OHRTHR43', 'OHRTHR42']
+    rootparams = ["OHRTHR43", "OHRTHR42"]
     time_step = 32.8
 
     def calc(self, data):
         TILT_BULK = (
-            np.abs((data['OHRTHR42'].vals + data['OHRTHR43'].vals) / 2.0 - 70.0)
+            np.abs((data["OHRTHR42"].vals + data["OHRTHR43"].vals) / 2.0 - 70.0)
             * 0.0704
         )
         return TILT_BULK
@@ -2833,42 +2833,42 @@ class DP_TILT_BULK(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_TILT_DIAM(DerivedParameterThermal):
-    rootparams = ['OOBAGRD6']
+    rootparams = ["OOBAGRD6"]
     time_step = 32.8
 
     def calc(self, data):
-        TILT_DIAM = np.abs(1.0 * data['OOBAGRD6'].vals) * 0.3032
+        TILT_DIAM = np.abs(1.0 * data["OOBAGRD6"].vals) * 0.3032
         return TILT_DIAM
 
 
 # --------------------------------------------
 class DP_TILT_MAX(DerivedParameterThermal):
-    rootparams = ['OOBAGRD6', 'OOBAGRD3', 'OHRTHR43', 'OHRTHR42']
+    rootparams = ["OOBAGRD6", "OOBAGRD3", "OHRTHR43", "OHRTHR42"]
     time_step = 32.8
 
     def calc(self, data):
-        TILT_DIAM = np.abs(1.0 * data['OOBAGRD6'].vals) * 0.3032
+        TILT_DIAM = np.abs(1.0 * data["OOBAGRD6"].vals) * 0.3032
         TILT_BULK = (
-            np.abs((data['OHRTHR42'].vals + data['OHRTHR43'].vals) / 2.0 - 70.0)
+            np.abs((data["OHRTHR42"].vals + data["OHRTHR43"].vals) / 2.0 - 70.0)
             * 0.0704
         )
-        TILT_AXIAL = np.abs(data['OOBAGRD3'].vals) * 0.1084
+        TILT_AXIAL = np.abs(data["OOBAGRD3"].vals) * 0.1084
         TILT_MAX = TILT_BULK + TILT_AXIAL + TILT_DIAM
         return TILT_MAX
 
 
 # --------------------------------------------
 class DP_TILT_RSS(DerivedParameterThermal):
-    rootparams = ['OOBAGRD6', 'OOBAGRD3', 'OHRTHR43', 'OHRTHR42']
+    rootparams = ["OOBAGRD6", "OOBAGRD3", "OHRTHR43", "OHRTHR42"]
     time_step = 32.8
 
     def calc(self, data):
-        TILT_DIAM = np.abs(1.0 * data['OOBAGRD6'].vals) * 0.3032
+        TILT_DIAM = np.abs(1.0 * data["OOBAGRD6"].vals) * 0.3032
         TILT_BULK = (
-            np.abs((data['OHRTHR42'].vals + data['OHRTHR43'].vals) / 2.0 - 70.0)
+            np.abs((data["OHRTHR42"].vals + data["OHRTHR43"].vals) / 2.0 - 70.0)
             * 0.0704
         )
-        TILT_AXIAL = np.abs(data['OOBAGRD3'].vals) * 0.1084
+        TILT_AXIAL = np.abs(data["OOBAGRD3"].vals) * 0.1084
         TILT_RSS = np.sqrt(TILT_BULK**2 + TILT_AXIAL**2 + TILT_DIAM**2)
         return TILT_RSS
 
@@ -2876,12 +2876,12 @@ class DP_TILT_RSS(DerivedParameterThermal):
 # --------------------------------------------
 class DP_TSSMAX(DerivedParameterThermal):
     rootparams = [
-        'OOBTHR51',
-        'OOBTHR50',
-        'OOBTHR53',
-        'OOBTHR52',
-        'OOBTHR54',
-        'OOBTHR49',
+        "OOBTHR51",
+        "OOBTHR50",
+        "OOBTHR53",
+        "OOBTHR52",
+        "OOBTHR54",
+        "OOBTHR49",
     ]
     time_step = 32.8
 
@@ -2895,12 +2895,12 @@ class DP_TSSMAX(DerivedParameterThermal):
 # --------------------------------------------
 class DP_TSSMIN(DerivedParameterThermal):
     rootparams = [
-        'OOBTHR51',
-        'OOBTHR50',
-        'OOBTHR53',
-        'OOBTHR52',
-        'OOBTHR54',
-        'OOBTHR49',
+        "OOBTHR51",
+        "OOBTHR50",
+        "OOBTHR53",
+        "OOBTHR52",
+        "OOBTHR54",
+        "OOBTHR49",
     ]
     time_step = 32.8
 
@@ -2913,12 +2913,12 @@ class DP_TSSMIN(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_HADG(DerivedParameterThermal):
-    rootparams = ['OHRMGRD3', 'OHRMGRD6']
+    rootparams = ["OHRMGRD3", "OHRMGRD6"]
     time_step = 32.8
 
     def calc(self, data):
         HADG = np.max(
-            (np.abs(data['OHRMGRD3'].vals), np.abs(data['OHRMGRD6'].vals)), axis=0
+            (np.abs(data["OHRMGRD3"].vals), np.abs(data["OHRMGRD6"].vals)), axis=0
         )
 
         return HADG
@@ -2927,12 +2927,12 @@ class DP_HADG(DerivedParameterThermal):
 # --------------------------------------------
 class DP_ABH_DUTYCYCLE(DerivedParameterThermal):
     rootparams = [
-        '4OHTRZ53',
-        '4OHTRZ54',
-        '4OHTRZ55',
-        '4OHTRZ57',
-        '4S1PWR05',
-        '4S1PWR06',
+        "4OHTRZ53",
+        "4OHTRZ54",
+        "4OHTRZ55",
+        "4OHTRZ57",
+        "4S1PWR05",
+        "4S1PWR06",
     ]
     time_step = 32.8
 
@@ -2940,11 +2940,11 @@ class DP_ABH_DUTYCYCLE(DerivedParameterThermal):
         self.fix_bus_5_and_bus_6(data)
         RTOTAL = 1.0 / (1 / 94.1 + 1 / 124.3 + 1 / 126.8 + 1 / 142.3)
         DC1 = (
-            np.abs(data['4OHTRZ53'].vals) / 94.1 + np.abs(data['4OHTRZ54'].vals) / 124.3
+            np.abs(data["4OHTRZ53"].vals) / 94.1 + np.abs(data["4OHTRZ54"].vals) / 124.3
         )
         DC2 = (
-            np.abs(data['4OHTRZ55'].vals) / 126.8
-            + np.abs(data['4OHTRZ57'].vals) / 142.3
+            np.abs(data["4OHTRZ55"].vals) / 126.8
+            + np.abs(data["4OHTRZ57"].vals) / 142.3
         )
         ABH_DUTYCYCLE = RTOTAL * (DC1 + DC2)
 

--- a/Ska/engarchive/derived/thermal.py
+++ b/Ska/engarchive/derived/thermal.py
@@ -13,15 +13,31 @@ class DerivedParameterThermal(base.DerivedParameter):
 
     def fix_bus_5_and_bus_6(self, data):
         # These zones cannot be commanded if Bus 5 or Bus 6 is disabled
-        bus_5_and_6_zones = ['4OHTRZ27', '4OHTRZ28', '4OHTRZ43', '4OHTRZ45',
-                             '4OHTRZ47', '4OHTRZ49', '4OHTRZ52', '4OHTRZ53',
-                             '4OHTRZ29', '4OHTRZ35', '4OHTRZ42', '4OHTRZ44',
-                             '4OHTRZ46', '4OHTRZ48', '4OHTRZ50', '4OHTRZ54']
+        bus_5_and_6_zones = [
+            '4OHTRZ27',
+            '4OHTRZ28',
+            '4OHTRZ43',
+            '4OHTRZ45',
+            '4OHTRZ47',
+            '4OHTRZ49',
+            '4OHTRZ52',
+            '4OHTRZ53',
+            '4OHTRZ29',
+            '4OHTRZ35',
+            '4OHTRZ42',
+            '4OHTRZ44',
+            '4OHTRZ46',
+            '4OHTRZ48',
+            '4OHTRZ50',
+            '4OHTRZ54',
+        ]
 
         for msid in bus_5_and_6_zones:
             if msid in data.keys():
                 # Heater must be off if either bus is disabled
-                disa = (data['4S1PWR05'].vals == 'DISA') | (data['4S1PWR06'].vals == 'DISA')
+                disa = (data['4S1PWR05'].vals == 'DISA') | (
+                    data['4S1PWR06'].vals == 'DISA'
+                )
                 data[msid].vals[disa] = 0
 
     def fix_4OHTRZ50(self, data):
@@ -38,18 +54,39 @@ class DerivedParameterThermal(base.DerivedParameter):
 
 
 class DP_EE_AXIAL(DerivedParameterThermal):
-    rootparams = ['OHRTHR58', 'OHRTHR12', 'OHRTHR36', 'OHRTHR56', 'OHRTHR57',
-                  'OHRTHR55', 'OHRTHR35', 'OHRTHR37', 'OHRTHR34', 'OHRTHR13',
-                  'OHRTHR10', 'OHRTHR11']
+    rootparams = [
+        'OHRTHR58',
+        'OHRTHR12',
+        'OHRTHR36',
+        'OHRTHR56',
+        'OHRTHR57',
+        'OHRTHR55',
+        'OHRTHR35',
+        'OHRTHR37',
+        'OHRTHR34',
+        'OHRTHR13',
+        'OHRTHR10',
+        'OHRTHR11',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        HYPAVE = (data['OHRTHR12'].vals + data['OHRTHR13'].vals +
-                  data['OHRTHR36'].vals + data['OHRTHR37'].vals +
-                  data['OHRTHR57'].vals + data['OHRTHR58'].vals) / 6
-        PARAVE = (data['OHRTHR10'].vals + data['OHRTHR11'].vals +
-                  data['OHRTHR34'].vals + data['OHRTHR35'].vals +
-                  data['OHRTHR55'].vals + data['OHRTHR56'].vals) / 6
+        HYPAVE = (
+            data['OHRTHR12'].vals
+            + data['OHRTHR13'].vals
+            + data['OHRTHR36'].vals
+            + data['OHRTHR37'].vals
+            + data['OHRTHR57'].vals
+            + data['OHRTHR58'].vals
+        ) / 6
+        PARAVE = (
+            data['OHRTHR10'].vals
+            + data['OHRTHR11'].vals
+            + data['OHRTHR34'].vals
+            + data['OHRTHR35'].vals
+            + data['OHRTHR55'].vals
+            + data['OHRTHR56'].vals
+        ) / 6
         HAAG = PARAVE - HYPAVE
         DTAXIAL = np.abs(1.0 * HAAG)
         EE_AXIAL = DTAXIAL * 0.0034
@@ -58,23 +95,55 @@ class DP_EE_AXIAL(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_EE_BULK(DerivedParameterThermal):
-    rootparams = ['OHRTHR10', 'OHRTHR58', 'OHRTHR52', 'OHRTHR53', 'OHRTHR56',
-                  'OHRTHR57', 'OHRTHR54', 'OHRTHR55', 'OHRTHR12', 'OHRTHR35',
-                  'OHRTHR11', 'OHRTHR08', 'OHRTHR09', 'OHRTHR31', 'OHRTHR33',
-                  'OHRTHR34', 'OHRTHR13', 'OHRTHR36', 'OHRTHR37']
+    rootparams = [
+        'OHRTHR10',
+        'OHRTHR58',
+        'OHRTHR52',
+        'OHRTHR53',
+        'OHRTHR56',
+        'OHRTHR57',
+        'OHRTHR54',
+        'OHRTHR55',
+        'OHRTHR12',
+        'OHRTHR35',
+        'OHRTHR11',
+        'OHRTHR08',
+        'OHRTHR09',
+        'OHRTHR31',
+        'OHRTHR33',
+        'OHRTHR34',
+        'OHRTHR13',
+        'OHRTHR36',
+        'OHRTHR37',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        P_SUM = (data['OHRTHR10'].vals + data['OHRTHR11'].vals +
-                 data['OHRTHR34'].vals + data['OHRTHR35'].vals +
-                 data['OHRTHR55'].vals + data['OHRTHR56'].vals)
-        H_SUM = (data['OHRTHR12'].vals + data['OHRTHR13'].vals +
-                 data['OHRTHR36'].vals + data['OHRTHR37'].vals +
-                 data['OHRTHR57'].vals + data['OHRTHR58'].vals)
-        CAP_SUM = (data['OHRTHR08'].vals + data['OHRTHR09'].vals +
-                   data['OHRTHR31'].vals + data['OHRTHR33'].vals +
-                   data['OHRTHR52'].vals + data['OHRTHR53'].vals +
-                   data['OHRTHR54'].vals)
+        P_SUM = (
+            data['OHRTHR10'].vals
+            + data['OHRTHR11'].vals
+            + data['OHRTHR34'].vals
+            + data['OHRTHR35'].vals
+            + data['OHRTHR55'].vals
+            + data['OHRTHR56'].vals
+        )
+        H_SUM = (
+            data['OHRTHR12'].vals
+            + data['OHRTHR13'].vals
+            + data['OHRTHR36'].vals
+            + data['OHRTHR37'].vals
+            + data['OHRTHR57'].vals
+            + data['OHRTHR58'].vals
+        )
+        CAP_SUM = (
+            data['OHRTHR08'].vals
+            + data['OHRTHR09'].vals
+            + data['OHRTHR31'].vals
+            + data['OHRTHR33'].vals
+            + data['OHRTHR52'].vals
+            + data['OHRTHR53'].vals
+            + data['OHRTHR54'].vals
+        )
         HMCSAVE = (CAP_SUM + P_SUM + H_SUM) / 19.0
         DTBULK = np.abs(1.0 * HMCSAVE - 69.8)
         EE_BULK = DTBULK * 0.0267
@@ -85,6 +154,7 @@ class DP_EE_BULK(DerivedParameterThermal):
 # --------------------------------------------
 class DP_EE_DIAM(DerivedParameterThermal):
     """Kodak diametrical encircled energy"""
+
     rootparams = ['OHRMGRD6', 'OHRMGRD3']
     time_step = 32.8
 
@@ -98,15 +168,27 @@ class DP_EE_DIAM(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_EE_RADIAL(DerivedParameterThermal):
-    rootparams = ['OHRTHR52', 'OHRTHR53', 'OHRTHR54', 'OHRTHR31', 'OHRTHR09',
-                  'OHRTHR08', 'OHRTHR33']
+    rootparams = [
+        'OHRTHR52',
+        'OHRTHR53',
+        'OHRTHR54',
+        'OHRTHR31',
+        'OHRTHR09',
+        'OHRTHR08',
+        'OHRTHR33',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        CAPIAVE = (data['OHRTHR09'].vals + data['OHRTHR53'].vals +
-                   data['OHRTHR54'].vals) / 3
-        CAPOAVE = (data['OHRTHR08'].vals + data['OHRTHR31'].vals +
-                   data['OHRTHR33'].vals + data['OHRTHR52'].vals) / 4
+        CAPIAVE = (
+            data['OHRTHR09'].vals + data['OHRTHR53'].vals + data['OHRTHR54'].vals
+        ) / 3
+        CAPOAVE = (
+            data['OHRTHR08'].vals
+            + data['OHRTHR31'].vals
+            + data['OHRTHR33'].vals
+            + data['OHRTHR52'].vals
+        ) / 4
         HARG = CAPOAVE - CAPIAVE
         DTRADIAL = np.abs(1.0 * HARG)
         EE_RADIAL = DTRADIAL * 0.0127
@@ -115,34 +197,82 @@ class DP_EE_RADIAL(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_EE_THERM(DerivedParameterThermal):
-    rootparams = ['OHRTHR37', 'OHRTHR58', 'OHRMGRD6', 'OHRMGRD3', 'OHRTHR35',
-                  'OHRTHR52', 'OHRTHR53', 'OHRTHR56', 'OHRTHR57', 'OHRTHR54',
-                  'OHRTHR55', 'OHRTHR12', 'OHRTHR36', 'OHRTHR08', 'OHRTHR09',
-                  'OHRTHR31', 'OHRTHR33', 'OHRTHR34', 'OHRTHR13', 'OHRTHR10',
-                  'OHRTHR11']
+    rootparams = [
+        'OHRTHR37',
+        'OHRTHR58',
+        'OHRMGRD6',
+        'OHRMGRD3',
+        'OHRTHR35',
+        'OHRTHR52',
+        'OHRTHR53',
+        'OHRTHR56',
+        'OHRTHR57',
+        'OHRTHR54',
+        'OHRTHR55',
+        'OHRTHR12',
+        'OHRTHR36',
+        'OHRTHR08',
+        'OHRTHR09',
+        'OHRTHR31',
+        'OHRTHR33',
+        'OHRTHR34',
+        'OHRTHR13',
+        'OHRTHR10',
+        'OHRTHR11',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        CAP_SUM = (data['OHRTHR08'].vals + data['OHRTHR09'].vals +
-                   data['OHRTHR31'].vals + data['OHRTHR33'].vals +
-                   data['OHRTHR52'].vals + data['OHRTHR53'].vals +
-                   data['OHRTHR54'].vals)
-        CAPIAVE = (data['OHRTHR09'].vals + data['OHRTHR53'].vals +
-                   data['OHRTHR54'].vals) / 3
-        P_SUM = (data['OHRTHR10'].vals + data['OHRTHR11'].vals +
-                 data['OHRTHR34'].vals + data['OHRTHR35'].vals +
-                 data['OHRTHR55'].vals + data['OHRTHR56'].vals)
-        CAPOAVE = (data['OHRTHR08'].vals + data['OHRTHR31'].vals +
-                   data['OHRTHR33'].vals + data['OHRTHR52'].vals) / 4
-        H_SUM = (data['OHRTHR12'].vals + data['OHRTHR13'].vals +
-                 data['OHRTHR36'].vals + data['OHRTHR37'].vals +
-                 data['OHRTHR57'].vals + data['OHRTHR58'].vals)
-        PARAVE = (data['OHRTHR10'].vals + data['OHRTHR11'].vals +
-                  data['OHRTHR34'].vals + data['OHRTHR35'].vals +
-                  data['OHRTHR55'].vals + data['OHRTHR56'].vals) / 6
-        HYPAVE = (data['OHRTHR12'].vals + data['OHRTHR13'].vals +
-                  data['OHRTHR36'].vals + data['OHRTHR37'].vals +
-                  data['OHRTHR57'].vals + data['OHRTHR58'].vals) / 6
+        CAP_SUM = (
+            data['OHRTHR08'].vals
+            + data['OHRTHR09'].vals
+            + data['OHRTHR31'].vals
+            + data['OHRTHR33'].vals
+            + data['OHRTHR52'].vals
+            + data['OHRTHR53'].vals
+            + data['OHRTHR54'].vals
+        )
+        CAPIAVE = (
+            data['OHRTHR09'].vals + data['OHRTHR53'].vals + data['OHRTHR54'].vals
+        ) / 3
+        P_SUM = (
+            data['OHRTHR10'].vals
+            + data['OHRTHR11'].vals
+            + data['OHRTHR34'].vals
+            + data['OHRTHR35'].vals
+            + data['OHRTHR55'].vals
+            + data['OHRTHR56'].vals
+        )
+        CAPOAVE = (
+            data['OHRTHR08'].vals
+            + data['OHRTHR31'].vals
+            + data['OHRTHR33'].vals
+            + data['OHRTHR52'].vals
+        ) / 4
+        H_SUM = (
+            data['OHRTHR12'].vals
+            + data['OHRTHR13'].vals
+            + data['OHRTHR36'].vals
+            + data['OHRTHR37'].vals
+            + data['OHRTHR57'].vals
+            + data['OHRTHR58'].vals
+        )
+        PARAVE = (
+            data['OHRTHR10'].vals
+            + data['OHRTHR11'].vals
+            + data['OHRTHR34'].vals
+            + data['OHRTHR35'].vals
+            + data['OHRTHR55'].vals
+            + data['OHRTHR56'].vals
+        ) / 6
+        HYPAVE = (
+            data['OHRTHR12'].vals
+            + data['OHRTHR13'].vals
+            + data['OHRTHR36'].vals
+            + data['OHRTHR37'].vals
+            + data['OHRTHR57'].vals
+            + data['OHRTHR58'].vals
+        ) / 6
         VAL1 = np.abs(1.0 * data['OHRMGRD3'].vals)
         VAL2 = np.abs(1.0 * data['OHRMGRD6'].vals)
 
@@ -159,54 +289,117 @@ class DP_EE_THERM(DerivedParameterThermal):
         EE_AXIAL = DTAXIAL * 0.0034
         EE_BULK = DTBULK * 0.0267
         EE_DIAM = DTDIAM * 0.401
-        EE_THERM = (EE_BULK + EE_AXIAL + EE_RADIAL + EE_DIAM)
+        EE_THERM = EE_BULK + EE_AXIAL + EE_RADIAL + EE_DIAM
 
         return EE_THERM
 
 
 # --------------------------------------------
 class DP_HAAG(DerivedParameterThermal):
-    rootparams = ['OHRTHR58', 'OHRTHR12', 'OHRTHR56', 'OHRTHR57', 'OHRTHR55',
-                  'OHRTHR13', 'OHRTHR36', 'OHRTHR37', 'OHRTHR34', 'OHRTHR35',
-                  'OHRTHR10', 'OHRTHR11']
+    rootparams = [
+        'OHRTHR58',
+        'OHRTHR12',
+        'OHRTHR56',
+        'OHRTHR57',
+        'OHRTHR55',
+        'OHRTHR13',
+        'OHRTHR36',
+        'OHRTHR37',
+        'OHRTHR34',
+        'OHRTHR35',
+        'OHRTHR10',
+        'OHRTHR11',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        HYPAVE = (data['OHRTHR12'].vals + data['OHRTHR13'].vals +
-                  data['OHRTHR36'].vals + data['OHRTHR37'].vals +
-                  data['OHRTHR57'].vals + data['OHRTHR58'].vals) / 6
-        PARAVE = (data['OHRTHR10'].vals + data['OHRTHR11'].vals +
-                  data['OHRTHR34'].vals + data['OHRTHR35'].vals +
-                  data['OHRTHR55'].vals + data['OHRTHR56'].vals) / 6
+        HYPAVE = (
+            data['OHRTHR12'].vals
+            + data['OHRTHR13'].vals
+            + data['OHRTHR36'].vals
+            + data['OHRTHR37'].vals
+            + data['OHRTHR57'].vals
+            + data['OHRTHR58'].vals
+        ) / 6
+        PARAVE = (
+            data['OHRTHR10'].vals
+            + data['OHRTHR11'].vals
+            + data['OHRTHR34'].vals
+            + data['OHRTHR35'].vals
+            + data['OHRTHR55'].vals
+            + data['OHRTHR56'].vals
+        ) / 6
         HAAG = PARAVE - HYPAVE
         return HAAG
 
 
 # --------------------------------------------
 class DP_HARG(DerivedParameterThermal):
-    rootparams = ['OHRTHR52', 'OHRTHR53', 'OHRTHR54', 'OHRTHR31', 'OHRTHR09',
-                  'OHRTHR08', 'OHRTHR33']
+    rootparams = [
+        'OHRTHR52',
+        'OHRTHR53',
+        'OHRTHR54',
+        'OHRTHR31',
+        'OHRTHR09',
+        'OHRTHR08',
+        'OHRTHR33',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        CAPIAVE = (data['OHRTHR09'].vals + data['OHRTHR53'].vals +
-                   data['OHRTHR54'].vals) / 3
-        CAPOAVE = (data['OHRTHR08'].vals + data['OHRTHR31'].vals +
-                   data['OHRTHR33'].vals + data['OHRTHR52'].vals) / 4
+        CAPIAVE = (
+            data['OHRTHR09'].vals + data['OHRTHR53'].vals + data['OHRTHR54'].vals
+        ) / 3
+        CAPOAVE = (
+            data['OHRTHR08'].vals
+            + data['OHRTHR31'].vals
+            + data['OHRTHR33'].vals
+            + data['OHRTHR52'].vals
+        ) / 4
         HARG = CAPOAVE - CAPIAVE
         return HARG
 
 
 # --------------------------------------------
 class DP_HMAX35(DerivedParameterThermal):
-    rootparams = ['OHRTHR52', 'OHRTHR53', 'OHRTHR50', 'OHRTHR51', 'OHRTHR56',
-                  'OHRTHR55', 'OHRTHR23', 'OHRTHR22', 'OHRTHR30', 'OHRTHR33',
-                  'OHRTHR12', 'OHRTHR13', 'OHRTHR10', 'OHRTHR11', 'OHRTHR36',
-                  'OHRTHR37', 'OHRTHR49', 'OHRTHR45', 'OHRTHR44', 'OHRTHR47',
-                  'OHRTHR46', 'OHRTHR42', 'OHRTHR29', 'OHRTHR02', 'OHRTHR05',
-                  'OHRTHR04', 'OHRTHR07', 'OHRTHR06', 'OHRTHR09', 'OHRTHR08',
-                  'OHRTHR21', 'OHRTHR27', 'OHRTHR26', 'OHRTHR25', 'OHRTHR24',
-                  'OHRTHR03']
+    rootparams = [
+        'OHRTHR52',
+        'OHRTHR53',
+        'OHRTHR50',
+        'OHRTHR51',
+        'OHRTHR56',
+        'OHRTHR55',
+        'OHRTHR23',
+        'OHRTHR22',
+        'OHRTHR30',
+        'OHRTHR33',
+        'OHRTHR12',
+        'OHRTHR13',
+        'OHRTHR10',
+        'OHRTHR11',
+        'OHRTHR36',
+        'OHRTHR37',
+        'OHRTHR49',
+        'OHRTHR45',
+        'OHRTHR44',
+        'OHRTHR47',
+        'OHRTHR46',
+        'OHRTHR42',
+        'OHRTHR29',
+        'OHRTHR02',
+        'OHRTHR05',
+        'OHRTHR04',
+        'OHRTHR07',
+        'OHRTHR06',
+        'OHRTHR09',
+        'OHRTHR08',
+        'OHRTHR21',
+        'OHRTHR27',
+        'OHRTHR26',
+        'OHRTHR25',
+        'OHRTHR24',
+        'OHRTHR03',
+    ]
     time_step = 32.8
 
     def calc(self, data):
@@ -218,37 +411,99 @@ class DP_HMAX35(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_HMCSAVE(DerivedParameterThermal):
-    rootparams = ['OHRTHR10', 'OHRTHR58', 'OHRTHR52', 'OHRTHR53', 'OHRTHR56',
-                  'OHRTHR57', 'OHRTHR54', 'OHRTHR55', 'OHRTHR12', 'OHRTHR35',
-                  'OHRTHR11', 'OHRTHR08', 'OHRTHR09', 'OHRTHR31', 'OHRTHR33',
-                  'OHRTHR34', 'OHRTHR13', 'OHRTHR36', 'OHRTHR37']
+    rootparams = [
+        'OHRTHR10',
+        'OHRTHR58',
+        'OHRTHR52',
+        'OHRTHR53',
+        'OHRTHR56',
+        'OHRTHR57',
+        'OHRTHR54',
+        'OHRTHR55',
+        'OHRTHR12',
+        'OHRTHR35',
+        'OHRTHR11',
+        'OHRTHR08',
+        'OHRTHR09',
+        'OHRTHR31',
+        'OHRTHR33',
+        'OHRTHR34',
+        'OHRTHR13',
+        'OHRTHR36',
+        'OHRTHR37',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        P_SUM = (data['OHRTHR10'].vals + data['OHRTHR11'].vals +
-                 data['OHRTHR34'].vals + data['OHRTHR35'].vals +
-                 data['OHRTHR55'].vals + data['OHRTHR56'].vals)
-        H_SUM = (data['OHRTHR12'].vals + data['OHRTHR13'].vals +
-                 data['OHRTHR36'].vals + data['OHRTHR37'].vals +
-                 data['OHRTHR57'].vals + data['OHRTHR58'].vals)
-        CAP_SUM = (data['OHRTHR08'].vals + data['OHRTHR09'].vals +
-                   data['OHRTHR31'].vals + data['OHRTHR33'].vals +
-                   data['OHRTHR52'].vals + data['OHRTHR53'].vals +
-                   data['OHRTHR54'].vals)
+        P_SUM = (
+            data['OHRTHR10'].vals
+            + data['OHRTHR11'].vals
+            + data['OHRTHR34'].vals
+            + data['OHRTHR35'].vals
+            + data['OHRTHR55'].vals
+            + data['OHRTHR56'].vals
+        )
+        H_SUM = (
+            data['OHRTHR12'].vals
+            + data['OHRTHR13'].vals
+            + data['OHRTHR36'].vals
+            + data['OHRTHR37'].vals
+            + data['OHRTHR57'].vals
+            + data['OHRTHR58'].vals
+        )
+        CAP_SUM = (
+            data['OHRTHR08'].vals
+            + data['OHRTHR09'].vals
+            + data['OHRTHR31'].vals
+            + data['OHRTHR33'].vals
+            + data['OHRTHR52'].vals
+            + data['OHRTHR53'].vals
+            + data['OHRTHR54'].vals
+        )
         HMCSAVE = (CAP_SUM + P_SUM + H_SUM) / 19.0
         return HMCSAVE
 
 
 # --------------------------------------------
 class DP_HMIN35(DerivedParameterThermal):
-    rootparams = ['OHRTHR52', 'OHRTHR53', 'OHRTHR50', 'OHRTHR51', 'OHRTHR56',
-                  'OHRTHR55', 'OHRTHR23', 'OHRTHR08', 'OHRTHR30', 'OHRTHR33',
-                  'OHRTHR12', 'OHRTHR13', 'OHRTHR36', 'OHRTHR11', 'OHRTHR10',
-                  'OHRTHR37', 'OHRTHR49', 'OHRTHR45', 'OHRTHR44', 'OHRTHR47',
-                  'OHRTHR46', 'OHRTHR42', 'OHRTHR29', 'OHRTHR02', 'OHRTHR05',
-                  'OHRTHR04', 'OHRTHR07', 'OHRTHR06', 'OHRTHR09', 'OHRTHR22',
-                  'OHRTHR21', 'OHRTHR27', 'OHRTHR26', 'OHRTHR25', 'OHRTHR24',
-                  'OHRTHR03']
+    rootparams = [
+        'OHRTHR52',
+        'OHRTHR53',
+        'OHRTHR50',
+        'OHRTHR51',
+        'OHRTHR56',
+        'OHRTHR55',
+        'OHRTHR23',
+        'OHRTHR08',
+        'OHRTHR30',
+        'OHRTHR33',
+        'OHRTHR12',
+        'OHRTHR13',
+        'OHRTHR36',
+        'OHRTHR11',
+        'OHRTHR10',
+        'OHRTHR37',
+        'OHRTHR49',
+        'OHRTHR45',
+        'OHRTHR44',
+        'OHRTHR47',
+        'OHRTHR46',
+        'OHRTHR42',
+        'OHRTHR29',
+        'OHRTHR02',
+        'OHRTHR05',
+        'OHRTHR04',
+        'OHRTHR07',
+        'OHRTHR06',
+        'OHRTHR09',
+        'OHRTHR22',
+        'OHRTHR21',
+        'OHRTHR27',
+        'OHRTHR26',
+        'OHRTHR25',
+        'OHRTHR24',
+        'OHRTHR03',
+    ]
     time_step = 32.8
 
     def calc(self, data):
@@ -260,14 +515,44 @@ class DP_HMIN35(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_HRMA_AVE(DerivedParameterThermal):
-    rootparams = ['OHRTHR52', 'OHRTHR53', 'OHRTHR50', 'OHRTHR51', 'OHRTHR56',
-                  'OHRTHR55', 'OHRTHR09', 'OHRTHR08', 'OHRTHR30', 'OHRTHR33',
-                  'OHRTHR12', 'OHRTHR13', 'OHRTHR10', 'OHRTHR11', 'OHRTHR36',
-                  'OHRTHR37', 'OHRTHR49', 'OHRTHR45', 'OHRTHR44', 'OHRTHR47',
-                  'OHRTHR46', 'OHRTHR42', 'OHRTHR29', 'OHRTHR02', 'OHRTHR05',
-                  'OHRTHR04', 'OHRTHR07', 'OHRTHR06', 'OHRTHR23', 'OHRTHR22',
-                  'OHRTHR21', 'OHRTHR27', 'OHRTHR26', 'OHRTHR25', 'OHRTHR24',
-                  'OHRTHR03']
+    rootparams = [
+        'OHRTHR52',
+        'OHRTHR53',
+        'OHRTHR50',
+        'OHRTHR51',
+        'OHRTHR56',
+        'OHRTHR55',
+        'OHRTHR09',
+        'OHRTHR08',
+        'OHRTHR30',
+        'OHRTHR33',
+        'OHRTHR12',
+        'OHRTHR13',
+        'OHRTHR10',
+        'OHRTHR11',
+        'OHRTHR36',
+        'OHRTHR37',
+        'OHRTHR49',
+        'OHRTHR45',
+        'OHRTHR44',
+        'OHRTHR47',
+        'OHRTHR46',
+        'OHRTHR42',
+        'OHRTHR29',
+        'OHRTHR02',
+        'OHRTHR05',
+        'OHRTHR04',
+        'OHRTHR07',
+        'OHRTHR06',
+        'OHRTHR23',
+        'OHRTHR22',
+        'OHRTHR21',
+        'OHRTHR27',
+        'OHRTHR26',
+        'OHRTHR25',
+        'OHRTHR24',
+        'OHRTHR03',
+    ]
     time_step = 32.8
 
     def calc(self, data):
@@ -280,14 +565,44 @@ class DP_HRMA_AVE(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_HRMHCHK(DerivedParameterThermal):
-    rootparams = ['OHRTHR52', 'OHRTHR53', 'OHRTHR50', 'OHRTHR51', 'OHRTHR56',
-                  'OHRTHR55', 'OHRTHR09', 'OHRTHR08', 'OHRTHR30', 'OHRTHR33',
-                  'OHRTHR12', 'OHRTHR13', 'OHRTHR10', 'OHRTHR11', 'OHRTHR36',
-                  'OHRTHR37', 'OHRTHR49', 'OHRTHR45', 'OHRTHR44', 'OHRTHR47',
-                  'OHRTHR46', 'OHRTHR42', 'OHRTHR03', 'OHRTHR02', 'OHRTHR05',
-                  'OHRTHR04', 'OHRTHR07', 'OHRTHR06', 'OHRTHR23', 'OHRTHR22',
-                  'OHRTHR21', 'OHRTHR27', 'OHRTHR26', 'OHRTHR25', 'OHRTHR24',
-                  'OHRTHR29']
+    rootparams = [
+        'OHRTHR52',
+        'OHRTHR53',
+        'OHRTHR50',
+        'OHRTHR51',
+        'OHRTHR56',
+        'OHRTHR55',
+        'OHRTHR09',
+        'OHRTHR08',
+        'OHRTHR30',
+        'OHRTHR33',
+        'OHRTHR12',
+        'OHRTHR13',
+        'OHRTHR10',
+        'OHRTHR11',
+        'OHRTHR36',
+        'OHRTHR37',
+        'OHRTHR49',
+        'OHRTHR45',
+        'OHRTHR44',
+        'OHRTHR47',
+        'OHRTHR46',
+        'OHRTHR42',
+        'OHRTHR03',
+        'OHRTHR02',
+        'OHRTHR05',
+        'OHRTHR04',
+        'OHRTHR07',
+        'OHRTHR06',
+        'OHRTHR23',
+        'OHRTHR22',
+        'OHRTHR21',
+        'OHRTHR27',
+        'OHRTHR26',
+        'OHRTHR25',
+        'OHRTHR24',
+        'OHRTHR29',
+    ]
     time_step = 32.8
 
     def calc(self, data):
@@ -303,23 +618,49 @@ class DP_HRMHCHK(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_OBAAG(DerivedParameterThermal):
-    rootparams = ['4RT704T', '4RT705T', '4RT708T', '4RT707T', '4RT709T', '4RT711T',
-                  '4RT700T', '4RT702T', '4RT701T', '4RT703T', 'OOBTHR34',
-                  'OOBTHR33', 'OOBTHR31', 'OOBTHR62', 'OOBTHR63', '4RT706T',
-                  '4RT710T']
+    rootparams = [
+        '4RT704T',
+        '4RT705T',
+        '4RT708T',
+        '4RT707T',
+        '4RT709T',
+        '4RT711T',
+        '4RT700T',
+        '4RT702T',
+        '4RT701T',
+        '4RT703T',
+        'OOBTHR34',
+        'OOBTHR33',
+        'OOBTHR31',
+        'OOBTHR62',
+        'OOBTHR63',
+        '4RT706T',
+        '4RT710T',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        AVE2 = (data['4RT705T'].vals + data['4RT706T'].vals +
-                data['4RT707T'].vals + data['4RT708T'].vals +
-                data['4RT709T'].vals + data['4RT710T'].vals +
-                data['4RT711T'].vals)
-        AVE1 = (data['OOBTHR62'].vals + data['OOBTHR63'].vals +
-                data['4RT700T'].vals + data['4RT701T'].vals +
-                data['4RT702T'].vals + data['4RT703T'].vals +
-                data['4RT704T'].vals)
-        DIAVE = (data['OOBTHR31'].vals + data['OOBTHR33'].vals +
-                 data['OOBTHR34'].vals) / 3
+        AVE2 = (
+            data['4RT705T'].vals
+            + data['4RT706T'].vals
+            + data['4RT707T'].vals
+            + data['4RT708T'].vals
+            + data['4RT709T'].vals
+            + data['4RT710T'].vals
+            + data['4RT711T'].vals
+        )
+        AVE1 = (
+            data['OOBTHR62'].vals
+            + data['OOBTHR63'].vals
+            + data['4RT700T'].vals
+            + data['4RT701T'].vals
+            + data['4RT702T'].vals
+            + data['4RT703T'].vals
+            + data['4RT704T'].vals
+        )
+        DIAVE = (
+            data['OOBTHR31'].vals + data['OOBTHR33'].vals + data['OOBTHR34'].vals
+        ) / 3
         AXAVE = (AVE1 + AVE2) / 14
         OBAAG = AXAVE - DIAVE
         return OBAAG
@@ -327,134 +668,310 @@ class DP_OBAAG(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_OBAAGW(DerivedParameterThermal):
-    rootparams = ['4RT705T', '4RT707T', '4RT709T', '4RT711T', '4RT701T', '4RT703T',
-                  'OOBTHR34', 'OOBTHR33', 'OOBTHR31']
+    rootparams = [
+        '4RT705T',
+        '4RT707T',
+        '4RT709T',
+        '4RT711T',
+        '4RT701T',
+        '4RT703T',
+        'OOBTHR34',
+        'OOBTHR33',
+        'OOBTHR31',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        AFT_FIT = (data['OOBTHR31'].vals + data['OOBTHR33'].vals +
-                   data['OOBTHR34'].vals) / 3
-        FWD_FIT = (data['4RT701T'].vals + data['4RT703T'].vals +
-                   data['4RT705T'].vals + data['4RT707T'].vals +
-                   data['4RT709T'].vals + data['4RT711T'].vals) / 6
+        AFT_FIT = (
+            data['OOBTHR31'].vals + data['OOBTHR33'].vals + data['OOBTHR34'].vals
+        ) / 3
+        FWD_FIT = (
+            data['4RT701T'].vals
+            + data['4RT703T'].vals
+            + data['4RT705T'].vals
+            + data['4RT707T'].vals
+            + data['4RT709T'].vals
+            + data['4RT711T'].vals
+        ) / 6
         OBAAGW = FWD_FIT - AFT_FIT
         return OBAAGW
 
 
 # --------------------------------------------
 class DP_OBACAVE(DerivedParameterThermal):
-    rootparams = ['OOBTHR19', 'OOBTHR18', 'OOBTHR15', 'OOBTHR14', 'OOBTHR17',
-                  'OOBTHR11', 'OOBTHR10', 'OOBTHR13', 'OOBTHR12', 'OOBTHR30',
-                  'OOBTHR08', 'OOBTHR09', 'OOBTHR24', 'OOBTHR25', 'OOBTHR26',
-                  'OOBTHR27', 'OOBTHR20', 'OOBTHR21', 'OOBTHR22', 'OOBTHR23',
-                  'OOBTHR28', 'OOBTHR29']
+    rootparams = [
+        'OOBTHR19',
+        'OOBTHR18',
+        'OOBTHR15',
+        'OOBTHR14',
+        'OOBTHR17',
+        'OOBTHR11',
+        'OOBTHR10',
+        'OOBTHR13',
+        'OOBTHR12',
+        'OOBTHR30',
+        'OOBTHR08',
+        'OOBTHR09',
+        'OOBTHR24',
+        'OOBTHR25',
+        'OOBTHR26',
+        'OOBTHR27',
+        'OOBTHR20',
+        'OOBTHR21',
+        'OOBTHR22',
+        'OOBTHR23',
+        'OOBTHR28',
+        'OOBTHR29',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        MIDCONE = (data['OOBTHR19'].vals + data['OOBTHR20'].vals +
-                   data['OOBTHR21'].vals + data['OOBTHR22'].vals +
-                   data['OOBTHR23'].vals + data['OOBTHR24'].vals +
-                   data['OOBTHR25'].vals)
-        AFTCONE = (data['OOBTHR26'].vals + data['OOBTHR27'].vals +
-                   data['OOBTHR28'].vals + data['OOBTHR29'].vals +
-                   data['OOBTHR30'].vals)
-        FWDCONE = (data['OOBTHR08'].vals + data['OOBTHR09'].vals +
-                   data['OOBTHR10'].vals + data['OOBTHR11'].vals +
-                   data['OOBTHR12'].vals + data['OOBTHR13'].vals +
-                   data['OOBTHR14'].vals + data['OOBTHR15'].vals +
-                   data['OOBTHR17'].vals + data['OOBTHR18'].vals)
+        MIDCONE = (
+            data['OOBTHR19'].vals
+            + data['OOBTHR20'].vals
+            + data['OOBTHR21'].vals
+            + data['OOBTHR22'].vals
+            + data['OOBTHR23'].vals
+            + data['OOBTHR24'].vals
+            + data['OOBTHR25'].vals
+        )
+        AFTCONE = (
+            data['OOBTHR26'].vals
+            + data['OOBTHR27'].vals
+            + data['OOBTHR28'].vals
+            + data['OOBTHR29'].vals
+            + data['OOBTHR30'].vals
+        )
+        FWDCONE = (
+            data['OOBTHR08'].vals
+            + data['OOBTHR09'].vals
+            + data['OOBTHR10'].vals
+            + data['OOBTHR11'].vals
+            + data['OOBTHR12'].vals
+            + data['OOBTHR13'].vals
+            + data['OOBTHR14'].vals
+            + data['OOBTHR15'].vals
+            + data['OOBTHR17'].vals
+            + data['OOBTHR18'].vals
+        )
         OBACAVE = (FWDCONE + MIDCONE + AFTCONE) / 22
         return OBACAVE
 
 
 # --------------------------------------------
 class DP_OBACAVEW(DerivedParameterThermal):
-    rootparams = ['4RT705T', 'OOBTHR19', '4RT707T', 'OOBTHR15', 'OOBTHR14',
-                  '4RT711T', 'OOBTHR11', 'OOBTHR10', 'OOBTHR13', '4RT701T',
-                  'OOBTHR34', 'OOBTHR33', 'OOBTHR31', 'OOBTHR30', 'OOBTHR18',
-                  '4RT709T', '4RT703T', 'OOBTHR17', 'OOBTHR08', 'OOBTHR09',
-                  'OOBTHR24', 'OOBTHR25', 'OOBTHR26', 'OOBTHR27', 'OOBTHR20',
-                  'OOBTHR21', 'OOBTHR22', 'OOBTHR23', 'OOBTHR12', 'OOBTHR28',
-                  'OOBTHR29']
+    rootparams = [
+        '4RT705T',
+        'OOBTHR19',
+        '4RT707T',
+        'OOBTHR15',
+        'OOBTHR14',
+        '4RT711T',
+        'OOBTHR11',
+        'OOBTHR10',
+        'OOBTHR13',
+        '4RT701T',
+        'OOBTHR34',
+        'OOBTHR33',
+        'OOBTHR31',
+        'OOBTHR30',
+        'OOBTHR18',
+        '4RT709T',
+        '4RT703T',
+        'OOBTHR17',
+        'OOBTHR08',
+        'OOBTHR09',
+        'OOBTHR24',
+        'OOBTHR25',
+        'OOBTHR26',
+        'OOBTHR27',
+        'OOBTHR20',
+        'OOBTHR21',
+        'OOBTHR22',
+        'OOBTHR23',
+        'OOBTHR12',
+        'OOBTHR28',
+        'OOBTHR29',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        FWD_FIT = (data['4RT701T'].vals + data['4RT703T'].vals +
-                   data['4RT705T'].vals + data['4RT707T'].vals +
-                   data['4RT709T'].vals + data['4RT711T'].vals) / 6
-        AFTCONE = (data['OOBTHR26'].vals + data['OOBTHR27'].vals +
-                   data['OOBTHR28'].vals + data['OOBTHR29'].vals +
-                   data['OOBTHR30'].vals)
-        AFT_FIT = (data['OOBTHR31'].vals + data['OOBTHR33'].vals +
-                   data['OOBTHR34'].vals) / 3
-        MIDCONE = (data['OOBTHR19'].vals + data['OOBTHR20'].vals +
-                   data['OOBTHR21'].vals + data['OOBTHR22'].vals +
-                   data['OOBTHR23'].vals + data['OOBTHR24'].vals +
-                   data['OOBTHR25'].vals)
-        FWDCONE = (data['OOBTHR08'].vals + data['OOBTHR09'].vals +
-                   data['OOBTHR10'].vals + data['OOBTHR11'].vals +
-                   data['OOBTHR12'].vals + data['OOBTHR13'].vals +
-                   data['OOBTHR14'].vals + data['OOBTHR15'].vals +
-                   data['OOBTHR17'].vals + data['OOBTHR18'].vals)
+        FWD_FIT = (
+            data['4RT701T'].vals
+            + data['4RT703T'].vals
+            + data['4RT705T'].vals
+            + data['4RT707T'].vals
+            + data['4RT709T'].vals
+            + data['4RT711T'].vals
+        ) / 6
+        AFTCONE = (
+            data['OOBTHR26'].vals
+            + data['OOBTHR27'].vals
+            + data['OOBTHR28'].vals
+            + data['OOBTHR29'].vals
+            + data['OOBTHR30'].vals
+        )
+        AFT_FIT = (
+            data['OOBTHR31'].vals + data['OOBTHR33'].vals + data['OOBTHR34'].vals
+        ) / 3
+        MIDCONE = (
+            data['OOBTHR19'].vals
+            + data['OOBTHR20'].vals
+            + data['OOBTHR21'].vals
+            + data['OOBTHR22'].vals
+            + data['OOBTHR23'].vals
+            + data['OOBTHR24'].vals
+            + data['OOBTHR25'].vals
+        )
+        FWDCONE = (
+            data['OOBTHR08'].vals
+            + data['OOBTHR09'].vals
+            + data['OOBTHR10'].vals
+            + data['OOBTHR11'].vals
+            + data['OOBTHR12'].vals
+            + data['OOBTHR13'].vals
+            + data['OOBTHR14'].vals
+            + data['OOBTHR15'].vals
+            + data['OOBTHR17'].vals
+            + data['OOBTHR18'].vals
+        )
         OBACAVE = (FWDCONE + MIDCONE + AFTCONE) / 22
-        OBACAVEW = (OBACAVE * 148. - FWD_FIT * 70. - AFT_FIT * 29.) / 49.
+        OBACAVEW = (OBACAVE * 148.0 - FWD_FIT * 70.0 - AFT_FIT * 29.0) / 49.0
         return OBACAVEW
 
 
 # --------------------------------------------
 class DP_OBADIG(DerivedParameterThermal):
-    rootparams = ['OOBTHR08', 'OOBTHR19', 'OOBTHR31', 'OOBTHR13', 'OOBTHR26',
-                  'OOBTHR34', 'OOBTHR33', 'OOBTHR22', 'OOBTHR23', 'OOBTHR60',
-                  'OOBTHR61', 'OOBTHR28', 'OOBTHR29']
+    rootparams = [
+        'OOBTHR08',
+        'OOBTHR19',
+        'OOBTHR31',
+        'OOBTHR13',
+        'OOBTHR26',
+        'OOBTHR34',
+        'OOBTHR33',
+        'OOBTHR22',
+        'OOBTHR23',
+        'OOBTHR60',
+        'OOBTHR61',
+        'OOBTHR28',
+        'OOBTHR29',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        MZSAVE = (data['OOBTHR08'].vals + data['OOBTHR19'].vals +
-                  data['OOBTHR26'].vals + data['OOBTHR31'].vals +
-                  data['OOBTHR60'].vals) / 5
-        PZSAVE = (data['OOBTHR13'].vals + data['OOBTHR22'].vals +
-                  data['OOBTHR23'].vals + data['OOBTHR28'].vals +
-                  data['OOBTHR29'].vals + data['OOBTHR61'].vals +
-                  data['OOBTHR33'].vals + data['OOBTHR34'].vals) / 8
+        MZSAVE = (
+            data['OOBTHR08'].vals
+            + data['OOBTHR19'].vals
+            + data['OOBTHR26'].vals
+            + data['OOBTHR31'].vals
+            + data['OOBTHR60'].vals
+        ) / 5
+        PZSAVE = (
+            data['OOBTHR13'].vals
+            + data['OOBTHR22'].vals
+            + data['OOBTHR23'].vals
+            + data['OOBTHR28'].vals
+            + data['OOBTHR29'].vals
+            + data['OOBTHR61'].vals
+            + data['OOBTHR33'].vals
+            + data['OOBTHR34'].vals
+        ) / 8
         OBADIG = MZSAVE - PZSAVE
         return OBADIG
 
 
 # --------------------------------------------
 class DP_OBADIGW(DerivedParameterThermal):
-    rootparams = ['OOBTHR08', '4RT705T', 'OOBTHR19', '4RT707T', 'OOBTHR22',
-                  '4RT711T', 'OOBTHR13', '4RT701T', 'OOBTHR26', 'OOBTHR34',
-                  'OOBTHR33', 'OOBTHR31', 'OOBTHR23', 'OOBTHR60', 'OOBTHR61',
-                  'OOBTHR28', 'OOBTHR29']
+    rootparams = [
+        'OOBTHR08',
+        '4RT705T',
+        'OOBTHR19',
+        '4RT707T',
+        'OOBTHR22',
+        '4RT711T',
+        'OOBTHR13',
+        '4RT701T',
+        'OOBTHR26',
+        'OOBTHR34',
+        'OOBTHR33',
+        'OOBTHR31',
+        'OOBTHR23',
+        'OOBTHR60',
+        'OOBTHR61',
+        'OOBTHR28',
+        'OOBTHR29',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        FWD_FIT_PZ = (data['4RT705T'].vals + data['4RT707T'].vals) / 2. * 70.0
-        AFT_FIT_MZ = data['OOBTHR31'].vals * 29.
-        PZSAVE = (data['OOBTHR13'].vals + data['OOBTHR22'].vals +
-                  data['OOBTHR23'].vals + data['OOBTHR28'].vals +
-                  data['OOBTHR29'].vals + data['OOBTHR61'].vals +
-                  data['OOBTHR33'].vals + data['OOBTHR34'].vals) / 8
-        MZSAVE = (data['OOBTHR08'].vals + data['OOBTHR19'].vals +
-                  data['OOBTHR26'].vals + data['OOBTHR31'].vals +
-                  data['OOBTHR60'].vals) / 5
-        AFT_FIT_PZ = (data['OOBTHR33'].vals + data['OOBTHR34'].vals) / 2 * 29.
-        FWD_FIT_MZ = (data['4RT701T'].vals + data['4RT711T'].vals) / 2. * 70.0
+        FWD_FIT_PZ = (data['4RT705T'].vals + data['4RT707T'].vals) / 2.0 * 70.0
+        AFT_FIT_MZ = data['OOBTHR31'].vals * 29.0
+        PZSAVE = (
+            data['OOBTHR13'].vals
+            + data['OOBTHR22'].vals
+            + data['OOBTHR23'].vals
+            + data['OOBTHR28'].vals
+            + data['OOBTHR29'].vals
+            + data['OOBTHR61'].vals
+            + data['OOBTHR33'].vals
+            + data['OOBTHR34'].vals
+        ) / 8
+        MZSAVE = (
+            data['OOBTHR08'].vals
+            + data['OOBTHR19'].vals
+            + data['OOBTHR26'].vals
+            + data['OOBTHR31'].vals
+            + data['OOBTHR60'].vals
+        ) / 5
+        AFT_FIT_PZ = (data['OOBTHR33'].vals + data['OOBTHR34'].vals) / 2 * 29.0
+        FWD_FIT_MZ = (data['4RT701T'].vals + data['4RT711T'].vals) / 2.0 * 70.0
         OBADIG = MZSAVE - PZSAVE
-        OBADIGW = (OBADIG * 148. - (FWD_FIT_MZ - FWD_FIT_PZ) -
-                   (AFT_FIT_MZ - AFT_FIT_PZ)) / 49.
+        OBADIGW = (
+            OBADIG * 148.0 - (FWD_FIT_MZ - FWD_FIT_PZ) - (AFT_FIT_MZ - AFT_FIT_PZ)
+        ) / 49.0
         return OBADIGW
 
 
 # --------------------------------------------
 class DP_OBA_AVE(DerivedParameterThermal):
-    rootparams = ['OOBTHR19', 'OOBTHR18', 'OOBTHR15', 'OOBTHR14', 'OOBTHR17',
-                  'OOBTHR11', 'OOBTHR10', 'OOBTHR13', 'OOBTHR12', 'OOBTHR37',
-                  'OOBTHR36', 'OOBTHR35', 'OOBTHR34', 'OOBTHR33', 'OOBTHR31',
-                  'OOBTHR30', 'OOBTHR39', 'OOBTHR38', 'OOBTHR08', 'OOBTHR09',
-                  'OOBTHR24', 'OOBTHR25', 'OOBTHR26', 'OOBTHR27', 'OOBTHR20',
-                  'OOBTHR21', 'OOBTHR22', 'OOBTHR23', 'OOBTHR46', 'OOBTHR44',
-                  'OOBTHR45', 'OOBTHR28', 'OOBTHR29', 'OOBTHR40', 'OOBTHR41']
+    rootparams = [
+        'OOBTHR19',
+        'OOBTHR18',
+        'OOBTHR15',
+        'OOBTHR14',
+        'OOBTHR17',
+        'OOBTHR11',
+        'OOBTHR10',
+        'OOBTHR13',
+        'OOBTHR12',
+        'OOBTHR37',
+        'OOBTHR36',
+        'OOBTHR35',
+        'OOBTHR34',
+        'OOBTHR33',
+        'OOBTHR31',
+        'OOBTHR30',
+        'OOBTHR39',
+        'OOBTHR38',
+        'OOBTHR08',
+        'OOBTHR09',
+        'OOBTHR24',
+        'OOBTHR25',
+        'OOBTHR26',
+        'OOBTHR27',
+        'OOBTHR20',
+        'OOBTHR21',
+        'OOBTHR22',
+        'OOBTHR23',
+        'OOBTHR46',
+        'OOBTHR44',
+        'OOBTHR45',
+        'OOBTHR28',
+        'OOBTHR29',
+        'OOBTHR40',
+        'OOBTHR41',
+    ]
     time_step = 32.8
 
     def calc(self, data):
@@ -467,13 +984,43 @@ class DP_OBA_AVE(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_OMAX34(DerivedParameterThermal):
-    rootparams = ['OOBTHR19', 'OOBTHR18', 'OOBTHR15', 'OOBTHR14', 'OOBTHR17',
-                  'OOBTHR11', 'OOBTHR10', 'OOBTHR13', 'OOBTHR12', 'OOBTHR37',
-                  'OOBTHR36', 'OOBTHR35', 'OOBTHR34', 'OOBTHR33', 'OOBTHR31',
-                  'OOBTHR30', 'OOBTHR39', 'OOBTHR38', 'OOBTHR28', 'OOBTHR08',
-                  'OOBTHR09', 'OOBTHR24', 'OOBTHR25', 'OOBTHR26', 'OOBTHR27',
-                  'OOBTHR20', 'OOBTHR21', 'OOBTHR22', 'OOBTHR23', 'OOBTHR46',
-                  'OOBTHR45', 'OOBTHR42', 'OOBTHR29', 'OOBTHR40', 'OOBTHR41']
+    rootparams = [
+        'OOBTHR19',
+        'OOBTHR18',
+        'OOBTHR15',
+        'OOBTHR14',
+        'OOBTHR17',
+        'OOBTHR11',
+        'OOBTHR10',
+        'OOBTHR13',
+        'OOBTHR12',
+        'OOBTHR37',
+        'OOBTHR36',
+        'OOBTHR35',
+        'OOBTHR34',
+        'OOBTHR33',
+        'OOBTHR31',
+        'OOBTHR30',
+        'OOBTHR39',
+        'OOBTHR38',
+        'OOBTHR28',
+        'OOBTHR08',
+        'OOBTHR09',
+        'OOBTHR24',
+        'OOBTHR25',
+        'OOBTHR26',
+        'OOBTHR27',
+        'OOBTHR20',
+        'OOBTHR21',
+        'OOBTHR22',
+        'OOBTHR23',
+        'OOBTHR46',
+        'OOBTHR45',
+        'OOBTHR42',
+        'OOBTHR29',
+        'OOBTHR40',
+        'OOBTHR41',
+    ]
     time_step = 32.8
 
     def calc(self, data):
@@ -485,13 +1032,43 @@ class DP_OMAX34(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_OMIN34(DerivedParameterThermal):
-    rootparams = ['OOBTHR19', 'OOBTHR18', 'OOBTHR15', 'OOBTHR14', 'OOBTHR17',
-                  'OOBTHR11', 'OOBTHR10', 'OOBTHR13', 'OOBTHR12', 'OOBTHR37',
-                  'OOBTHR36', 'OOBTHR35', 'OOBTHR34', 'OOBTHR33', 'OOBTHR31',
-                  'OOBTHR30', 'OOBTHR39', 'OOBTHR38', 'OOBTHR28', 'OOBTHR08',
-                  'OOBTHR09', 'OOBTHR24', 'OOBTHR25', 'OOBTHR26', 'OOBTHR27',
-                  'OOBTHR20', 'OOBTHR21', 'OOBTHR22', 'OOBTHR23', 'OOBTHR46',
-                  'OOBTHR45', 'OOBTHR42', 'OOBTHR29', 'OOBTHR40', 'OOBTHR41']
+    rootparams = [
+        'OOBTHR19',
+        'OOBTHR18',
+        'OOBTHR15',
+        'OOBTHR14',
+        'OOBTHR17',
+        'OOBTHR11',
+        'OOBTHR10',
+        'OOBTHR13',
+        'OOBTHR12',
+        'OOBTHR37',
+        'OOBTHR36',
+        'OOBTHR35',
+        'OOBTHR34',
+        'OOBTHR33',
+        'OOBTHR31',
+        'OOBTHR30',
+        'OOBTHR39',
+        'OOBTHR38',
+        'OOBTHR28',
+        'OOBTHR08',
+        'OOBTHR09',
+        'OOBTHR24',
+        'OOBTHR25',
+        'OOBTHR26',
+        'OOBTHR27',
+        'OOBTHR20',
+        'OOBTHR21',
+        'OOBTHR22',
+        'OOBTHR23',
+        'OOBTHR46',
+        'OOBTHR45',
+        'OOBTHR42',
+        'OOBTHR29',
+        'OOBTHR40',
+        'OOBTHR41',
+    ]
     time_step = 32.8
 
     def calc(self, data):
@@ -504,6 +1081,7 @@ class DP_OMIN34(DerivedParameterThermal):
 # --------------------------------------------
 class DP_P01(DerivedParameterThermal):
     """Zone 1 heater power"""
+
     rootparams = ['ELBV', '4OHTRZ01']
     time_step = 0.25625
 
@@ -1313,8 +1891,15 @@ class DP_P80(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_PABH(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ53', '4OHTRZ54', '4OHTRZ55', '4OHTRZ57',
-                  '4S1PWR05', '4S1PWR06']
+    rootparams = [
+        'ELBV',
+        '4OHTRZ53',
+        '4OHTRZ54',
+        '4OHTRZ55',
+        '4OHTRZ57',
+        '4S1PWR05',
+        '4S1PWR06',
+    ]
     time_step = 0.25625
 
     def calc(self, data):
@@ -1330,8 +1915,16 @@ class DP_PABH(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_PAFTCONE(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ48', '4OHTRZ49', '4OHTRZ50', '4OHTRZ51',
-                  '4OHTRZ52', '4S1PWR05', '4S1PWR06']
+    rootparams = [
+        'ELBV',
+        '4OHTRZ48',
+        '4OHTRZ49',
+        '4OHTRZ50',
+        '4OHTRZ51',
+        '4OHTRZ52',
+        '4S1PWR05',
+        '4S1PWR06',
+    ]
     time_step = 0.25625
 
     def calc(self, data):
@@ -1391,8 +1984,16 @@ class DP_PCONE(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_PFAP(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ01', '4OHTRZ02', '4OHTRZ03', '4OHTRZ04',
-                  '4OHTRZ05', '4OHTRZ06', '4OHTRZ07']
+    rootparams = [
+        'ELBV',
+        '4OHTRZ01',
+        '4OHTRZ02',
+        '4OHTRZ03',
+        '4OHTRZ04',
+        '4OHTRZ05',
+        '4OHTRZ06',
+        '4OHTRZ07',
+    ]
     time_step = 0.25625
 
     def calc(self, data):
@@ -1410,9 +2011,21 @@ class DP_PFAP(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_PFWDCONE(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ31', '4OHTRZ32', '4OHTRZ33', '4OHTRZ34',
-                  '4OHTRZ35', '4OHTRZ36', '4OHTRZ37', '4OHTRZ38', '4OHTRZ39',
-                  '4OHTRZ40', '4S1PWR05', '4S1PWR06']
+    rootparams = [
+        'ELBV',
+        '4OHTRZ31',
+        '4OHTRZ32',
+        '4OHTRZ33',
+        '4OHTRZ34',
+        '4OHTRZ35',
+        '4OHTRZ36',
+        '4OHTRZ37',
+        '4OHTRZ38',
+        '4OHTRZ39',
+        '4OHTRZ40',
+        '4S1PWR05',
+        '4S1PWR06',
+    ]
     time_step = 0.25625
 
     def calc(self, data):
@@ -1428,8 +2041,7 @@ class DP_PFWDCONE(DerivedParameterThermal):
         P38 = data['4OHTRZ38'].vals * VSQUARED / 27.8
         P39 = data['4OHTRZ39'].vals * VSQUARED / 36.8
         P40 = data['4OHTRZ40'].vals * VSQUARED / 28.3
-        PFWDCONE = (P31 + P32 + P33 + P34 + P35 + P36 + P37 + P38 + P39 +
-                    P40)
+        PFWDCONE = P31 + P32 + P33 + P34 + P35 + P36 + P37 + P38 + P39 + P40
         return PFWDCONE
 
 
@@ -1449,11 +2061,31 @@ class DP_PFWDCYL(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_PHRMA(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ01', '4OHTRZ02', '4OHTRZ03', '4OHTRZ04',
-                  '4OHTRZ05', '4OHTRZ06', '4OHTRZ07', '4OHTRZ08', '4OHTRZ09',
-                  '4OHTRZ10', '4OHTRZ11', '4OHTRZ12', '4OHTRZ13', '4OHTRZ14',
-                  '4OHTRZ15', '4OHTRZ16', '4OHTRZ17', '4OHTRZ18', '4OHTRZ19',
-                  '4OHTRZ20', '4OHTRZ23', '4OHTRZ24']
+    rootparams = [
+        'ELBV',
+        '4OHTRZ01',
+        '4OHTRZ02',
+        '4OHTRZ03',
+        '4OHTRZ04',
+        '4OHTRZ05',
+        '4OHTRZ06',
+        '4OHTRZ07',
+        '4OHTRZ08',
+        '4OHTRZ09',
+        '4OHTRZ10',
+        '4OHTRZ11',
+        '4OHTRZ12',
+        '4OHTRZ13',
+        '4OHTRZ14',
+        '4OHTRZ15',
+        '4OHTRZ16',
+        '4OHTRZ17',
+        '4OHTRZ18',
+        '4OHTRZ19',
+        '4OHTRZ20',
+        '4OHTRZ23',
+        '4OHTRZ24',
+    ]
     time_step = 0.25625
 
     def calc(self, data):
@@ -1480,16 +2112,46 @@ class DP_PHRMA(DerivedParameterThermal):
         P20 = data['4OHTRZ20'].vals * VSQUARED / 379.0
         P23 = data['4OHTRZ23'].vals * VSQUARED / 386.0
         P24 = data['4OHTRZ24'].vals * VSQUARED / 385.8
-        PHRMA = (P01 + P02 + P03 + P04 + P05 + P06 + P07 + P08 + P09 + P10 +
-                 P11 + P12 + P13 + P14 + P15 + P16 + P17 + P18 + P19 + P20 +
-                 P23 + P24)
+        PHRMA = (
+            P01
+            + P02
+            + P03
+            + P04
+            + P05
+            + P06
+            + P07
+            + P08
+            + P09
+            + P10
+            + P11
+            + P12
+            + P13
+            + P14
+            + P15
+            + P16
+            + P17
+            + P18
+            + P19
+            + P20
+            + P23
+            + P24
+        )
         return PHRMA
 
 
 # --------------------------------------------
 class DP_PHRMASTRUTS(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ25', '4OHTRZ26', '4OHTRZ27', '4OHTRZ28',
-                  '4OHTRZ29', '4OHTRZ30', '4S1PWR05', '4S1PWR06']
+    rootparams = [
+        'ELBV',
+        '4OHTRZ25',
+        '4OHTRZ26',
+        '4OHTRZ27',
+        '4OHTRZ28',
+        '4OHTRZ29',
+        '4OHTRZ30',
+        '4S1PWR05',
+        '4S1PWR06',
+    ]
     time_step = 0.25625
 
     def calc(self, data):
@@ -1520,8 +2182,18 @@ class DP_PIC(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_PMIDCONE(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ41', '4OHTRZ42', '4OHTRZ43', '4OHTRZ44',
-                  '4OHTRZ45', '4OHTRZ46', '4OHTRZ47', '4S1PWR05', '4S1PWR06']
+    rootparams = [
+        'ELBV',
+        '4OHTRZ41',
+        '4OHTRZ42',
+        '4OHTRZ43',
+        '4OHTRZ44',
+        '4OHTRZ45',
+        '4OHTRZ46',
+        '4OHTRZ47',
+        '4S1PWR05',
+        '4S1PWR06',
+    ]
     time_step = 0.25625
 
     def calc(self, data):
@@ -1554,14 +2226,49 @@ class DP_PMNT(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_POBAT(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ25', '4OHTRZ26', '4OHTRZ27', '4OHTRZ28', '4OHTRZ29',
-                  '4OHTRZ30', '4OHTRZ31', '4OHTRZ32', '4OHTRZ33', '4OHTRZ34',
-                  '4OHTRZ35', '4OHTRZ36', '4OHTRZ37', '4OHTRZ38', '4OHTRZ39',
-                  '4OHTRZ40', '4OHTRZ41', '4OHTRZ42', '4OHTRZ43', '4OHTRZ44',
-                  '4OHTRZ45', '4OHTRZ46', '4OHTRZ47', '4OHTRZ48', '4OHTRZ49',
-                  '4OHTRZ50', '4OHTRZ51', '4OHTRZ52', '4OHTRZ53', '4OHTRZ54',
-                  '4OHTRZ55', '4OHTRZ57', '4OHTRZ75', '4OHTRZ76', '4OHTRZ77',
-                  '4OHTRZ78', '4OHTRZ79', '4OHTRZ80', '4S1PWR05', '4S1PWR06']
+    rootparams = [
+        'ELBV',
+        '4OHTRZ25',
+        '4OHTRZ26',
+        '4OHTRZ27',
+        '4OHTRZ28',
+        '4OHTRZ29',
+        '4OHTRZ30',
+        '4OHTRZ31',
+        '4OHTRZ32',
+        '4OHTRZ33',
+        '4OHTRZ34',
+        '4OHTRZ35',
+        '4OHTRZ36',
+        '4OHTRZ37',
+        '4OHTRZ38',
+        '4OHTRZ39',
+        '4OHTRZ40',
+        '4OHTRZ41',
+        '4OHTRZ42',
+        '4OHTRZ43',
+        '4OHTRZ44',
+        '4OHTRZ45',
+        '4OHTRZ46',
+        '4OHTRZ47',
+        '4OHTRZ48',
+        '4OHTRZ49',
+        '4OHTRZ50',
+        '4OHTRZ51',
+        '4OHTRZ52',
+        '4OHTRZ53',
+        '4OHTRZ54',
+        '4OHTRZ55',
+        '4OHTRZ57',
+        '4OHTRZ75',
+        '4OHTRZ76',
+        '4OHTRZ77',
+        '4OHTRZ78',
+        '4OHTRZ79',
+        '4OHTRZ80',
+        '4S1PWR05',
+        '4S1PWR06',
+    ]
     time_step = 0.25625
 
     def calc(self, data):
@@ -1608,11 +2315,35 @@ class DP_POBAT(DerivedParameterThermal):
         P55 = data['4OHTRZ55'].vals * VSQUARED / 126.8
         P57 = data['4OHTRZ57'].vals * VSQUARED / 142.3
 
-        PSTRUTS = (P75 + P76 + P77 + P78 + P79 + P80 + P25 + P26 + P27 + P28 +
-                   P29 + P30)
-        POBACONE = (P31 + P32 + P33 + P34 + P35 + P36 + P37 + P38 + P39 + P40 +
-                    P41 + P42 + P43 + P44 + P45 + P46 + P47 + P48 + P49 + P50 +
-                    P51 + P52 + P53 + P54 + P55 + P57)
+        PSTRUTS = P75 + P76 + P77 + P78 + P79 + P80 + P25 + P26 + P27 + P28 + P29 + P30
+        POBACONE = (
+            P31
+            + P32
+            + P33
+            + P34
+            + P35
+            + P36
+            + P37
+            + P38
+            + P39
+            + P40
+            + P41
+            + P42
+            + P43
+            + P44
+            + P45
+            + P46
+            + P47
+            + P48
+            + P49
+            + P50
+            + P51
+            + P52
+            + P53
+            + P54
+            + P55
+            + P57
+        )
         POBAT = PSTRUTS + POBACONE
         return POBAT
 
@@ -1661,8 +2392,15 @@ class DP_PRADVNT(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_PSCSTRUTS(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ75', '4OHTRZ76', '4OHTRZ77',
-                  '4OHTRZ78', '4OHTRZ79', '4OHTRZ80']
+    rootparams = [
+        'ELBV',
+        '4OHTRZ75',
+        '4OHTRZ76',
+        '4OHTRZ77',
+        '4OHTRZ78',
+        '4OHTRZ79',
+        '4OHTRZ80',
+    ]
     time_step = 0.25625
 
     def calc(self, data):
@@ -1679,9 +2417,21 @@ class DP_PSCSTRUTS(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_PTFTE(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ58', '4OHTRZ59', '4OHTRZ60', '4OHTRZ61',
-                  '4OHTRZ62', '4OHTRZ63', '4OHTRZ64', '4OHTRZ65', '4OHTRZ66',
-                  '4OHTRZ67', '4OHTRZ68', '4OHTRZ69']
+    rootparams = [
+        'ELBV',
+        '4OHTRZ58',
+        '4OHTRZ59',
+        '4OHTRZ60',
+        '4OHTRZ61',
+        '4OHTRZ62',
+        '4OHTRZ63',
+        '4OHTRZ64',
+        '4OHTRZ65',
+        '4OHTRZ66',
+        '4OHTRZ67',
+        '4OHTRZ68',
+        '4OHTRZ69',
+    ]
     time_step = 0.25625
 
     def calc(self, data):
@@ -1699,28 +2449,89 @@ class DP_PTFTE(DerivedParameterThermal):
         P68 = data['4OHTRZ68'].vals * VSQUARED / 29.0
         P69 = data['4OHTRZ69'].vals * VSQUARED / 37.5
 
-        PTFTE = (P58 + P59 + P60 + P61 + P62 + P63 + P64 + P65 + P66 + P67 +
-                 P68 + P69)
+        PTFTE = P58 + P59 + P60 + P61 + P62 + P63 + P64 + P65 + P66 + P67 + P68 + P69
         return PTFTE
 
 
 # --------------------------------------------
 class DP_PTOTAL(DerivedParameterThermal):
-    rootparams = ['ELBV', '4OHTRZ01', '4OHTRZ02', '4OHTRZ03', '4OHTRZ04',
-                  '4OHTRZ05', '4OHTRZ06', '4OHTRZ07', '4OHTRZ08', '4OHTRZ09',
-                  '4OHTRZ10', '4OHTRZ11', '4OHTRZ12', '4OHTRZ13', '4OHTRZ14',
-                  '4OHTRZ15', '4OHTRZ16', '4OHTRZ17', '4OHTRZ18', '4OHTRZ19',
-                  '4OHTRZ20', '4OHTRZ23', '4OHTRZ24', '4OHTRZ25', '4OHTRZ26',
-                  '4OHTRZ27', '4OHTRZ28', '4OHTRZ29', '4OHTRZ30', '4OHTRZ31',
-                  '4OHTRZ32', '4OHTRZ33', '4OHTRZ34', '4OHTRZ35', '4OHTRZ36',
-                  '4OHTRZ37', '4OHTRZ38', '4OHTRZ39', '4OHTRZ40', '4OHTRZ41',
-                  '4OHTRZ42', '4OHTRZ43', '4OHTRZ44', '4OHTRZ45', '4OHTRZ46',
-                  '4OHTRZ47', '4OHTRZ48', '4OHTRZ49', '4OHTRZ50', '4OHTRZ51',
-                  '4OHTRZ52', '4OHTRZ53', '4OHTRZ54', '4OHTRZ55', '4OHTRZ57',
-                  '4OHTRZ58', '4OHTRZ59', '4OHTRZ60', '4OHTRZ61', '4OHTRZ62',
-                  '4OHTRZ63', '4OHTRZ64', '4OHTRZ65', '4OHTRZ66', '4OHTRZ67',
-                  '4OHTRZ68', '4OHTRZ69', '4OHTRZ75', '4OHTRZ76', '4OHTRZ77',
-                  '4OHTRZ78', '4OHTRZ79', '4OHTRZ80', '4S1PWR05', '4S1PWR06']
+    rootparams = [
+        'ELBV',
+        '4OHTRZ01',
+        '4OHTRZ02',
+        '4OHTRZ03',
+        '4OHTRZ04',
+        '4OHTRZ05',
+        '4OHTRZ06',
+        '4OHTRZ07',
+        '4OHTRZ08',
+        '4OHTRZ09',
+        '4OHTRZ10',
+        '4OHTRZ11',
+        '4OHTRZ12',
+        '4OHTRZ13',
+        '4OHTRZ14',
+        '4OHTRZ15',
+        '4OHTRZ16',
+        '4OHTRZ17',
+        '4OHTRZ18',
+        '4OHTRZ19',
+        '4OHTRZ20',
+        '4OHTRZ23',
+        '4OHTRZ24',
+        '4OHTRZ25',
+        '4OHTRZ26',
+        '4OHTRZ27',
+        '4OHTRZ28',
+        '4OHTRZ29',
+        '4OHTRZ30',
+        '4OHTRZ31',
+        '4OHTRZ32',
+        '4OHTRZ33',
+        '4OHTRZ34',
+        '4OHTRZ35',
+        '4OHTRZ36',
+        '4OHTRZ37',
+        '4OHTRZ38',
+        '4OHTRZ39',
+        '4OHTRZ40',
+        '4OHTRZ41',
+        '4OHTRZ42',
+        '4OHTRZ43',
+        '4OHTRZ44',
+        '4OHTRZ45',
+        '4OHTRZ46',
+        '4OHTRZ47',
+        '4OHTRZ48',
+        '4OHTRZ49',
+        '4OHTRZ50',
+        '4OHTRZ51',
+        '4OHTRZ52',
+        '4OHTRZ53',
+        '4OHTRZ54',
+        '4OHTRZ55',
+        '4OHTRZ57',
+        '4OHTRZ58',
+        '4OHTRZ59',
+        '4OHTRZ60',
+        '4OHTRZ61',
+        '4OHTRZ62',
+        '4OHTRZ63',
+        '4OHTRZ64',
+        '4OHTRZ65',
+        '4OHTRZ66',
+        '4OHTRZ67',
+        '4OHTRZ68',
+        '4OHTRZ69',
+        '4OHTRZ75',
+        '4OHTRZ76',
+        '4OHTRZ77',
+        '4OHTRZ78',
+        '4OHTRZ79',
+        '4OHTRZ80',
+        '4S1PWR05',
+        '4S1PWR06',
+    ]
     time_step = 0.25625
 
     def calc(self, data):
@@ -1803,16 +2614,60 @@ class DP_PTOTAL(DerivedParameterThermal):
         P29 = data['4OHTRZ29'].vals * VSQUARED / 384.0
         P30 = data['4OHTRZ30'].vals * VSQUARED / 383.0
 
-        PHRMA = (P01 + P02 + P03 + P04 + P05 + P06 + P07 + P08 + P09 + P10 +
-                 P11 + P12 + P13 + P14 + P15 + P16 + P17 + P18 + P19 + P20 +
-                 P23 + P24)
-        POBACONE = (P31 + P32 + P33 + P34 + P35 + P36 + P37 + P38 + P39 + P40 +
-                    P41 + P42 + P43 + P44 + P45 + P46 + P47 + P48 + P49 + P50 +
-                    P51 + P52 + P53 + P54 + P55 + P57)
-        PTFTE = (P58 + P59 + P60 + P61 + P62 + P63 + P64 + P65 + P66 + P67 +
-                 P68 + P69)
-        PSTRUTS = (P75 + P76 + P77 + P78 + P79 + P80 + P25 + P26 + P27 + P28 +
-                   P29 + P30)
+        PHRMA = (
+            P01
+            + P02
+            + P03
+            + P04
+            + P05
+            + P06
+            + P07
+            + P08
+            + P09
+            + P10
+            + P11
+            + P12
+            + P13
+            + P14
+            + P15
+            + P16
+            + P17
+            + P18
+            + P19
+            + P20
+            + P23
+            + P24
+        )
+        POBACONE = (
+            P31
+            + P32
+            + P33
+            + P34
+            + P35
+            + P36
+            + P37
+            + P38
+            + P39
+            + P40
+            + P41
+            + P42
+            + P43
+            + P44
+            + P45
+            + P46
+            + P47
+            + P48
+            + P49
+            + P50
+            + P51
+            + P52
+            + P53
+            + P54
+            + P55
+            + P57
+        )
+        PTFTE = P58 + P59 + P60 + P61 + P62 + P63 + P64 + P65 + P66 + P67 + P68 + P69
+        PSTRUTS = P75 + P76 + P77 + P78 + P79 + P80 + P25 + P26 + P27 + P28 + P29 + P30
 
         POBAT = PSTRUTS + POBACONE
         PTOTAL = PHRMA + POBAT + PTFTE
@@ -1825,7 +2680,7 @@ class DP_SUNANGLE(DerivedParameterThermal):
     time_step = 0.25625
 
     def calc(self, data):
-        SUNANGLE = (90 - data['AOSARES1'].vals)
+        SUNANGLE = 90 - data['AOSARES1'].vals
         return SUNANGLE
 
 
@@ -1835,8 +2690,10 @@ class DP_TABMAX(DerivedParameterThermal):
     time_step = 32.8
 
     def calc(self, data):
-        TABMAX = np.max([data['OOBTHR42'].vals, data['OOBTHR43'].vals,
-                         data['OOBTHR47'].vals], axis=0)
+        TABMAX = np.max(
+            [data['OOBTHR42'].vals, data['OOBTHR43'].vals, data['OOBTHR47'].vals],
+            axis=0,
+        )
         return TABMAX
 
 
@@ -1846,8 +2703,10 @@ class DP_TABMIN(DerivedParameterThermal):
     time_step = 32.8
 
     def calc(self, data):
-        TABMIN = np.min([data['OOBTHR42'].vals, data['OOBTHR43'].vals,
-                         data['OOBTHR47'].vals], axis=0)
+        TABMIN = np.min(
+            [data['OOBTHR42'].vals, data['OOBTHR43'].vals, data['OOBTHR47'].vals],
+            axis=0,
+        )
         return TABMIN
 
 
@@ -1857,41 +2716,70 @@ class DP_TELAB_AVE(DerivedParameterThermal):
     time_step = 32.8
 
     def calc(self, data):
-        TELAB_AVE = (data['OOBTHR42'].vals + data['OOBTHR43'].vals +
-                     data['OOBTHR47'].vals) / 3
+        TELAB_AVE = (
+            data['OOBTHR42'].vals + data['OOBTHR43'].vals + data['OOBTHR47'].vals
+        ) / 3
         return TELAB_AVE
 
 
 # --------------------------------------------
 class DP_TELHS_AVE(DerivedParameterThermal):
-    rootparams = ['OOBTHR02', 'OOBTHR03', 'OOBTHR06', 'OOBTHR07', 'OOBTHR04',
-                  'OOBTHR05']
+    rootparams = [
+        'OOBTHR02',
+        'OOBTHR03',
+        'OOBTHR06',
+        'OOBTHR07',
+        'OOBTHR04',
+        'OOBTHR05',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        TELHS_AVE = (data['OOBTHR02'].vals + data['OOBTHR03'].vals +
-                     data['OOBTHR04'].vals + data['OOBTHR05'].vals +
-                     data['OOBTHR06'].vals + data['OOBTHR07'].vals) / 6
+        TELHS_AVE = (
+            data['OOBTHR02'].vals
+            + data['OOBTHR03'].vals
+            + data['OOBTHR04'].vals
+            + data['OOBTHR05'].vals
+            + data['OOBTHR06'].vals
+            + data['OOBTHR07'].vals
+        ) / 6
         return TELHS_AVE
 
 
 # --------------------------------------------
 class DP_TELSS_AVE(DerivedParameterThermal):
-    rootparams = ['OOBTHR51', 'OOBTHR50', 'OOBTHR53', 'OOBTHR52', 'OOBTHR54',
-                  'OOBTHR49']
+    rootparams = [
+        'OOBTHR51',
+        'OOBTHR50',
+        'OOBTHR53',
+        'OOBTHR52',
+        'OOBTHR54',
+        'OOBTHR49',
+    ]
     time_step = 32.8
 
     def calc(self, data):
-        TELSS_AVE = (data['OOBTHR49'].vals + data['OOBTHR50'].vals +
-                     data['OOBTHR51'].vals + data['OOBTHR52'].vals +
-                     data['OOBTHR53'].vals + data['OOBTHR54'].vals) / 6
+        TELSS_AVE = (
+            data['OOBTHR49'].vals
+            + data['OOBTHR50'].vals
+            + data['OOBTHR51'].vals
+            + data['OOBTHR52'].vals
+            + data['OOBTHR53'].vals
+            + data['OOBTHR54'].vals
+        ) / 6
         return TELSS_AVE
 
 
 # --------------------------------------------
 class DP_THSMAX(DerivedParameterThermal):
-    rootparams = ['OOBTHR02', 'OOBTHR03', 'OOBTHR06', 'OOBTHR07', 'OOBTHR04',
-                  'OOBTHR05']
+    rootparams = [
+        'OOBTHR02',
+        'OOBTHR03',
+        'OOBTHR06',
+        'OOBTHR07',
+        'OOBTHR04',
+        'OOBTHR05',
+    ]
     time_step = 32.8
 
     def calc(self, data):
@@ -1903,8 +2791,14 @@ class DP_THSMAX(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_THSMIN(DerivedParameterThermal):
-    rootparams = ['OOBTHR02', 'OOBTHR03', 'OOBTHR06', 'OOBTHR07', 'OOBTHR04',
-                  'OOBTHR05']
+    rootparams = [
+        'OOBTHR02',
+        'OOBTHR03',
+        'OOBTHR06',
+        'OOBTHR07',
+        'OOBTHR04',
+        'OOBTHR05',
+    ]
     time_step = 32.8
 
     def calc(self, data):
@@ -1930,8 +2824,10 @@ class DP_TILT_BULK(DerivedParameterThermal):
     time_step = 32.8
 
     def calc(self, data):
-        TILT_BULK = np.abs((data['OHRTHR42'].vals + data['OHRTHR43'].vals)
-                           / 2.0 - 70.0) * 0.0704
+        TILT_BULK = (
+            np.abs((data['OHRTHR42'].vals + data['OHRTHR43'].vals) / 2.0 - 70.0)
+            * 0.0704
+        )
         return TILT_BULK
 
 
@@ -1952,10 +2848,12 @@ class DP_TILT_MAX(DerivedParameterThermal):
 
     def calc(self, data):
         TILT_DIAM = np.abs(1.0 * data['OOBAGRD6'].vals) * 0.3032
-        TILT_BULK = np.abs((data['OHRTHR42'].vals + data['OHRTHR43'].vals)
-                           / 2.0 - 70.0) * 0.0704
+        TILT_BULK = (
+            np.abs((data['OHRTHR42'].vals + data['OHRTHR43'].vals) / 2.0 - 70.0)
+            * 0.0704
+        )
         TILT_AXIAL = np.abs(data['OOBAGRD3'].vals) * 0.1084
-        TILT_MAX = (TILT_BULK + TILT_AXIAL + TILT_DIAM)
+        TILT_MAX = TILT_BULK + TILT_AXIAL + TILT_DIAM
         return TILT_MAX
 
 
@@ -1966,17 +2864,25 @@ class DP_TILT_RSS(DerivedParameterThermal):
 
     def calc(self, data):
         TILT_DIAM = np.abs(1.0 * data['OOBAGRD6'].vals) * 0.3032
-        TILT_BULK = np.abs((data['OHRTHR42'].vals + data['OHRTHR43'].vals)
-                           / 2.0 - 70.0) * 0.0704
+        TILT_BULK = (
+            np.abs((data['OHRTHR42'].vals + data['OHRTHR43'].vals) / 2.0 - 70.0)
+            * 0.0704
+        )
         TILT_AXIAL = np.abs(data['OOBAGRD3'].vals) * 0.1084
-        TILT_RSS = np.sqrt(TILT_BULK ** 2 + TILT_AXIAL ** 2 + TILT_DIAM ** 2)
+        TILT_RSS = np.sqrt(TILT_BULK**2 + TILT_AXIAL**2 + TILT_DIAM**2)
         return TILT_RSS
 
 
 # --------------------------------------------
 class DP_TSSMAX(DerivedParameterThermal):
-    rootparams = ['OOBTHR51', 'OOBTHR50', 'OOBTHR53', 'OOBTHR52', 'OOBTHR54',
-                  'OOBTHR49']
+    rootparams = [
+        'OOBTHR51',
+        'OOBTHR50',
+        'OOBTHR53',
+        'OOBTHR52',
+        'OOBTHR54',
+        'OOBTHR49',
+    ]
     time_step = 32.8
 
     def calc(self, data):
@@ -1988,8 +2894,14 @@ class DP_TSSMAX(DerivedParameterThermal):
 
 # --------------------------------------------
 class DP_TSSMIN(DerivedParameterThermal):
-    rootparams = ['OOBTHR51', 'OOBTHR50', 'OOBTHR53', 'OOBTHR52', 'OOBTHR54',
-                  'OOBTHR49']
+    rootparams = [
+        'OOBTHR51',
+        'OOBTHR50',
+        'OOBTHR53',
+        'OOBTHR52',
+        'OOBTHR54',
+        'OOBTHR49',
+    ]
     time_step = 32.8
 
     def calc(self, data):
@@ -2005,21 +2917,35 @@ class DP_HADG(DerivedParameterThermal):
     time_step = 32.8
 
     def calc(self, data):
-        HADG = np.max((np.abs(data['OHRMGRD3'].vals), np.abs(data['OHRMGRD6'].vals)), axis=0)
+        HADG = np.max(
+            (np.abs(data['OHRMGRD3'].vals), np.abs(data['OHRMGRD6'].vals)), axis=0
+        )
 
         return HADG
 
 
 # --------------------------------------------
 class DP_ABH_DUTYCYCLE(DerivedParameterThermal):
-    rootparams = ['4OHTRZ53', '4OHTRZ54', '4OHTRZ55', '4OHTRZ57', '4S1PWR05', '4S1PWR06']
+    rootparams = [
+        '4OHTRZ53',
+        '4OHTRZ54',
+        '4OHTRZ55',
+        '4OHTRZ57',
+        '4S1PWR05',
+        '4S1PWR06',
+    ]
     time_step = 32.8
 
     def calc(self, data):
         self.fix_bus_5_and_bus_6(data)
-        RTOTAL = 1. / (1 / 94.1 + 1 / 124.3 + 1 / 126.8 + 1 / 142.3)
-        DC1 = np.abs(data['4OHTRZ53'].vals) / 94.1 + np.abs(data['4OHTRZ54'].vals) / 124.3
-        DC2 = np.abs(data['4OHTRZ55'].vals) / 126.8 + np.abs(data['4OHTRZ57'].vals) / 142.3
+        RTOTAL = 1.0 / (1 / 94.1 + 1 / 124.3 + 1 / 126.8 + 1 / 142.3)
+        DC1 = (
+            np.abs(data['4OHTRZ53'].vals) / 94.1 + np.abs(data['4OHTRZ54'].vals) / 124.3
+        )
+        DC2 = (
+            np.abs(data['4OHTRZ55'].vals) / 126.8
+            + np.abs(data['4OHTRZ57'].vals) / 142.3
+        )
         ABH_DUTYCYCLE = RTOTAL * (DC1 + DC2)
 
         return ABH_DUTYCYCLE

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -30,12 +30,12 @@ from .remote_access import ENG_ARCHIVE
 from .units import Units
 
 # Module-level units, defaults to CXC units (e.g. Kelvins etc)
-UNITS = Units(system='cxc')
+UNITS = Units(system="cxc")
 
 # Module-level control of whether MSID.fetch will cache the last 30 results
 CACHE = False
 
-IGNORE_COLNAMES = ('TIME', 'MJF', 'MNF', 'TLM_FMT')
+IGNORE_COLNAMES = ("TIME", "MJF", "MNF", "TLM_FMT")
 DIR_PATH = os.path.dirname(os.path.abspath(__file__))
 
 # Dates near the start of 2000 that demarcates the split between the 1999 data
@@ -43,11 +43,11 @@ DIR_PATH = os.path.dirname(os.path.abspath(__file__))
 # while post-2000 data starts as late as 2000:001:11:58:59.  Dates between LO
 # and HI get taken from either 1999 or post-2000.  The times are 4 millisec before
 # a minor frame boundary to avoid collisions.
-DATE2000_LO = DateTime('2000:001:00:00:00.090').date
-DATE2000_HI = DateTime('2000:003:00:00:00.234').date
+DATE2000_LO = DateTime("2000:001:00:00:00.090").date
+DATE2000_HI = DateTime("2000:003:00:00:00.234").date
 
 # Launch date (earliest possible date for telemetry)
-LAUNCH_DATE = '1999:204'
+LAUNCH_DATE = "1999:204"
 
 # Maximum number of MSIDs that should ever match an input MSID spec
 # (to prevent accidentally selecting a very large number of MSIDs)
@@ -56,28 +56,28 @@ MAX_GLOB_MATCHES = 10
 # Special-case state codes that override those in the TDB
 STATE_CODES = {
     # SIMDIAG
-    '3SDSWELF': [(0, 'F'), (1, 'T')],
-    '3SDSYRS': [(0, 'F'), (1, 'T')],
-    '3SDWMRS': [(0, 'F'), (1, 'T')],
+    "3SDSWELF": [(0, "F"), (1, "T")],
+    "3SDSYRS": [(0, "F"), (1, "T")],
+    "3SDWMRS": [(0, "F"), (1, "T")],
     # SIM_MRG
-    '3TSCMOVE': [(0, 'F'), (1, 'T')],
-    '3FAMOVE': [(0, 'F'), (1, 'T')],
-    '3SEAID': [(0, 'SEA-A'), (1, 'SEA-B')],
-    '3SEARSET': [(0, 'F'), (1, 'T')],
-    '3SEAROMF': [(0, 'F'), (1, 'T')],
-    '3SEAINCM': [(0, 'F'), (1, 'T')],
-    '3STAB2EN': [(0, 'DISABLE'), (1, 'ENABLE')],
-    '3SMOTPEN': [(0, 'ENABLE'), (1, 'DISABLE')],
-    '3SMOTSEL': [(0, 'TSC'), (1, 'FA')],
-    '3SHTREN': [(0, 'DISABLE'), (1, 'ENABLE')],
-    '3SEARAMF': [(0, 'F'), (1, 'T')],
+    "3TSCMOVE": [(0, "F"), (1, "T")],
+    "3FAMOVE": [(0, "F"), (1, "T")],
+    "3SEAID": [(0, "SEA-A"), (1, "SEA-B")],
+    "3SEARSET": [(0, "F"), (1, "T")],
+    "3SEAROMF": [(0, "F"), (1, "T")],
+    "3SEAINCM": [(0, "F"), (1, "T")],
+    "3STAB2EN": [(0, "DISABLE"), (1, "ENABLE")],
+    "3SMOTPEN": [(0, "ENABLE"), (1, "DISABLE")],
+    "3SMOTSEL": [(0, "TSC"), (1, "FA")],
+    "3SHTREN": [(0, "DISABLE"), (1, "ENABLE")],
+    "3SEARAMF": [(0, "F"), (1, "T")],
 }
 
 # Cached version (by content type) of first and last available times in archive
 CONTENT_TIME_RANGES = {}
 
 # Default source of data.
-DEFAULT_DATA_SOURCE = 'cxc'
+DEFAULT_DATA_SOURCE = "cxc"
 
 
 class _DataSource(object):
@@ -87,7 +87,7 @@ class _DataSource(object):
     """
 
     _data_sources = (DEFAULT_DATA_SOURCE,)
-    _allowed = ('cxc', 'maude', 'test-drop-half')
+    _allowed = ("cxc", "maude", "test-drop-half")
 
     def __init__(self, *data_sources):
         self._new_data_sources = data_sources
@@ -110,14 +110,14 @@ class _DataSource(object):
             data_source.split()[0] not in cls._allowed for data_source in data_sources
         ):
             raise ValueError(
-                'data_sources {} not in allowed set {}'.format(
+                "data_sources {} not in allowed set {}".format(
                     data_sources, cls._allowed
                 )
             )
 
         if len(data_sources) == 0:
             raise ValueError(
-                'must select at least one data source in {}'.format(cls._allowed)
+                "must select at least one data source in {}".format(cls._allowed)
             )
 
         cls._data_sources = data_sources
@@ -133,7 +133,7 @@ class _DataSource(object):
         if include_test:
             sources = cls._data_sources
         else:
-            sources = [x for x in cls._data_sources if not x.startswith('test')]
+            sources = [x for x in cls._data_sources if not x.startswith("test")]
 
         return tuple(source.split()[0] for source in sources)
 
@@ -147,9 +147,9 @@ class _DataSource(object):
         """
         source = source.split()[0]
 
-        if source == 'cxc':
+        if source == "cxc":
             out = list(content.keys())
-        elif source == 'maude':
+        elif source == "maude":
             import maude
 
             out = list(maude.MSIDS.keys())
@@ -179,7 +179,7 @@ class _DataSource(object):
             name, opts = vals[0], vals[1:]
             out[name] = {}
             for opt in opts:
-                key, val = opt.split('=')
+                key, val = opt.split("=")
                 val = ast.literal_eval(val)
                 out[name][key] = val
 
@@ -248,7 +248,7 @@ def _split_path(path):
     path = Path(path)
     parts = path.parts
     if remote_access.access_remotely and path.drive:
-        parts = ('/',) + parts[1:]
+        parts = ("/",) + parts[1:]
     return parts
 
 
@@ -256,20 +256,20 @@ def _get_start_stop_dates(times):
     if len(times) == 0:
         return {}
     else:
-        return {'start': DateTime(times[0]).date, 'stop': DateTime(times[-1]).date}
+        return {"start": DateTime(times[0]).date, "stop": DateTime(times[-1]).date}
 
 
 # Context dictionary to provide context for msid_files
-ft = pyyaks.context.ContextDict('ft')
+ft = pyyaks.context.ContextDict("ft")
 
 # Global (eng_archive) definition of file names
-msid_files = pyyaks.context.ContextDict('msid_files', basedir=ENG_ARCHIVE)
+msid_files = pyyaks.context.ContextDict("msid_files", basedir=ENG_ARCHIVE)
 msid_files.update(file_defs.msid_files)
 
 # Module-level values defining available content types and column (MSID) names.
 # Then convert from astropy Table to recarray for API stability.
 # Note that filetypes.as_array().view(np.recarray) does not quite work...
-filetypes = ascii.read(os.path.join(DIR_PATH, 'filetypes.dat'))
+filetypes = ascii.read(os.path.join(DIR_PATH, "filetypes.dat"))
 filetypes_arr = filetypes.as_array()
 filetypes = np.recarray(len(filetypes_arr), dtype=filetypes_arr.dtype)
 filetypes[()] = filetypes_arr
@@ -278,8 +278,8 @@ filetypes[()] = filetypes_arr
 # once to the remote machine since passing them one at a time is rather slow)
 all_msid_names_files = dict()
 for filetype in filetypes:
-    ft['content'] = filetype['content'].lower()
-    all_msid_names_files[str(ft['content'])] = _split_path(msid_files['colnames'].abs)
+    ft["content"] = filetype["content"].lower()
+    all_msid_names_files[str(ft["content"])] = _split_path(msid_files["colnames"].abs)
 
 
 # Function to load MSID names from the files (executed remotely, if necessary)
@@ -290,7 +290,7 @@ def load_msid_names(all_msid_names_files):
     all_colnames = dict()
     for k, msid_names_file in all_msid_names_files.items():
         try:
-            all_colnames[k] = pickle.load(open(os.path.join(*msid_names_file), 'rb'))
+            all_colnames[k] = pickle.load(open(os.path.join(*msid_names_file), "rb"))
         except IOError:
             pass
     return all_colnames
@@ -327,14 +327,14 @@ class NullHandler(logging.Handler):
         pass
 
 
-logger = logging.getLogger('Ska.engarchive.fetch')
+logger = logging.getLogger("Ska.engarchive.fetch")
 logger.addHandler(NullHandler())
 logger.propagate = False
 
 
 def get_units():
     """Get the unit system currently being used for conversions."""
-    return UNITS['system']
+    return UNITS["system"]
 
 
 def set_units(unit_system):
@@ -366,7 +366,7 @@ def read_bad_times(table):
     ``DateTime`` format.  Blank lines and any line starting with the #
     character are ignored.
     """
-    bad_times = ascii.read(table, format='no_header', names=['msid', 'start', 'stop'])
+    bad_times = ascii.read(table, format="no_header", names=["msid", "start", "stop"])
 
     for msid, start, stop in bad_times:
         msid_bad_times.setdefault(msid.upper(), []).append((start, stop))
@@ -374,7 +374,7 @@ def read_bad_times(table):
 
 # Set up bad times dict
 msid_bad_times = dict()
-read_bad_times(os.path.join(DIR_PATH, 'msid_bad_times.dat'))
+read_bad_times(os.path.join(DIR_PATH, "msid_bad_times.dat"))
 
 
 def msid_glob(msid):
@@ -404,8 +404,8 @@ def msid_glob(msid):
 
     if not msids:
         raise ValueError(
-            'MSID {!r} is not in {} data source(s)'.format(
-                msid, ' or '.join(x.upper() for x in sources)
+            "MSID {!r} is not in {} data source(s)".format(
+                msid, " or ".join(x.upper() for x in sources)
             )
         )
 
@@ -431,15 +431,15 @@ def _msid_glob(msid, source):
 
     # CALC_ is a synonym for DP_ which works in both CXC and MAUDE archives, so
     # swap to DP_ if CALC_ is found. These are calculated pseudo-MSIDs.
-    if MSID.startswith('CALC_'):
-        MSID = 'DP_' + MSID[5:]
+    if MSID.startswith("CALC_"):
+        MSID = "DP_" + MSID[5:]
 
     # matches_msid is a list of MSIDs that match the input MSID. Providing the
     # initial DP_ is optional so we try both if the MSID doesn't already start
     # with DP_ (i.e. PITCH or DP_PITCH).
     matches_msid = (MSID,)
-    if not MSID.startswith('DP_'):
-        matches_msid += ('DP_' + MSID,)
+    if not MSID.startswith("DP_"):
+        matches_msid += ("DP_" + MSID,)
 
     # If one of matches_msid is in the source then return the upper
     # case version and whatever the user supplied (could be any case).
@@ -456,8 +456,8 @@ def _msid_glob(msid, source):
         if matches:
             if len(matches) > MAX_GLOB_MATCHES:
                 raise ValueError(
-                    'MSID spec {} matches more than {} MSIDs.  '
-                    'Refine the spec or increase fetch.MAX_GLOB_MATCHES'.format(
+                    "MSID spec {} matches more than {} MSIDs.  "
+                    "Refine the spec or increase fetch.MAX_GLOB_MATCHES".format(
                         msid, MAX_GLOB_MATCHES
                     )
                 )
@@ -489,9 +489,9 @@ def _get_table_intervals_as_list(table, check_overlaps=True):
         except Exception:
             pass
     else:
-        for prefix in ('date', 't'):
-            start = prefix + 'start'
-            stop = prefix + 'stop'
+        for prefix in ("date", "t"):
+            start = prefix + "start"
+            stop = prefix + "stop"
             try:
                 intervals = [
                     (DateTime(row[start]).secs, DateTime(row[stop]).secs)
@@ -509,7 +509,7 @@ def _get_table_intervals_as_list(table, check_overlaps=True):
 
         # Check for overlaps
         if any(i0[1] > i1[0] for i0, i1 in zip(intervals[:-1], intervals[1:])):
-            raise ValueError('Input intervals overlap')
+            raise ValueError("Input intervals overlap")
 
     return intervals
 
@@ -537,17 +537,17 @@ class MSID(object):
     def __init__(self, msid, start=LAUNCH_DATE, stop=None, filter_bad=False, stat=None):
         msids, MSIDs = msid_glob(msid)
         if len(MSIDs) > 1:
-            raise ValueError('Multiple matches for {} in Eng Archive'.format(msid))
+            raise ValueError("Multiple matches for {} in Eng Archive".format(msid))
         else:
             self.msid = msids[0]
             self.MSID = MSIDs[0]
 
         # Capture the current module units
-        self.units = Units(self.units['system'])
+        self.units = Units(self.units["system"])
         self.unit = self.units.get_msid_unit(self.MSID)
         self.stat = stat
         if stat:
-            self.dt = {'5min': 328, 'daily': 86400}[stat]
+            self.dt = {"5min": 328, "daily": 86400}[stat]
 
         # If ``start`` is actually a table of intervals then fetch
         # each interval separately and concatenate the results
@@ -557,7 +557,7 @@ class MSID(object):
 
         self.tstart = DateTime(start).secs
         self.tstop = (
-            DateTime(stop).secs if stop else DateTime(time.time(), format='unix').secs
+            DateTime(stop).secs if stop else DateTime(time.time(), format="unix").secs
         )
         self.datestart = DateTime(self.tstart).date
         self.datestop = DateTime(self.tstop).date
@@ -587,17 +587,17 @@ class MSID(object):
     def __repr__(self):
         attrs = [self.__class__.__name__, self.MSID]
         for name, val in (
-            ('start', self.datestart),
-            ('stop', self.datestop),
-            ('len', len(self)),
-            ('dtype', self.dtype.name),
-            ('unit', self.unit),
-            ('stat', self.stat),
+            ("start", self.datestart),
+            ("stop", self.datestop),
+            ("len", len(self)),
+            ("dtype", self.dtype.name),
+            ("unit", self.unit),
+            ("stat", self.stat),
         ):
             if val is not None:
-                attrs.append('{}={}'.format(name, val))
+                attrs.append("{}={}".format(name, val))
 
-        return '<' + ' '.join(attrs) + '>'
+        return "<" + " ".join(attrs) + ">"
 
     def _get_data_over_intervals(self, intervals):
         """
@@ -623,7 +623,7 @@ class MSID(object):
     def _get_data(self):
         """Get data from the Eng archive"""
         logger.info(
-            'Getting data for %s between %s to %s',
+            "Getting data for %s between %s to %s",
             self.msid,
             self.datestart,
             self.datestop,
@@ -636,30 +636,30 @@ class MSID(object):
 
         # Avoid stomping on caller's filetype 'ft' values with _cache_ft()
         with _cache_ft():
-            ft['content'] = self.content
-            ft['msid'] = self.MSID
+            ft["content"] = self.content
+            ft["msid"] = self.MSID
 
             with _set_msid_files_basedir(self.datestart):
                 if self.stat:
-                    if 'maude' in data_source.sources():
+                    if "maude" in data_source.sources():
                         raise ValueError(
-                            'MAUDE data source does not support telemetry statistics'
+                            "MAUDE data source does not support telemetry statistics"
                         )
-                    ft['interval'] = self.stat
+                    ft["interval"] = self.stat
                     self._get_stat_data()
                 else:
-                    self.colnames = ['vals', 'times', 'bads']
+                    self.colnames = ["vals", "times", "bads"]
                     args = (
                         self.content,
                         self.tstart,
                         self.tstop,
                         self.MSID,
-                        self.units['system'],
+                        self.units["system"],
                     )
 
                     if (
-                        'cxc' in data_source.sources()
-                        and self.MSID in data_source.get_msids('cxc')
+                        "cxc" in data_source.sources()
+                        and self.MSID in data_source.get_msids("cxc")
                     ):
                         # CACHE is normally True only when doing ingest processing.  Note
                         # also that to support caching the get_msid_data_from_cxc_cached
@@ -670,10 +670,10 @@ class MSID(object):
                             else self._get_msid_data_from_cxc
                         )
                         self.vals, self.times, self.bads = get_msid_data(*args)
-                        self.data_source['cxc'] = _get_start_stop_dates(self.times)
+                        self.data_source["cxc"] = _get_start_stop_dates(self.times)
 
-                    if 'test-drop-half' in data_source.sources() and hasattr(
-                        self, 'vals'
+                    if "test-drop-half" in data_source.sources() and hasattr(
+                        self, "vals"
                     ):
                         # For testing purposes drop half the data off the end.  This assumes another
                         # data_source like 'cxc' has been selected.
@@ -686,25 +686,25 @@ class MSID(object):
                             self.data_source[source] = _get_start_stop_dates(self.times)
 
                     if (
-                        'maude' in data_source.sources()
-                        and self.MSID in data_source.get_msids('maude')
+                        "maude" in data_source.sources()
+                        and self.MSID in data_source.get_msids("maude")
                     ):
                         # Update self.vals, times, bads in place.  This might concatenate MAUDE
                         # telemetry to existing CXC values.
                         self._get_msid_data_from_maude(*args)
 
     def _get_comp_data(self, comp_cls):
-        logger.info(f'Getting computed values for {self.msid}')
+        logger.info(f"Getting computed values for {self.msid}")
 
         # Do computation.  This returns a dict of MSID attribute values.
-        attrs = comp_cls(self.units['system'])(
+        attrs = comp_cls(self.units["system"])(
             self.tstart, self.tstop, self.msid, self.stat
         )
 
         # Allow upstream class to be a bit sloppy on times and include samples
         # outside the time range.  This can happen with classes that inherit
         # from DerivedParameter.
-        ok = (attrs['times'] >= self.tstart) & (attrs['times'] <= self.tstop)
+        ok = (attrs["times"] >= self.tstart) & (attrs["times"] <= self.tstop)
         all_ok = np.all(ok)
 
         # List of "colnames", which is the ndarray attributes.  There can be
@@ -712,7 +712,7 @@ class MSID(object):
         self.colnames = [
             attr
             for attr, val in attrs.items()
-            if (isinstance(val, np.ndarray) and len(val) == len(attrs['times']))
+            if (isinstance(val, np.ndarray) and len(val) == len(attrs["times"]))
         ]
 
         # Apply attributes to self
@@ -720,7 +720,7 @@ class MSID(object):
             if (
                 not all_ok
                 and isinstance(val, np.ndarray)
-                and len(val) == len(attrs['times'])
+                and len(val) == len(attrs["times"])
             ):
                 val = val[ok]
             setattr(self, attr, val)
@@ -728,8 +728,8 @@ class MSID(object):
     def _get_stat_data(self):
         """Do the actual work of getting stats values for an MSID from HDF5
         files"""
-        filename = msid_files['stats'].abs
-        logger.info('Opening %s', filename)
+        filename = msid_files["stats"].abs
+        logger.info("Opening %s", filename)
 
         @local_or_remote_function(
             "Getting stat data for " + self.MSID + " from Ska eng archive server..."
@@ -737,10 +737,10 @@ class MSID(object):
         def get_stat_data_from_server(filename, dt, tstart, tstop):
             import tables
 
-            open_file = getattr(tables, 'open_file', None) or tables.openFile
+            open_file = getattr(tables, "open_file", None) or tables.openFile
             h5 = open_file(os.path.join(*filename))
             table = h5.root.data
-            times = (table.col('index') + 0.5) * dt
+            times = (table.col("index") + 0.5) * dt
             row0, row1 = np.searchsorted(times, [tstart, tstop])
             table_rows = table[row0:row1]  # returns np.ndarray (structured array)
             h5.close()
@@ -749,31 +749,31 @@ class MSID(object):
         times, table_rows, row0, row1 = get_stat_data_from_server(
             _split_path(filename), self.dt, self.tstart, self.tstop
         )
-        logger.info('Closed %s', filename)
+        logger.info("Closed %s", filename)
 
         self.bads = None
         self.times = times
-        self.colnames = ['times']
+        self.colnames = ["times"]
         for colname in table_rows.dtype.names:
             # Don't like the way columns were named in the stats tables.
             # Fix that here.
-            colname_out = _plural(colname) if colname != 'n' else 'samples'
+            colname_out = _plural(colname) if colname != "n" else "samples"
 
             if colname_out in (
-                'vals',
-                'mins',
-                'maxes',
-                'means',
-                'p01s',
-                'p05s',
-                'p16s',
-                'p50s',
-                'p84s',
-                'p95s',
-                'p99s',
+                "vals",
+                "mins",
+                "maxes",
+                "means",
+                "p01s",
+                "p05s",
+                "p16s",
+                "p50s",
+                "p84s",
+                "p95s",
+                "p99s",
             ):
                 vals = self.units.convert(self.MSID, table_rows[colname])
-            elif colname_out == 'stds':
+            elif colname_out == "stds":
                 vals = self.units.convert(
                     self.MSID, table_rows[colname], delta_val=True
                 )
@@ -786,9 +786,9 @@ class MSID(object):
         # Redefine the 'vals' attribute to be 'means' if it exists.  This is a
         # more consistent use of the 'vals' attribute and there is little use
         # for the original sampled version.
-        if hasattr(self, 'means'):
+        if hasattr(self, "means"):
             # Create new attribute midvals and add as a column (fixes kadi#17)
-            self.colnames.append('midvals')
+            self.colnames.append("midvals")
             self.midvals = self.vals
             self.vals = self.means
 
@@ -797,8 +797,8 @@ class MSID(object):
         # string attribute.  None of the others like mins/maxes etc will exist.
         for colname in self.colnames:
             vals = getattr(self, colname)
-            if vals.dtype.kind == 'S':
-                setattr(self, colname, vals.astype('U'))
+            if vals.dtype.kind == "S":
+                setattr(self, colname, vals.astype("U"))
 
     @staticmethod
     @cache.lru_cache(30)
@@ -824,15 +824,15 @@ class MSID(object):
         cache_key = (content, h5_slice.start, h5_slice.stop)
 
         # Read the TIME values either from cache or from disk.
-        if times_cache['key'] == cache_key:
-            logger.info('Using times_cache for %s %s to %s', content, tstart, tstop)
-            times = times_cache['val']  # Already filtered on times_ok
-            times_ok = times_cache['ok']  # For filtering MSID.val and MSID.bad
-            times_all_ok = times_cache['all_ok']
+        if times_cache["key"] == cache_key:
+            logger.info("Using times_cache for %s %s to %s", content, tstart, tstop)
+            times = times_cache["val"]  # Already filtered on times_ok
+            times_ok = times_cache["ok"]  # For filtering MSID.val and MSID.bad
+            times_all_ok = times_cache["all_ok"]
         else:
-            ft['msid'] = 'time'
-            filename = msid_files['msid'].abs
-            logger.info('Reading %s', filename)
+            ft["msid"] = "time"
+            filename = msid_files["msid"].abs
+            logger.info("Reading %s", filename)
 
             @local_or_remote_function(
                 "Getting time data from Ska eng archive server..."
@@ -840,7 +840,7 @@ class MSID(object):
             def get_time_data_from_server(h5_slice, filename):
                 import tables
 
-                open_file = getattr(tables, 'open_file', None) or tables.openFile
+                open_file = getattr(tables, "open_file", None) or tables.openFile
                 h5 = open_file(os.path.join(*filename))
                 times_ok = ~h5.root.quality[h5_slice]
                 times = h5.root.data[h5_slice]
@@ -861,9 +861,9 @@ class MSID(object):
             )
 
         # Extract the actual MSID values and bad values mask
-        ft['msid'] = msid
-        filename = msid_files['msid'].abs
-        logger.info('Reading %s', filename)
+        ft["msid"] = msid
+        filename = msid_files["msid"].abs
+        logger.info("Reading %s", filename)
 
         @local_or_remote_function(
             "Getting msid data for " + msid + " from Ska eng archive server..."
@@ -871,7 +871,7 @@ class MSID(object):
         def get_msid_data_from_server(h5_slice, filename):
             import tables
 
-            open_file = getattr(tables, 'open_file', None) or tables.openFile
+            open_file = getattr(tables, "open_file", None) or tables.openFile
             h5 = open_file(os.path.join(*filename))
             vals = h5.root.data[h5_slice]
             bads = h5.root.quality[h5_slice]
@@ -892,13 +892,13 @@ class MSID(object):
 
         # Filter bad times rows if needed
         if not times_all_ok:
-            logger.info('Filtering bad times values for %s', msid)
+            logger.info("Filtering bad times values for %s", msid)
             bads = bads[times_ok]
             vals = vals[times_ok]
 
         # Slice down to exact requested time range
         row0, row1 = np.searchsorted(times, [tstart, tstop])
-        logger.info('Slicing %s arrays [%d:%d]', msid, row0, row1)
+        logger.info("Slicing %s arrays [%d:%d]", msid, row0, row1)
         vals = Units(unit_system).convert(msid.upper(), vals[row0:row1])
         times = times[row0:row1]
         bads = bads[row0:row1]
@@ -908,8 +908,8 @@ class MSID(object):
         bads = _fix_ctu_dwell_mode_bads(msid, bads)
 
         # Change bytestring to (unicode) string
-        if vals.dtype.kind == 'S':
-            vals = vals.astype('U')
+        if vals.dtype.kind == "S":
+            vals = vals.astype("U")
 
         return (vals, times, bads)
 
@@ -922,7 +922,7 @@ class MSID(object):
 
         # Telemetry values from another data_source may already be available.  If
         # so then only query MAUDE from after the last available point.
-        telem_already = hasattr(self, 'times') and len(self.times) > 2
+        telem_already = hasattr(self, "times") and len(self.times) > 2
 
         if telem_already:
             tstart = self.times[-1] + 0.001  # Don't fetch the last point again
@@ -932,24 +932,24 @@ class MSID(object):
                 return
 
         # Actually query MAUDE
-        options = data_source.options()['maude']
+        options = data_source.options()["maude"]
         try:
             out = maude.get_msids(msids=msid, start=tstart, stop=tstop, **options)
         except Exception as e:
-            raise Exception('MAUDE query failed: {}'.format(e))
+            raise Exception("MAUDE query failed: {}".format(e))
 
         # Only one MSID is queried from MAUDE but maude.get_msids() already returns
         # a list of results, so select the first element.
-        out = out['data'][0]
+        out = out["data"][0]
 
         vals = Units(unit_system).convert(
-            msid.upper(), out['values'], from_system='eng'
+            msid.upper(), out["values"], from_system="eng"
         )
-        times = out['times']
+        times = out["times"]
         bads = np.zeros(len(vals), dtype=bool)  # No 'bad' values from MAUDE
 
-        self.data_source['maude'] = _get_start_stop_dates(times)
-        self.data_source['maude']['flags'] = out['flags']
+        self.data_source["maude"] = _get_start_stop_dates(times)
+        self.data_source["maude"]["flags"] = out["flags"]
 
         if telem_already:
             vals = np.concatenate([self.vals, vals])
@@ -965,13 +965,13 @@ class MSID(object):
         """List of state codes tuples (raw_count, state_code) for state-valued
         MSIDs
         """
-        if self.vals.dtype.kind not in ('S', 'U'):
+        if self.vals.dtype.kind not in ("S", "U"):
             self._state_codes = None
 
         if self.MSID in STATE_CODES:
             self._state_codes = STATE_CODES[self.MSID]
 
-        if not hasattr(self, '_state_codes'):
+        if not hasattr(self, "_state_codes"):
             import Ska.tdb
 
             try:
@@ -979,16 +979,16 @@ class MSID(object):
             except Exception:
                 self._state_codes = None
             else:
-                if states is None or len(set(states['CALIBRATION_SET_NUM'])) != 1:
+                if states is None or len(set(states["CALIBRATION_SET_NUM"])) != 1:
                     warnings.warn(
-                        'MSID {} has string vals but no state codes '
-                        'or multiple calibration sets'.format(self.msid)
+                        "MSID {} has string vals but no state codes "
+                        "or multiple calibration sets".format(self.msid)
                     )
                     self._state_codes = None
                 else:
-                    states = np.sort(states.data, order='LOW_RAW_COUNT')
+                    states = np.sort(states.data, order="LOW_RAW_COUNT")
                     self._state_codes = [
-                        (state['LOW_RAW_COUNT'], state['STATE_CODE'])
+                        (state["LOW_RAW_COUNT"], state["STATE_CODE"])
                         for state in states
                     ]
         return self._state_codes
@@ -999,15 +999,15 @@ class MSID(object):
         stored in ``self.vals``
         """
         # If this is not a string-type value then there are no raw values
-        if self.vals.dtype.kind not in ('S', 'U') or self.state_codes is None:
+        if self.vals.dtype.kind not in ("S", "U") or self.state_codes is None:
             self._raw_vals = None
 
-        if not hasattr(self, '_raw_vals'):
-            self._raw_vals = np.zeros(len(self.vals), dtype='int8') - 1
+        if not hasattr(self, "_raw_vals"):
+            self._raw_vals = np.zeros(len(self.vals), dtype="int8") - 1
             # CXC state code telem all has same length with trailing spaces
             # so find max length for formatting below.
             max_len = max(len(x[1]) for x in self.state_codes)
-            fmtstr = '{:' + str(max_len) + 's}'
+            fmtstr = "{:" + str(max_len) + "s}"
             for raw_val, state_code in self.state_codes:
                 ok = self.vals == fmtstr.format(state_code)
                 self._raw_vals[ok] = raw_val
@@ -1064,11 +1064,11 @@ class MSID(object):
             tstop = min(tstop, self.times[-1])
             times = np.arange(tstart, tstop, dt)
 
-        logger.info('Interpolating index for %s', self.msid)
+        logger.info("Interpolating index for %s", self.msid)
         indexes = Ska.Numpy.interpolate(
-            np.arange(len(self.times)), self.times, times, method='nearest', sorted=True
+            np.arange(len(self.times)), self.times, times, method="nearest", sorted=True
         )
-        logger.info('Slicing on indexes')
+        logger.info("Slicing on indexes")
         for colname in self.colnames:
             colvals = getattr(self, colname)
             if colvals is not None:
@@ -1105,9 +1105,9 @@ class MSID(object):
             return
 
         if np.any(obj.bads):
-            logger.info('Filtering bad values for %s', obj.msid)
+            logger.info("Filtering bad values for %s", obj.msid)
             ok = ~obj.bads
-            colnames = (x for x in obj.colnames if x != 'bads')
+            colnames = (x for x in obj.colnames if x != "bads")
             for colname in colnames:
                 setattr(obj, colname, getattr(obj, colname)[ok])
 
@@ -1144,7 +1144,7 @@ class MSID(object):
         :param copy: return a copy of MSID object with bad times filtered
         """
         if table is not None:
-            bad_times = ascii.read(table, format='no_header', names=['start', 'stop'])
+            bad_times = ascii.read(table, format="no_header", names=["start", "stop"])
         elif start is None and stop is None:
             bad_times = []
             for msid_glob, times in msid_bad_times.items():
@@ -1152,7 +1152,7 @@ class MSID(object):
                     bad_times.extend(times)
         elif start is None or stop is None:
             raise ValueError(
-                'filter_times requires either 2 args (start, stop) or no args'
+                "filter_times requires either 2 args (start, stop) or no args"
             )
         else:
             bad_times = [(start, stop)]
@@ -1261,7 +1261,7 @@ class MSID(object):
         # Check if this is an EventQuery.  Would rather not import EventQuery
         # because this is expensive (django), so just look at the names in
         # object MRO.
-        if 'EventQuery' in (cls.__name__ for cls in intervals.__class__.__mro__):
+        if "EventQuery" in (cls.__name__ for cls in intervals.__class__.__mro__):
             intervals = intervals.intervals(self.datestart, self.datestop)
 
         intervals = [
@@ -1280,8 +1280,8 @@ class MSID(object):
             # Find the indexes of bad data.  Using side=left,right respectively
             # will exclude points exactly equal to the bad_times values
             # (though in reality an exact tie is extremely unlikely).
-            i0 = np.searchsorted(self.times, tstart, side='left')
-            i1 = np.searchsorted(self.times, tstop, side='right')
+            i0 = np.searchsorted(self.times, tstart, side="left")
+            i1 = np.searchsorted(self.times, tstop, side="right")
             ok[i0:i1] = not exclude
 
         colnames = (x for x in self.colnames)
@@ -1302,32 +1302,32 @@ class MSID(object):
         import zipfile
 
         colnames = self.colnames[:]
-        if self.bads is None and 'bads' in colnames:
-            colnames.remove('bads')
+        if self.bads is None and "bads" in colnames:
+            colnames.remove("bads")
 
         if self.state_codes:
-            colnames.append('raw_vals')
+            colnames.append("raw_vals")
 
         # Indexes value is not interesting for output
-        if 'indexes' in colnames:
-            colnames.remove('indexes')
+        if "indexes" in colnames:
+            colnames.remove("indexes")
 
         colvals = tuple(getattr(self, x) for x in colnames)
         fmt = ",".join("%s" for x in colnames)
 
         f = zipfile.ZipFile(
-            filename, ('a' if append and os.path.exists(filename) else 'w')
+            filename, ("a" if append and os.path.exists(filename) else "w")
         )
-        info = zipfile.ZipInfo(self.msid + '.csv')
+        info = zipfile.ZipInfo(self.msid + ".csv")
         info.external_attr = 0o664 << 16  # Set permissions
         info.date_time = time.localtime()[:7]
         info.compress_type = zipfile.ZIP_DEFLATED
         f.writestr(
             info,
             ",".join(colnames)
-            + '\n'
-            + '\n'.join(fmt % x for x in zip(*colvals))
-            + '\n',
+            + "\n"
+            + "\n".join(fmt % x for x in zip(*colvals))
+            + "\n",
         )
         f.close()
 
@@ -1372,12 +1372,12 @@ class MSID(object):
         from . import utils
 
         ops = {
-            '==': operator.eq,
-            '!=': operator.ne,
-            '>': operator.gt,
-            '<': operator.lt,
-            '>=': operator.ge,
-            '<=': operator.le,
+            "==": operator.eq,
+            "!=": operator.ne,
+            ">": operator.gt,
+            "<": operator.lt,
+            ">=": operator.ge,
+            "<=": operator.le,
         }
         try:
             op = ops[op]
@@ -1432,11 +1432,11 @@ class MSID(object):
             times = self.times
 
         if len(self.vals) < 2:
-            raise ValueError('Filtered data length must be at least 2')
+            raise ValueError("Filtered data length must be at least 2")
 
         return utils.state_intervals(times, vals)
 
-    def iplot(self, fmt='-b', fmt_minmax='-c', **plot_kwargs):
+    def iplot(self, fmt="-b", fmt_minmax="-c", **plot_kwargs):
         """Make an interactive plot for exploring the MSID data.
 
         This method opens a new plot figure (or clears the current figure) and
@@ -1503,7 +1503,7 @@ class MSID(object):
         # Upper-cased version of msid name from user
         title = self.msid.upper()
         if self.stat:
-            title = f'{title} ({self.stat})'
+            title = f"{title} ({self.stat})"
         plt.title(title)
         if self.unit:
             plt.ylabel(self.unit)
@@ -1562,7 +1562,7 @@ class MSIDset(collections.OrderedDict):
 
     def __deepcopy__(self, memo=None):
         out = self.__class__([], None)
-        for attr in ('tstart', 'tstop', 'datestart', 'datestop'):
+        for attr in ("tstart", "tstop", "datestart", "datestop"):
             setattr(out, attr, getattr(self, attr))
         for msid in self:
             out[msid] = self[msid].copy()
@@ -1761,15 +1761,15 @@ class MSIDset(collections.OrderedDict):
         for msid in msids:
             if filter_bad and not bad_union:
                 msid.filter_bad()
-            logger.info('Interpolating index for %s', msid.msid)
+            logger.info("Interpolating index for %s", msid.msid)
             indexes = Ska.Numpy.interpolate(
                 np.arange(len(msid.times)),
                 msid.times,
                 obj.times,
-                method='nearest',
+                method="nearest",
                 sorted=True,
             )
-            logger.info('Slicing on indexes')
+            logger.info("Slicing on indexes")
             for colname in msid.colnames:
                 colvals = getattr(msid, colname)
                 if colvals is not None:
@@ -1786,9 +1786,9 @@ class MSIDset(collections.OrderedDict):
             for msid in msids:
                 if msid.stat is None and msid.bads is None:
                     warnings.warn(
-                        'WARNING: {!r} MSID has bad values already filtered.\n'
-                        'This prevents `filter_bad_union` from working as expected.\n'
-                        'Use MSIDset (not Msidset) with filter_bad=False.\n'
+                        "WARNING: {!r} MSID has bad values already filtered.\n"
+                        "This prevents `filter_bad_union` from working as expected.\n"
+                        "Use MSIDset (not Msidset) with filter_bad=False.\n"
                     )
                 if msid.bads is not None:  # 5min and daily stats have no bad values
                     common_bads |= msid.bads
@@ -1884,29 +1884,29 @@ class HrcSsMsid(Msid):
     units = UNITS
 
     def __new__(self, msid, start=LAUNCH_DATE, stop=None, stat=None):
-        ss_msids = '2TLEV1RT 2VLEV1RT 2SHEV1RT 2TLEV2RT 2VLEV2RT 2SHEV2RT'
+        ss_msids = "2TLEV1RT 2VLEV1RT 2SHEV1RT 2TLEV2RT 2VLEV2RT 2SHEV2RT"
         if msid.upper() not in ss_msids.split():
             raise ValueError(
-                'MSID {} is not in HRC secondary science ({})'.format(msid, ss_msids)
+                "MSID {} is not in HRC secondary science ({})".format(msid, ss_msids)
             )
 
         # If this is not full-resolution then add boolean bads mask to individual MSIDs
-        msids = [msid, 'HRC_SS_HK_BAD']
+        msids = [msid, "HRC_SS_HK_BAD"]
         out = MSIDset(msids, start=start, stop=stop, stat=stat)
         if stat is not None:
             for m in msids:
                 out[m].bads = np.zeros(len(out[m].vals), dtype=np.bool)
 
         # Set bad mask
-        i_bads = np.flatnonzero(out['HRC_SS_HK_BAD'].vals > 0)
-        out['HRC_SS_HK_BAD'].bads[i_bads] = True
+        i_bads = np.flatnonzero(out["HRC_SS_HK_BAD"].vals > 0)
+        out["HRC_SS_HK_BAD"].bads[i_bads] = True
 
         # For full-resolution smear the bad mask out by +/- 5 samples
         if stat is None:
             for i_bad in i_bads:
                 i0 = max(0, i_bad - 5)
                 i1 = i_bad + 5
-                out['HRC_SS_HK_BAD'].bads[i0:i1] = True
+                out["HRC_SS_HK_BAD"].bads[i0:i1] = True
 
         # Finally interpolate and filter out bad values
         out.interpolate(times=out[msid].times, bad_union=True, filter_bad=True)
@@ -1949,16 +1949,16 @@ def get_time_range(msid, format=None):
     """
     MSID = msid.upper()
     with _cache_ft():
-        ft['content'] = content[MSID]
-        ft['msid'] = 'time'
-        filename = msid_files['msid'].abs
-        logger.info('Reading %s', filename)
+        ft["content"] = content[MSID]
+        ft["msid"] = "time"
+        filename = msid_files["msid"].abs
+        logger.info("Reading %s", filename)
 
         @local_or_remote_function("Getting time range from Ska eng archive server...")
         def get_time_data_from_server(filename):
             import tables
 
-            open_file = getattr(tables, 'open_file', None) or tables.openFile
+            open_file = getattr(tables, "open_file", None) or tables.openFile
             h5 = open_file(os.path.join(*filename))
             tstart = h5.root.data[0]
             tstop = h5.root.data[-1]
@@ -1981,8 +1981,8 @@ def get_telem(
     msids,
     start=None,
     stop=None,
-    sampling='full',
-    unit_system='eng',
+    sampling="full",
+    unit_system="eng",
     interpolate_dt=None,
     remove_events=None,
     select_events=None,
@@ -2057,7 +2057,7 @@ def get_interval(content, tstart, tstop):
     :returns: rowslice
     """
 
-    ft['content'] = content
+    ft["content"] = content
 
     @local_or_remote_function(
         "Getting interval data from " + "DB on Ska eng archive server..."
@@ -2066,35 +2066,35 @@ def get_interval(content, tstart, tstop):
 
         import Ska.DBI
 
-        db = Ska.DBI.DBI(dbi='sqlite', server=os.path.join(*server))
+        db = Ska.DBI.DBI(dbi="sqlite", server=os.path.join(*server))
 
         query_row = db.fetchone(
-            'SELECT tstart, rowstart FROM archfiles '
-            'WHERE filetime < ? order by filetime desc',
+            "SELECT tstart, rowstart FROM archfiles "
+            "WHERE filetime < ? order by filetime desc",
             (tstart,),
         )
         if not query_row:
             query_row = db.fetchone(
-                'SELECT tstart, rowstart FROM archfiles order by filetime asc'
+                "SELECT tstart, rowstart FROM archfiles order by filetime asc"
             )
 
-        rowstart = query_row['rowstart']
+        rowstart = query_row["rowstart"]
 
         query_row = db.fetchone(
-            'SELECT tstop, rowstop FROM archfiles '
-            'WHERE filetime > ? order by filetime asc',
+            "SELECT tstop, rowstop FROM archfiles "
+            "WHERE filetime > ? order by filetime asc",
             (tstop,),
         )
         if not query_row:
             query_row = db.fetchone(
-                'SELECT tstop, rowstop FROM archfiles order by filetime desc'
+                "SELECT tstop, rowstop FROM archfiles order by filetime desc"
             )
 
-        rowstop = query_row['rowstop']
+        rowstop = query_row["rowstop"]
 
         return slice(rowstart, rowstop)
 
-    return get_interval_from_db(tstart, tstop, _split_path(msid_files['archfiles'].abs))
+    return get_interval_from_db(tstart, tstop, _split_path(msid_files["archfiles"].abs))
 
 
 @contextlib.contextmanager
@@ -2125,7 +2125,7 @@ def _set_msid_files_basedir(datestart, msid_files=msid_files):
             # Note: don't use os.path.join because ENG_ARCHIVE and basedir must
             # use linux '/' convention but this might be running on Windows.
             dirs = msid_files.basedir.split(os.pathsep)
-            msid_files.basedir = os.pathsep.join(dir_ + '/1999' for dir_ in dirs)
+            msid_files.basedir = os.pathsep.join(dir_ + "/1999" for dir_ in dirs)
         yield
     finally:
         msid_files.basedir = cache_basedir
@@ -2141,22 +2141,22 @@ def _fix_ctu_dwell_mode_bads(msid, bads):
     """
     MSID = msid.upper()
     stepped_on_msids = (
-        '4PRT5BT',
-        '4RT585T',
-        'AFLCA3BI',
-        'AIRU1BT',
-        'CSITB5V',
-        'CUSOAOVN',
-        'ECNV3V',
-        'PLAED4ET',
-        'PR1TV01T',
-        'TCYLFMZM',
-        'TOXTSUPN',
-        'ES1P5CV',
-        'ES2P5CV',
+        "4PRT5BT",
+        "4RT585T",
+        "AFLCA3BI",
+        "AIRU1BT",
+        "CSITB5V",
+        "CUSOAOVN",
+        "ECNV3V",
+        "PLAED4ET",
+        "PR1TV01T",
+        "TCYLFMZM",
+        "TOXTSUPN",
+        "ES1P5CV",
+        "ES2P5CV",
     )
 
-    if MSID in stepped_on_msids or re.match(r'DWELL\d\d', MSID):
+    if MSID in stepped_on_msids or re.match(r"DWELL\d\d", MSID):
         # Find transitions from good value to bad value.  Turn that
         # good value to bad to extend the badness by one sample.
         ok = (bads[:-1] == False) & (bads[1:] == True)  # noqa
@@ -2174,7 +2174,7 @@ def add_logging_handler(level=logging.INFO, formatter=None, handler=None):
     """
 
     if formatter is None:
-        formatter = logging.Formatter('%(funcName)s: %(message)s')
+        formatter = logging.Formatter("%(funcName)s: %(message)s")
 
     if handler is None:
         handler = logging.StreamHandler()
@@ -2188,4 +2188,4 @@ def _plural(x):
     """Return English plural of ``x``.  Super-simple and only valid for the
     known small set of cases within fetch where it will get applied.
     """
-    return x + 'es' if (x.endswith('x') or x.endswith('s')) else x + 's'
+    return x + "es" if (x.endswith("x") or x.endswith("s")) else x + "s"

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -59,7 +59,6 @@ STATE_CODES = {
     '3SDSWELF': [(0, 'F'), (1, 'T')],
     '3SDSYRS': [(0, 'F'), (1, 'T')],
     '3SDWMRS': [(0, 'F'), (1, 'T')],
-
     # SIM_MRG
     '3TSCMOVE': [(0, 'F'), (1, 'T')],
     '3FAMOVE': [(0, 'F'), (1, 'T')],
@@ -86,6 +85,7 @@ class _DataSource(object):
     Context manager and quasi-singleton configuration object for managing the
     data_source(s) used for fetching telemetry.
     """
+
     _data_sources = (DEFAULT_DATA_SOURCE,)
     _allowed = ('cxc', 'maude', 'test-drop-half')
 
@@ -106,13 +106,19 @@ class _DataSource(object):
 
         :param *data_sources: one or more sources (str)
         """
-        if any(data_source.split()[0] not in cls._allowed for data_source in data_sources):
-            raise ValueError('data_sources {} not in allowed set {}'
-                             .format(data_sources, cls._allowed))
+        if any(
+            data_source.split()[0] not in cls._allowed for data_source in data_sources
+        ):
+            raise ValueError(
+                'data_sources {} not in allowed set {}'.format(
+                    data_sources, cls._allowed
+                )
+            )
 
         if len(data_sources) == 0:
-            raise ValueError('must select at least one data source in {}'
-                             .format(cls._allowed))
+            raise ValueError(
+                'must select at least one data source in {}'.format(cls._allowed)
+            )
 
         cls._data_sources = data_sources
 
@@ -145,6 +151,7 @@ class _DataSource(object):
             out = list(content.keys())
         elif source == 'maude':
             import maude
+
             out = list(maude.MSIDS.keys())
         else:
             raise ValueError('source must be "cxc" or "msid"')
@@ -197,6 +204,7 @@ def local_or_remote_function(remote_print_output):
     the resultant path should re-join them with os.path.join. In the
     remote case the join will happen using the remote rules.
     """
+
     def the_decorator(func):
         def wrapper(*args, **kwargs):
             if remote_access.access_remotely:
@@ -206,15 +214,17 @@ def local_or_remote_function(remote_print_output):
                     try:
                         if not remote_access.establish_connection():
                             raise remote_access.RemoteConnectionError(
-                                "Unable to establish connection for remote fetch.")
+                                "Unable to establish connection for remote fetch."
+                            )
                     except EOFError:
                         # An EOF error can be raised if the python interpreter is being
                         # called in such a way that input cannot be received from the
                         # user (e.g. when the python interpreter is called from MATLAB)
                         # If that is the case (and remote access is enabled), then
                         # raise an import error
-                        raise ImportError("Unable to interactively get remote access "
-                                          "info from user.")
+                        raise ImportError(
+                            "Unable to interactively get remote access info from user."
+                        )
                 # Print the output, if specified
                 if remote_access.show_print_output and remote_print_output is not None:
                     print(remote_print_output)
@@ -223,7 +233,9 @@ def local_or_remote_function(remote_print_output):
                 return remote_access.execute_remotely(func, *args, **kwargs)
             else:
                 return func(*args, **kwargs)
+
         return wrapper
+
     return the_decorator
 
 
@@ -244,8 +256,7 @@ def _get_start_stop_dates(times):
     if len(times) == 0:
         return {}
     else:
-        return {'start': DateTime(times[0]).date,
-                'stop': DateTime(times[-1]).date}
+        return {'start': DateTime(times[0]).date, 'stop': DateTime(times[-1]).date}
 
 
 # Context dictionary to provide context for msid_files
@@ -268,14 +279,14 @@ filetypes[()] = filetypes_arr
 all_msid_names_files = dict()
 for filetype in filetypes:
     ft['content'] = filetype['content'].lower()
-    all_msid_names_files[str(ft['content'])] = \
-        _split_path(msid_files['colnames'].abs)
+    all_msid_names_files[str(ft['content'])] = _split_path(msid_files['colnames'].abs)
 
 
 # Function to load MSID names from the files (executed remotely, if necessary)
 @local_or_remote_function("Loading MSID names from Ska eng archive server...")
 def load_msid_names(all_msid_names_files):
     import pickle
+
     all_colnames = dict()
     for k, msid_names_file in all_msid_names_files.items():
         try:
@@ -289,8 +300,11 @@ def load_content(all_colnames):
     out = {}
     # Save the names
     for content_type, msid_names in all_colnames.items():
-        out.update((name, content_type) for name in sorted(msid_names)
-                   if name not in IGNORE_COLNAMES)
+        out.update(
+            (name, content_type)
+            for name in sorted(msid_names)
+            if name not in IGNORE_COLNAMES
+        )
     return out
 
 
@@ -319,8 +333,7 @@ logger.propagate = False
 
 
 def get_units():
-    """Get the unit system currently being used for conversions.
-    """
+    """Get the unit system currently being used for conversions."""
     return UNITS['system']
 
 
@@ -353,8 +366,7 @@ def read_bad_times(table):
     ``DateTime`` format.  Blank lines and any line starting with the #
     character are ignored.
     """
-    bad_times = ascii.read(table, format='no_header',
-                           names=['msid', 'start', 'stop'])
+    bad_times = ascii.read(table, format='no_header', names=['msid', 'start', 'stop'])
 
     for msid, start, stop in bad_times:
         msid_bad_times.setdefault(msid.upper(), []).append((start, stop))
@@ -391,8 +403,11 @@ def msid_glob(msid):
         MSIDS.update((m, None) for m in MS)
 
     if not msids:
-        raise ValueError('MSID {!r} is not in {} data source(s)'
-                         .format(msid, ' or '.join(x.upper() for x in sources)))
+        raise ValueError(
+            'MSID {!r} is not in {} data source(s)'.format(
+                msid, ' or '.join(x.upper() for x in sources)
+            )
+        )
 
     return list(msids), list(MSIDS)
 
@@ -442,8 +457,10 @@ def _msid_glob(msid, source):
             if len(matches) > MAX_GLOB_MATCHES:
                 raise ValueError(
                     'MSID spec {} matches more than {} MSIDs.  '
-                    'Refine the spec or increase fetch.MAX_GLOB_MATCHES'
-                    .format(msid, MAX_GLOB_MATCHES))
+                    'Refine the spec or increase fetch.MAX_GLOB_MATCHES'.format(
+                        msid, MAX_GLOB_MATCHES
+                    )
+                )
             return [x.lower() for x in matches], matches
 
     # msid not found for this data source
@@ -466,8 +483,9 @@ def _get_table_intervals_as_list(table, check_overlaps=True):
 
     if isinstance(table, (list, tuple)):
         try:
-            intervals = [(DateTime(row[0]).secs, DateTime(row[1]).secs)
-                         for row in table]
+            intervals = [
+                (DateTime(row[0]).secs, DateTime(row[1]).secs) for row in table
+            ]
         except Exception:
             pass
     else:
@@ -475,8 +493,10 @@ def _get_table_intervals_as_list(table, check_overlaps=True):
             start = prefix + 'start'
             stop = prefix + 'stop'
             try:
-                intervals = [(DateTime(row[start]).secs, DateTime(row[stop]).secs)
-                             for row in table]
+                intervals = [
+                    (DateTime(row[start]).secs, DateTime(row[stop]).secs)
+                    for row in table
+                ]
             except Exception:
                 pass
             else:
@@ -510,14 +530,14 @@ class MSID(object):
 
     :returns: MSID instance
     """
+
     units = UNITS
     fetch = sys.modules[__name__]
 
     def __init__(self, msid, start=LAUNCH_DATE, stop=None, filter_bad=False, stat=None):
         msids, MSIDs = msid_glob(msid)
         if len(MSIDs) > 1:
-            raise ValueError('Multiple matches for {} in Eng Archive'
-                             .format(msid))
+            raise ValueError('Multiple matches for {} in Eng Archive'.format(msid))
         else:
             self.msid = msids[0]
             self.MSID = MSIDs[0]
@@ -536,16 +556,16 @@ class MSID(object):
             start, stop = intervals[0][0], intervals[-1][1]
 
         self.tstart = DateTime(start).secs
-        self.tstop = (DateTime(stop).secs if stop else
-                      DateTime(time.time(), format='unix').secs)
+        self.tstop = (
+            DateTime(stop).secs if stop else DateTime(time.time(), format='unix').secs
+        )
         self.datestart = DateTime(self.tstart).date
         self.datestop = DateTime(self.tstop).date
         self.data_source = {}
         self.content = content.get(self.MSID)
 
         if self.datestart < DATE2000_LO and self.datestop > DATE2000_HI:
-            intervals = [(self.datestart, DATE2000_HI),
-                         (DATE2000_HI, self.datestop)]
+            intervals = [(self.datestart, DATE2000_HI), (DATE2000_HI, self.datestop)]
 
         # Get the times, values, bad values mask from the HDF5 files archive
         if intervals is None:
@@ -566,12 +586,14 @@ class MSID(object):
 
     def __repr__(self):
         attrs = [self.__class__.__name__, self.MSID]
-        for name, val in (('start', self.datestart),
-                          ('stop', self.datestop),
-                          ('len', len(self)),
-                          ('dtype', self.dtype.name),
-                          ('unit', self.unit),
-                          ('stat', self.stat)):
+        for name, val in (
+            ('start', self.datestart),
+            ('stop', self.datestop),
+            ('len', len(self)),
+            ('dtype', self.dtype.name),
+            ('unit', self.unit),
+            ('stat', self.stat),
+        ):
             if val is not None:
                 attrs.append('{}={}'.format(name, val))
 
@@ -583,7 +605,11 @@ class MSID(object):
         """
         msids = []
         for start, stop in intervals:
-            msids.append(self.fetch.MSID(self.msid, start, stop, filter_bad=False, stat=self.stat))
+            msids.append(
+                self.fetch.MSID(
+                    self.msid, start, stop, filter_bad=False, stat=self.stat
+                )
+            )
 
         # No bad values column for stat='5min' or 'daily', but still need this attribute.
         if self.stat:
@@ -596,8 +622,12 @@ class MSID(object):
 
     def _get_data(self):
         """Get data from the Eng archive"""
-        logger.info('Getting data for %s between %s to %s',
-                    self.msid, self.datestart, self.datestop)
+        logger.info(
+            'Getting data for %s between %s to %s',
+            self.msid,
+            self.datestart,
+            self.datestop,
+        )
 
         comp_cls = ComputedMsid.get_matching_comp_cls(self.msid)
         if comp_cls:
@@ -612,24 +642,39 @@ class MSID(object):
             with _set_msid_files_basedir(self.datestart):
                 if self.stat:
                     if 'maude' in data_source.sources():
-                        raise ValueError('MAUDE data source does not support telemetry statistics')
+                        raise ValueError(
+                            'MAUDE data source does not support telemetry statistics'
+                        )
                     ft['interval'] = self.stat
                     self._get_stat_data()
                 else:
                     self.colnames = ['vals', 'times', 'bads']
-                    args = (self.content, self.tstart, self.tstop, self.MSID, self.units['system'])
+                    args = (
+                        self.content,
+                        self.tstart,
+                        self.tstop,
+                        self.MSID,
+                        self.units['system'],
+                    )
 
-                    if ('cxc' in data_source.sources() and
-                            self.MSID in data_source.get_msids('cxc')):
+                    if (
+                        'cxc' in data_source.sources()
+                        and self.MSID in data_source.get_msids('cxc')
+                    ):
                         # CACHE is normally True only when doing ingest processing.  Note
                         # also that to support caching the get_msid_data_from_cxc_cached
                         # method must be static.
-                        get_msid_data = (self._get_msid_data_from_cxc_cached if CACHE
-                                         else self._get_msid_data_from_cxc)
+                        get_msid_data = (
+                            self._get_msid_data_from_cxc_cached
+                            if CACHE
+                            else self._get_msid_data_from_cxc
+                        )
                         self.vals, self.times, self.bads = get_msid_data(*args)
                         self.data_source['cxc'] = _get_start_stop_dates(self.times)
 
-                    if 'test-drop-half' in data_source.sources() and hasattr(self, 'vals'):
+                    if 'test-drop-half' in data_source.sources() and hasattr(
+                        self, 'vals'
+                    ):
                         # For testing purposes drop half the data off the end.  This assumes another
                         # data_source like 'cxc' has been selected.
                         idx = len(self.vals) // 2
@@ -640,8 +685,10 @@ class MSID(object):
                         for source in self.data_source:
                             self.data_source[source] = _get_start_stop_dates(self.times)
 
-                    if ('maude' in data_source.sources() and
-                            self.MSID in data_source.get_msids('maude')):
+                    if (
+                        'maude' in data_source.sources()
+                        and self.MSID in data_source.get_msids('maude')
+                    ):
                         # Update self.vals, times, bads in place.  This might concatenate MAUDE
                         # telemetry to existing CXC values.
                         self._get_msid_data_from_maude(*args)
@@ -650,7 +697,9 @@ class MSID(object):
         logger.info(f'Getting computed values for {self.msid}')
 
         # Do computation.  This returns a dict of MSID attribute values.
-        attrs = comp_cls(self.units['system'])(self.tstart, self.tstop, self.msid, self.stat)
+        attrs = comp_cls(self.units['system'])(
+            self.tstart, self.tstop, self.msid, self.stat
+        )
 
         # Allow upstream class to be a bit sloppy on times and include samples
         # outside the time range.  This can happen with classes that inherit
@@ -660,15 +709,19 @@ class MSID(object):
 
         # List of "colnames", which is the ndarray attributes.  There can be
         # non-ndarray attributes that get returned, including typically 'unit'.
-        self.colnames = [attr for attr, val in attrs.items()
-                         if (isinstance(val, np.ndarray)
-                             and len(val) == len(attrs['times']))]
+        self.colnames = [
+            attr
+            for attr, val in attrs.items()
+            if (isinstance(val, np.ndarray) and len(val) == len(attrs['times']))
+        ]
 
         # Apply attributes to self
         for attr, val in attrs.items():
-            if (not all_ok
-                    and isinstance(val, np.ndarray)
-                    and len(val) == len(attrs['times'])):
+            if (
+                not all_ok
+                and isinstance(val, np.ndarray)
+                and len(val) == len(attrs['times'])
+            ):
                 val = val[ok]
             setattr(self, attr, val)
 
@@ -678,10 +731,12 @@ class MSID(object):
         filename = msid_files['stats'].abs
         logger.info('Opening %s', filename)
 
-        @local_or_remote_function("Getting stat data for " + self.MSID +
-                                  " from Ska eng archive server...")
+        @local_or_remote_function(
+            "Getting stat data for " + self.MSID + " from Ska eng archive server..."
+        )
         def get_stat_data_from_server(filename, dt, tstart, tstop):
             import tables
+
             open_file = getattr(tables, 'open_file', None) or tables.openFile
             h5 = open_file(os.path.join(*filename))
             table = h5.root.data
@@ -690,9 +745,10 @@ class MSID(object):
             table_rows = table[row0:row1]  # returns np.ndarray (structured array)
             h5.close()
             return (times[row0:row1], table_rows, row0, row1)
-        times, table_rows, row0, row1 = \
-            get_stat_data_from_server(_split_path(filename),
-                                      self.dt, self.tstart, self.tstop)
+
+        times, table_rows, row0, row1 = get_stat_data_from_server(
+            _split_path(filename), self.dt, self.tstart, self.tstop
+        )
         logger.info('Closed %s', filename)
 
         self.bads = None
@@ -703,13 +759,24 @@ class MSID(object):
             # Fix that here.
             colname_out = _plural(colname) if colname != 'n' else 'samples'
 
-            if colname_out in ('vals', 'mins', 'maxes', 'means',
-                               'p01s', 'p05s', 'p16s', 'p50s',
-                               'p84s', 'p95s', 'p99s'):
+            if colname_out in (
+                'vals',
+                'mins',
+                'maxes',
+                'means',
+                'p01s',
+                'p05s',
+                'p16s',
+                'p50s',
+                'p84s',
+                'p95s',
+                'p99s',
+            ):
                 vals = self.units.convert(self.MSID, table_rows[colname])
             elif colname_out == 'stds':
-                vals = self.units.convert(self.MSID, table_rows[colname],
-                                          delta_val=True)
+                vals = self.units.convert(
+                    self.MSID, table_rows[colname], delta_val=True
+                )
             else:
                 vals = table_rows[colname]
 
@@ -758,8 +825,7 @@ class MSID(object):
 
         # Read the TIME values either from cache or from disk.
         if times_cache['key'] == cache_key:
-            logger.info('Using times_cache for %s %s to %s',
-                        content, tstart, tstop)
+            logger.info('Using times_cache for %s %s to %s', content, tstart, tstop)
             times = times_cache['val']  # Already filtered on times_ok
             times_ok = times_cache['ok']  # For filtering MSID.val and MSID.bad
             times_all_ok = times_cache['all_ok']
@@ -768,9 +834,12 @@ class MSID(object):
             filename = msid_files['msid'].abs
             logger.info('Reading %s', filename)
 
-            @local_or_remote_function("Getting time data from Ska eng archive server...")
+            @local_or_remote_function(
+                "Getting time data from Ska eng archive server..."
+            )
             def get_time_data_from_server(h5_slice, filename):
                 import tables
+
                 open_file = getattr(tables, 'open_file', None) or tables.openFile
                 h5 = open_file(os.path.join(*filename))
                 times_ok = ~h5.root.quality[h5_slice]
@@ -787,20 +856,21 @@ class MSID(object):
             if not times_all_ok:
                 times = times[times_ok]
 
-            times_cache.update(dict(key=cache_key,
-                                    val=times,
-                                    ok=times_ok,
-                                    all_ok=times_all_ok))
+            times_cache.update(
+                dict(key=cache_key, val=times, ok=times_ok, all_ok=times_all_ok)
+            )
 
         # Extract the actual MSID values and bad values mask
         ft['msid'] = msid
         filename = msid_files['msid'].abs
         logger.info('Reading %s', filename)
 
-        @local_or_remote_function("Getting msid data for " + msid +
-                                  " from Ska eng archive server...")
+        @local_or_remote_function(
+            "Getting msid data for " + msid + " from Ska eng archive server..."
+        )
         def get_msid_data_from_server(h5_slice, filename):
             import tables
+
             open_file = getattr(tables, 'open_file', None) or tables.openFile
             h5 = open_file(os.path.join(*filename))
             vals = h5.root.data[h5_slice]
@@ -872,7 +942,9 @@ class MSID(object):
         # a list of results, so select the first element.
         out = out['data'][0]
 
-        vals = Units(unit_system).convert(msid.upper(), out['values'], from_system='eng')
+        vals = Units(unit_system).convert(
+            msid.upper(), out['values'], from_system='eng'
+        )
         times = out['times']
         bads = np.zeros(len(vals), dtype=bool)  # No 'bad' values from MAUDE
 
@@ -901,19 +973,24 @@ class MSID(object):
 
         if not hasattr(self, '_state_codes'):
             import Ska.tdb
+
             try:
                 states = Ska.tdb.msids[self.MSID].Tsc
             except Exception:
                 self._state_codes = None
             else:
                 if states is None or len(set(states['CALIBRATION_SET_NUM'])) != 1:
-                    warnings.warn('MSID {} has string vals but no state codes '
-                                  'or multiple calibration sets'.format(self.msid))
+                    warnings.warn(
+                        'MSID {} has string vals but no state codes '
+                        'or multiple calibration sets'.format(self.msid)
+                    )
                     self._state_codes = None
                 else:
                     states = np.sort(states.data, order='LOW_RAW_COUNT')
-                    self._state_codes = [(state['LOW_RAW_COUNT'],
-                                          state['STATE_CODE']) for state in states]
+                    self._state_codes = [
+                        (state['LOW_RAW_COUNT'], state['STATE_CODE'])
+                        for state in states
+                    ]
         return self._state_codes
 
     @property
@@ -939,9 +1016,9 @@ class MSID(object):
 
     @property
     def tdb(self):
-        """Access the Telemetry database entries for this MSID
-        """
+        """Access the Telemetry database entries for this MSID"""
         import Ska.tdb
+
         return Ska.tdb.msids[self.MSID]
 
     def interpolate(self, dt=None, start=None, stop=None, times=None):
@@ -969,8 +1046,10 @@ class MSID(object):
 
         if times is not None:
             if any(kwarg is not None for kwarg in (dt, start, stop)):
-                raise ValueError('If "times" keyword is set then "dt", "start", '
-                                 'and "stop" cannot be set')
+                raise ValueError(
+                    'If "times" keyword is set then "dt", "start", '
+                    'and "stop" cannot be set'
+                )
             # Use user-supplied times that are within the range of telemetry.
             ok = (times >= self.times[0]) & (times <= self.times[-1])
             times = times[ok]
@@ -986,9 +1065,9 @@ class MSID(object):
             times = np.arange(tstart, tstop, dt)
 
         logger.info('Interpolating index for %s', self.msid)
-        indexes = Ska.Numpy.interpolate(np.arange(len(self.times)),
-                                        self.times, times,
-                                        method='nearest', sorted=True)
+        indexes = Ska.Numpy.interpolate(
+            np.arange(len(self.times)), self.times, times, method='nearest', sorted=True
+        )
         logger.info('Slicing on indexes')
         for colname in self.colnames:
             colvals = getattr(self, colname)
@@ -1003,6 +1082,7 @@ class MSID(object):
 
     def copy(self):
         from copy import deepcopy
+
         return deepcopy(self)
 
     def filter_bad(self, bads=None, copy=False):
@@ -1064,16 +1144,16 @@ class MSID(object):
         :param copy: return a copy of MSID object with bad times filtered
         """
         if table is not None:
-            bad_times = ascii.read(table, format='no_header',
-                                   names=['start', 'stop'])
+            bad_times = ascii.read(table, format='no_header', names=['start', 'stop'])
         elif start is None and stop is None:
             bad_times = []
             for msid_glob, times in msid_bad_times.items():
                 if fnmatch.fnmatch(self.MSID, msid_glob):
                     bad_times.extend(times)
         elif start is None or stop is None:
-            raise ValueError('filter_times requires either 2 args '
-                             '(start, stop) or no args')
+            raise ValueError(
+                'filter_times requires either 2 args (start, stop) or no args'
+            )
         else:
             bad_times = [(start, stop)]
 
@@ -1184,13 +1264,15 @@ class MSID(object):
         if 'EventQuery' in (cls.__name__ for cls in intervals.__class__.__mro__):
             intervals = intervals.intervals(self.datestart, self.datestop)
 
-        intervals = [(DateTime(start).secs, DateTime(stop).secs)
-                     for start, stop in intervals]
+        intervals = [
+            (DateTime(start).secs, DateTime(stop).secs) for start, stop in intervals
+        ]
 
         for tstart, tstop in intervals:
             if tstart > tstop:
-                raise ValueError("Start time %s must be less than stop time %s"
-                                 % (tstart, tstop))
+                raise ValueError(
+                    "Start time %s must be less than stop time %s" % (tstart, tstop)
+                )
 
             if tstop < self.times[0] or tstart > self.times[-1]:
                 continue
@@ -1233,16 +1315,20 @@ class MSID(object):
         colvals = tuple(getattr(self, x) for x in colnames)
         fmt = ",".join("%s" for x in colnames)
 
-        f = zipfile.ZipFile(filename, ('a' if append
-                                       and os.path.exists(filename)
-                                       else 'w'))
+        f = zipfile.ZipFile(
+            filename, ('a' if append and os.path.exists(filename) else 'w')
+        )
         info = zipfile.ZipInfo(self.msid + '.csv')
         info.external_attr = 0o664 << 16  # Set permissions
         info.date_time = time.localtime()[:7]
         info.compress_type = zipfile.ZIP_DEFLATED
-        f.writestr(info,
-                   ",".join(colnames) + '\n' +
-                   '\n'.join(fmt % x for x in zip(*colvals)) + '\n')
+        f.writestr(
+            info,
+            ",".join(colnames)
+            + '\n'
+            + '\n'.join(fmt % x for x in zip(*colvals))
+            + '\n',
+        )
         f.close()
 
     def logical_intervals(self, op, val, complete_intervals=True, max_gap=None):
@@ -1285,17 +1371,20 @@ class MSID(object):
         """
         from . import utils
 
-        ops = {'==': operator.eq,
-               '!=': operator.ne,
-               '>': operator.gt,
-               '<': operator.lt,
-               '>=': operator.ge,
-               '<=': operator.le}
+        ops = {
+            '==': operator.eq,
+            '!=': operator.ne,
+            '>': operator.gt,
+            '<': operator.lt,
+            '>=': operator.ge,
+            '<=': operator.le,
+        }
         try:
             op = ops[op]
         except KeyError:
-            raise ValueError('op = "{}" is not in allowed values: {}'
-                             .format(op, sorted(ops.keys())))
+            raise ValueError(
+                'op = "{}" is not in allowed values: {}'.format(op, sorted(ops.keys()))
+            )
 
         # Do local version of bad value filtering
         if self.bads is not None and np.any(self.bads):
@@ -1384,6 +1473,7 @@ class MSID(object):
         """
 
         from .plot import MsidPlot
+
         self._iplot = MsidPlot(self, fmt, fmt_minmax, **plot_kwargs)
 
     def plot(self, *args, **kwargs):
@@ -1406,9 +1496,9 @@ class MSID(object):
 
         import matplotlib.pyplot as plt
         from Ska.Matplotlib import plot_cxctime
+
         vals = self.raw_vals if self.state_codes else self.vals
-        plot_cxctime(self.times, vals, *args, state_codes=self.state_codes,
-                     **kwargs)
+        plot_cxctime(self.times, vals, *args, state_codes=self.state_codes, **kwargs)
         plt.margins(0.02, 0.05)
         # Upper-cased version of msid name from user
         title = self.msid.upper()
@@ -1435,9 +1525,12 @@ class MSIDset(collections.OrderedDict):
 
     :returns: Dict-like object containing MSID instances keyed by MSID name
     """
+
     MSID = MSID
 
-    def __init__(self, msids=None, start=LAUNCH_DATE, stop=None, filter_bad=False, stat=None):
+    def __init__(
+        self, msids=None, start=LAUNCH_DATE, stop=None, filter_bad=False, stat=None
+    ):
         if msids is None:
             msids = []
 
@@ -1448,7 +1541,7 @@ class MSIDset(collections.OrderedDict):
             start, stop = intervals[0][0], intervals[-1][1]
 
         self.tstart = DateTime(start).secs
-        self.tstop = (DateTime(stop).secs if stop else DateTime().secs)
+        self.tstop = DateTime(stop).secs if stop else DateTime().secs
         self.datestart = DateTime(self.tstart).date
         self.datestop = DateTime(self.tstop).date
 
@@ -1458,8 +1551,9 @@ class MSIDset(collections.OrderedDict):
             new_msids.extend(msid_glob(msid)[0])
         for msid in new_msids:
             if intervals is None:
-                self[msid] = self.MSID(msid, self.tstart, self.tstop,
-                                       filter_bad=False, stat=stat)
+                self[msid] = self.MSID(
+                    msid, self.tstart, self.tstop, filter_bad=False, stat=stat
+                )
             else:
                 self[msid] = self.MSID(msid, intervals, filter_bad=False, stat=stat)
 
@@ -1524,8 +1618,9 @@ class MSIDset(collections.OrderedDict):
         for content in set(x.content for x in obj.values()):
             bads = None
 
-            msids = [x for x in obj.values()
-                     if x.content == content and x.bads is not None]
+            msids = [
+                x for x in obj.values() if x.content == content and x.bads is not None
+            ]
             for msid in msids:
                 if bads is None:
                     bads = msid.bads.copy()
@@ -1574,8 +1669,16 @@ class MSIDset(collections.OrderedDict):
         if copy:
             return obj
 
-    def interpolate(self, dt=None, start=None, stop=None, filter_bad=True, times=None,
-                    bad_union=False, copy=False):
+    def interpolate(
+        self,
+        dt=None,
+        start=None,
+        stop=None,
+        filter_bad=True,
+        times=None,
+        bad_union=False,
+        copy=False,
+    ):
         """
         Perform nearest-neighbor interpolation of all MSID values in the set
         to a common time sequence.  The values are updated in-place.
@@ -1638,8 +1741,10 @@ class MSIDset(collections.OrderedDict):
 
         if times is not None:
             if any(kwarg is not None for kwarg in (dt, start, stop)):
-                raise ValueError('If "times" keyword is set then "dt", "start", '
-                                 'and "stop" cannot be set')
+                raise ValueError(
+                    'If "times" keyword is set then "dt", "start", '
+                    'and "stop" cannot be set'
+                )
             # Use user-supplied times that are within the range of telemetry.
             ok = (times >= max_fetch_tstart) & (times <= min_fetch_tstop)
             obj.times = times[ok]
@@ -1657,9 +1762,13 @@ class MSIDset(collections.OrderedDict):
             if filter_bad and not bad_union:
                 msid.filter_bad()
             logger.info('Interpolating index for %s', msid.msid)
-            indexes = Ska.Numpy.interpolate(np.arange(len(msid.times)),
-                                            msid.times, obj.times,
-                                            method='nearest', sorted=True)
+            indexes = Ska.Numpy.interpolate(
+                np.arange(len(msid.times)),
+                msid.times,
+                obj.times,
+                method='nearest',
+                sorted=True,
+            )
             logger.info('Slicing on indexes')
             for colname in msid.colnames:
                 colvals = getattr(msid, colname)
@@ -1676,9 +1785,11 @@ class MSIDset(collections.OrderedDict):
             common_bads = np.zeros(len(obj.times), dtype=bool)
             for msid in msids:
                 if msid.stat is None and msid.bads is None:
-                    warnings.warn('WARNING: {!r} MSID has bad values already filtered.\n'
-                                  'This prevents `filter_bad_union` from working as expected.\n'
-                                  'Use MSIDset (not Msidset) with filter_bad=False.\n')
+                    warnings.warn(
+                        'WARNING: {!r} MSID has bad values already filtered.\n'
+                        'This prevents `filter_bad_union` from working as expected.\n'
+                        'Use MSIDset (not Msidset) with filter_bad=False.\n'
+                    )
                 if msid.bads is not None:  # 5min and daily stats have no bad values
                     common_bads |= msid.bads
 
@@ -1723,11 +1834,13 @@ class Msid(MSID):
 
     :returns: MSID instance
     """
+
     units = UNITS
 
     def __init__(self, msid, start=LAUNCH_DATE, stop=None, filter_bad=True, stat=None):
-        super(Msid, self).__init__(msid, start=start, stop=stop,
-                                   filter_bad=filter_bad, stat=stat)
+        super(Msid, self).__init__(
+            msid, start=start, stop=stop, filter_bad=filter_bad, stat=stat
+        )
 
 
 class Msidset(MSIDset):
@@ -1743,11 +1856,13 @@ class Msidset(MSIDset):
 
     :returns: Dict-like object containing MSID instances keyed by MSID name
     """
+
     MSID = MSID
 
     def __init__(self, msids, start=LAUNCH_DATE, stop=None, filter_bad=True, stat=None):
-        super(Msidset, self).__init__(msids, start=start, stop=stop,
-                                      filter_bad=filter_bad, stat=stat)
+        super(Msidset, self).__init__(
+            msids, start=start, stop=stop, filter_bad=filter_bad, stat=stat
+        )
 
 
 class HrcSsMsid(Msid):
@@ -1765,13 +1880,15 @@ class HrcSsMsid(Msid):
     :returns: MSID instance
 
     """
+
     units = UNITS
 
     def __new__(self, msid, start=LAUNCH_DATE, stop=None, stat=None):
         ss_msids = '2TLEV1RT 2VLEV1RT 2SHEV1RT 2TLEV2RT 2VLEV2RT 2SHEV2RT'
         if msid.upper() not in ss_msids.split():
-            raise ValueError('MSID {} is not in HRC secondary science ({})'
-                             .format(msid, ss_msids))
+            raise ValueError(
+                'MSID {} is not in HRC secondary science ({})'.format(msid, ss_msids)
+            )
 
         # If this is not full-resolution then add boolean bads mask to individual MSIDs
         msids = [msid, 'HRC_SS_HK_BAD']
@@ -1840,6 +1957,7 @@ def get_time_range(msid, format=None):
         @local_or_remote_function("Getting time range from Ska eng archive server...")
         def get_time_data_from_server(filename):
             import tables
+
             open_file = getattr(tables, 'open_file', None) or tables.openFile
             h5 = open_file(os.path.join(*filename))
             tstart = h5.root.data[0]
@@ -1859,10 +1977,21 @@ def get_time_range(msid, format=None):
     return tstart, tstop
 
 
-def get_telem(msids, start=None, stop=None, sampling='full', unit_system='eng',
-              interpolate_dt=None, remove_events=None, select_events=None,
-              time_format=None, outfile=None, quiet=False,
-              max_fetch_Mb=1000, max_output_Mb=100):
+def get_telem(
+    msids,
+    start=None,
+    stop=None,
+    sampling='full',
+    unit_system='eng',
+    interpolate_dt=None,
+    remove_events=None,
+    select_events=None,
+    time_format=None,
+    outfile=None,
+    quiet=False,
+    max_fetch_Mb=1000,
+    max_output_Mb=100,
+):
     """
     High-level routine to get telemetry for one or more MSIDs and perform
     common processing functions:
@@ -1893,10 +2022,22 @@ def get_telem(msids, start=None, stop=None, sampling='full', unit_system='eng',
     :returns: MSIDset object
     """
     from .get_telem import get_telem
-    return get_telem(msids, start, stop, sampling, unit_system,
-                     interpolate_dt, remove_events, select_events,
-                     time_format, outfile, quiet,
-                     max_fetch_Mb, max_output_Mb)
+
+    return get_telem(
+        msids,
+        start,
+        stop,
+        sampling,
+        unit_system,
+        interpolate_dt,
+        remove_events,
+        select_events,
+        time_format,
+        outfile,
+        quiet,
+        max_fetch_Mb,
+        max_output_Mb,
+    )
 
 
 @lru_cache_timed(maxsize=1000, timeout=600)
@@ -1918,29 +2059,36 @@ def get_interval(content, tstart, tstop):
 
     ft['content'] = content
 
-    @local_or_remote_function("Getting interval data from " +
-                              "DB on Ska eng archive server...")
+    @local_or_remote_function(
+        "Getting interval data from " + "DB on Ska eng archive server..."
+    )
     def get_interval_from_db(tstart, tstop, server):
 
         import Ska.DBI
 
         db = Ska.DBI.DBI(dbi='sqlite', server=os.path.join(*server))
 
-        query_row = db.fetchone('SELECT tstart, rowstart FROM archfiles '
-                                'WHERE filetime < ? order by filetime desc',
-                                (tstart,))
+        query_row = db.fetchone(
+            'SELECT tstart, rowstart FROM archfiles '
+            'WHERE filetime < ? order by filetime desc',
+            (tstart,),
+        )
         if not query_row:
-            query_row = db.fetchone('SELECT tstart, rowstart FROM archfiles '
-                                    'order by filetime asc')
+            query_row = db.fetchone(
+                'SELECT tstart, rowstart FROM archfiles order by filetime asc'
+            )
 
         rowstart = query_row['rowstart']
 
-        query_row = db.fetchone('SELECT tstop, rowstop FROM archfiles '
-                                'WHERE filetime > ? order by filetime asc',
-                                (tstop,))
+        query_row = db.fetchone(
+            'SELECT tstop, rowstop FROM archfiles '
+            'WHERE filetime > ? order by filetime asc',
+            (tstop,),
+        )
         if not query_row:
-            query_row = db.fetchone('SELECT tstop, rowstop FROM archfiles '
-                                    'order by filetime desc')
+            query_row = db.fetchone(
+                'SELECT tstop, rowstop FROM archfiles order by filetime desc'
+            )
 
         rowstop = query_row['rowstop']
 
@@ -1992,9 +2140,21 @@ def _fix_ctu_dwell_mode_bads(msid, bads):
     appropriate direction.
     """
     MSID = msid.upper()
-    stepped_on_msids = ('4PRT5BT', '4RT585T', 'AFLCA3BI', 'AIRU1BT', 'CSITB5V',
-                        'CUSOAOVN', 'ECNV3V', 'PLAED4ET', 'PR1TV01T', 'TCYLFMZM',
-                        'TOXTSUPN', 'ES1P5CV', 'ES2P5CV')
+    stepped_on_msids = (
+        '4PRT5BT',
+        '4RT585T',
+        'AFLCA3BI',
+        'AIRU1BT',
+        'CSITB5V',
+        'CUSOAOVN',
+        'ECNV3V',
+        'PLAED4ET',
+        'PR1TV01T',
+        'TCYLFMZM',
+        'TOXTSUPN',
+        'ES1P5CV',
+        'ES2P5CV',
+    )
 
     if MSID in stepped_on_msids or re.match(r'DWELL\d\d', MSID):
         # Find transitions from good value to bad value.  Turn that
@@ -2005,9 +2165,7 @@ def _fix_ctu_dwell_mode_bads(msid, bads):
     return bads
 
 
-def add_logging_handler(level=logging.INFO,
-                        formatter=None,
-                        handler=None):
+def add_logging_handler(level=logging.INFO, formatter=None, handler=None):
     """Configure logging for fetch module.
 
     :param level: logging level (logging.DEBUG, logging.INFO, etc)

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -3,35 +3,31 @@
 """
 Fetch values from the Ska engineering telemetry archive.
 """
-import sys
-import os
-import time
+import collections
 import contextlib
+import fnmatch
 import logging
 import operator
-import fnmatch
-import collections
-import warnings
+import os
+import pickle
 import re
+import sys
+import time
+import warnings
 from pathlib import Path
 
 import numpy as np
-from astropy.io import ascii
 import pyyaks.context
-
-import pickle
-
-from . import file_defs
-from .units import Units
-from . import cache
-from . import remote_access
-from .remote_access import ENG_ARCHIVE
-from .derived.comps import ComputedMsid
-from .lazy import LazyDict
-from . import __version__  # noqa
-
+from astropy.io import ascii
 from Chandra.Time import DateTime
 from ska_helpers.utils import lru_cache_timed
+
+from . import __version__  # noqa
+from . import cache, file_defs, remote_access
+from .derived.comps import ComputedMsid
+from .lazy import LazyDict
+from .remote_access import ENG_ARCHIVE
+from .units import Units
 
 # Module-level units, defaults to CXC units (e.g. Kelvins etc)
 UNITS = Units(system='cxc')

--- a/Ska/engarchive/fetch_eng.py
+++ b/Ska/engarchive/fetch_eng.py
@@ -6,11 +6,11 @@ from . import fetch
 from .fetch import *  # noqa
 
 # Module-level units, defaults to CXC units (e.g. Kelvins etc)
-UNITS = fetch.Units('eng')
+UNITS = fetch.Units("eng")
 
 
 def get_units():
-    return UNITS['system']
+    return UNITS["system"]
 
 
 get_units.__doc__ = fetch.get_units.__doc__

--- a/Ska/engarchive/fetch_eng.py
+++ b/Ska/engarchive/fetch_eng.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import sys
 
-from .fetch import *  # noqa
-from . import fetch
 from . import __version__  # noqa
+from . import fetch
+from .fetch import *  # noqa
 
 # Module-level units, defaults to CXC units (e.g. Kelvins etc)
 UNITS = fetch.Units('eng')

--- a/Ska/engarchive/fetch_sci.py
+++ b/Ska/engarchive/fetch_sci.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import sys
 
-from .fetch import *  # noqa
-from . import fetch
 from . import __version__  # noqa
+from . import fetch
+from .fetch import *  # noqa
 
 # Module-level units, defaults to CXC units (e.g. Kelvins etc)
 UNITS = fetch.Units('sci')

--- a/Ska/engarchive/fetch_sci.py
+++ b/Ska/engarchive/fetch_sci.py
@@ -6,11 +6,11 @@ from . import fetch
 from .fetch import *  # noqa
 
 # Module-level units, defaults to CXC units (e.g. Kelvins etc)
-UNITS = fetch.Units('sci')
+UNITS = fetch.Units("sci")
 
 
 def get_units():
-    return UNITS['system']
+    return UNITS["system"]
 
 
 get_units.__doc__ = fetch.get_units.__doc__

--- a/Ska/engarchive/file_defs.py
+++ b/Ska/engarchive/file_defs.py
@@ -21,38 +21,41 @@ SKA = os.environ.get('SKA') or '/proj/sot/ska'
 msid_root = os.path.join(SKA, 'data', 'eng_archive')
 msid_roots = [msid_root]
 
-msid_files = {'filetypes': 'filetypes.dat',
-              'msid_bad_times': 'msid_bad_times.dat',
-              'contentdir': 'data/{{ft.content}}/',
-              'headers': 'data/{{ft.content}}/headers.pickle',
-              'archfiles': 'data/{{ft.content}}/archfiles.db3',
-              'colnames': 'data/{{ft.content}}/colnames.pickle',
-              'colnames_all': 'data/{{ft.content}}/colnames_all.pickle',
-              'msid': 'data/{{ft.content}}/{{ft.msid | upper}}.h5',
-              'data': 'data/{{ft.content}}/{{ft.msid | upper}}.h5',
-              'statsdir': 'data/{{ft.content}}/{{ft.interval}}/',
-              'stats': 'data/{{ft.content}}/{{ft.interval}}/{{ft.msid | upper}}.h5',
-              'last_date_id': 'data/{{ft.content}}/{{ft.interval}}/last_date_id',
-              }
+msid_files = {
+    'filetypes': 'filetypes.dat',
+    'msid_bad_times': 'msid_bad_times.dat',
+    'contentdir': 'data/{{ft.content}}/',
+    'headers': 'data/{{ft.content}}/headers.pickle',
+    'archfiles': 'data/{{ft.content}}/archfiles.db3',
+    'colnames': 'data/{{ft.content}}/colnames.pickle',
+    'colnames_all': 'data/{{ft.content}}/colnames_all.pickle',
+    'msid': 'data/{{ft.content}}/{{ft.msid | upper}}.h5',
+    'data': 'data/{{ft.content}}/{{ft.msid | upper}}.h5',
+    'statsdir': 'data/{{ft.content}}/{{ft.interval}}/',
+    'stats': 'data/{{ft.content}}/{{ft.interval}}/{{ft.msid | upper}}.h5',
+    'last_date_id': 'data/{{ft.content}}/{{ft.interval}}/last_date_id',
+}
 
 
 # NOTE: arch_root used ONLY in one-off or legacy code, not in update_archive.py or
 # transfer_stage.py
 arch_root = '/data/cosmos2/eng_archive'
-arch_files = {'stagedir': 'stage/{{ft.content}}/',
-              'rootdir': '',
-              'archrootdir': 'data/{{ft.content}}/arch/',
-              'archdir': 'data/{{ft.content}}/arch/{{ft.year}}/{{ft.doy}}/',
-              'archfile': 'data/{{ft.content}}/arch/{{ft.year}}/{{ft.doy}}/{{ft.basename}}',
-              }
+arch_files = {
+    'stagedir': 'stage/{{ft.content}}/',
+    'rootdir': '',
+    'archrootdir': 'data/{{ft.content}}/arch/',
+    'archdir': 'data/{{ft.content}}/arch/{{ft.year}}/{{ft.doy}}/',
+    'archfile': 'data/{{ft.content}}/arch/{{ft.year}}/{{ft.doy}}/{{ft.basename}}',
+}
 
 # Files within the sync repo (for maintaining client archive)
-sync_files = {'index': 'sync/{{ft.content}}/index.ecsv',
-              'msid_contents': 'sync/msid_contents.pkl.gz',
-              'last_rows': 'sync/{{ft.content}}/last_rows_{{ft.interval}}.pkl',
-              'data_dir': 'sync/{{ft.content}}/{{ft.date_id}}',
-              'data': 'sync/{{ft.content}}/{{ft.date_id}}/{{ft.interval}}.pkl.gz',
-              }
+sync_files = {
+    'index': 'sync/{{ft.content}}/index.ecsv',
+    'msid_contents': 'sync/msid_contents.pkl.gz',
+    'last_rows': 'sync/{{ft.content}}/last_rows_{{ft.interval}}.pkl',
+    'data_dir': 'sync/{{ft.content}}/{{ft.date_id}}',
+    'data': 'sync/{{ft.content}}/{{ft.date_id}}/{{ft.interval}}.pkl.gz',
+}
 
 # Used when originally creating database.
 orig_arch_root = '/data/cosmos2/tlm'

--- a/Ska/engarchive/file_defs.py
+++ b/Ska/engarchive/file_defs.py
@@ -13,50 +13,50 @@ all MSIDs in the same content-type group (e.g. ACIS2ENG).
 """
 import os
 
-SKA = os.environ.get('SKA') or '/proj/sot/ska'
+SKA = os.environ.get("SKA") or "/proj/sot/ska"
 
 # Root directories for MSID files.  msid_root is prime, others are backups.
 # NOTE: msid_root(s) used ONLY in one-off or legacy code, not in update_archive.py or
 # transfer_stage.py
-msid_root = os.path.join(SKA, 'data', 'eng_archive')
+msid_root = os.path.join(SKA, "data", "eng_archive")
 msid_roots = [msid_root]
 
 msid_files = {
-    'filetypes': 'filetypes.dat',
-    'msid_bad_times': 'msid_bad_times.dat',
-    'contentdir': 'data/{{ft.content}}/',
-    'headers': 'data/{{ft.content}}/headers.pickle',
-    'archfiles': 'data/{{ft.content}}/archfiles.db3',
-    'colnames': 'data/{{ft.content}}/colnames.pickle',
-    'colnames_all': 'data/{{ft.content}}/colnames_all.pickle',
-    'msid': 'data/{{ft.content}}/{{ft.msid | upper}}.h5',
-    'data': 'data/{{ft.content}}/{{ft.msid | upper}}.h5',
-    'statsdir': 'data/{{ft.content}}/{{ft.interval}}/',
-    'stats': 'data/{{ft.content}}/{{ft.interval}}/{{ft.msid | upper}}.h5',
-    'last_date_id': 'data/{{ft.content}}/{{ft.interval}}/last_date_id',
+    "filetypes": "filetypes.dat",
+    "msid_bad_times": "msid_bad_times.dat",
+    "contentdir": "data/{{ft.content}}/",
+    "headers": "data/{{ft.content}}/headers.pickle",
+    "archfiles": "data/{{ft.content}}/archfiles.db3",
+    "colnames": "data/{{ft.content}}/colnames.pickle",
+    "colnames_all": "data/{{ft.content}}/colnames_all.pickle",
+    "msid": "data/{{ft.content}}/{{ft.msid | upper}}.h5",
+    "data": "data/{{ft.content}}/{{ft.msid | upper}}.h5",
+    "statsdir": "data/{{ft.content}}/{{ft.interval}}/",
+    "stats": "data/{{ft.content}}/{{ft.interval}}/{{ft.msid | upper}}.h5",
+    "last_date_id": "data/{{ft.content}}/{{ft.interval}}/last_date_id",
 }
 
 
 # NOTE: arch_root used ONLY in one-off or legacy code, not in update_archive.py or
 # transfer_stage.py
-arch_root = '/data/cosmos2/eng_archive'
+arch_root = "/data/cosmos2/eng_archive"
 arch_files = {
-    'stagedir': 'stage/{{ft.content}}/',
-    'rootdir': '',
-    'archrootdir': 'data/{{ft.content}}/arch/',
-    'archdir': 'data/{{ft.content}}/arch/{{ft.year}}/{{ft.doy}}/',
-    'archfile': 'data/{{ft.content}}/arch/{{ft.year}}/{{ft.doy}}/{{ft.basename}}',
+    "stagedir": "stage/{{ft.content}}/",
+    "rootdir": "",
+    "archrootdir": "data/{{ft.content}}/arch/",
+    "archdir": "data/{{ft.content}}/arch/{{ft.year}}/{{ft.doy}}/",
+    "archfile": "data/{{ft.content}}/arch/{{ft.year}}/{{ft.doy}}/{{ft.basename}}",
 }
 
 # Files within the sync repo (for maintaining client archive)
 sync_files = {
-    'index': 'sync/{{ft.content}}/index.ecsv',
-    'msid_contents': 'sync/msid_contents.pkl.gz',
-    'last_rows': 'sync/{{ft.content}}/last_rows_{{ft.interval}}.pkl',
-    'data_dir': 'sync/{{ft.content}}/{{ft.date_id}}',
-    'data': 'sync/{{ft.content}}/{{ft.date_id}}/{{ft.interval}}.pkl.gz',
+    "index": "sync/{{ft.content}}/index.ecsv",
+    "msid_contents": "sync/msid_contents.pkl.gz",
+    "last_rows": "sync/{{ft.content}}/last_rows_{{ft.interval}}.pkl",
+    "data_dir": "sync/{{ft.content}}/{{ft.date_id}}",
+    "data": "sync/{{ft.content}}/{{ft.date_id}}/{{ft.interval}}.pkl.gz",
 }
 
 # Used when originally creating database.
-orig_arch_root = '/data/cosmos2/tlm'
-orig_arch_files = {'contentdir': '{{ft.content}}/'}
+orig_arch_root = "/data/cosmos2/tlm"
+orig_arch_files = {"contentdir": "{{ft.content}}/"}

--- a/Ska/engarchive/fix_bad_values.py
+++ b/Ska/engarchive/fix_bad_values.py
@@ -69,18 +69,18 @@ def _set_msid_files_basedir(datestart):
         if datestart < fetch.DATE2000_LO:
             # Note: don't use os.path.join because ENG_ARCHIVE and basedir must
             # use linux '/' convention but this might be running on Windows.
-            msid_files.basedir = msid_files.basedir + '/1999'
+            msid_files.basedir = msid_files.basedir + "/1999"
         yield
     finally:
         msid_files.basedir = cache_basedir
 
 
 def get_opt():
-    parser = argparse.ArgumentParser(description='Fix bad values in eng archive')
-    parser.add_argument('--msid', type=str, help='MSID name')
-    parser.add_argument('--start', help='Start time of bad values')
-    parser.add_argument('--stop', help='Stop time of bad values')
-    parser.add_argument('--value', help='Update with <value> instead of setting as bad')
+    parser = argparse.ArgumentParser(description="Fix bad values in eng archive")
+    parser.add_argument("--msid", type=str, help="MSID name")
+    parser.add_argument("--start", help="Start time of bad values")
+    parser.add_argument("--stop", help="Stop time of bad values")
+    parser.add_argument("--value", help="Update with <value> instead of setting as bad")
     parser.add_argument(
         "--run",
         action="store_true",
@@ -98,10 +98,10 @@ def get_opt():
 
 def calc_stats_vals(msid, rows, indexes, interval):
     quantiles = (1, 5, 16, 50, 84, 95, 99)
-    cols_stats = ('index', 'n', 'val')
+    cols_stats = ("index", "n", "val")
     n_out = len(rows) - 1
     msid_dtype = msid.vals.dtype
-    msid_is_numeric = not msid_dtype.name.startswith('string')
+    msid_is_numeric = not msid_dtype.name.startswith("string")
     # Predeclare numpy arrays of correct type and sufficient size for accumulating results.
     out = dict(
         index=np.ndarray((n_out,), dtype=np.int32),
@@ -109,7 +109,7 @@ def calc_stats_vals(msid, rows, indexes, interval):
         val=np.ndarray((n_out,), dtype=msid_dtype),
     )
     if msid_is_numeric:
-        cols_stats += ('min', 'max', 'mean')
+        cols_stats += ("min", "max", "mean")
         out.update(
             dict(
                 min=np.ndarray((n_out,), dtype=msid_dtype),
@@ -117,11 +117,11 @@ def calc_stats_vals(msid, rows, indexes, interval):
                 mean=np.ndarray((n_out,), dtype=np.float32),
             )
         )
-        if interval == 'daily':
-            cols_stats += ('std',) + tuple('p%02d' % x for x in quantiles)
-            out['std'] = np.ndarray((n_out,), dtype=msid_dtype)
+        if interval == "daily":
+            cols_stats += ("std",) + tuple("p%02d" % x for x in quantiles)
+            out["std"] = np.ndarray((n_out,), dtype=msid_dtype)
             out.update(
-                ('p%02d' % x, np.ndarray((n_out,), dtype=msid_dtype)) for x in quantiles
+                ("p%02d" % x, np.ndarray((n_out,), dtype=msid_dtype)) for x in quantiles
             )
     i = 0
     for row0, row1, index in itertools.izip(rows[:-1], rows[1:], indexes[:-1]):
@@ -129,9 +129,9 @@ def calc_stats_vals(msid, rows, indexes, interval):
         times = msid.times[row0:row1]
         n_vals = len(vals)
         if n_vals > 0:
-            out['index'][i] = index
-            out['n'][i] = n_vals
-            out['val'][i] = vals[n_vals // 2]
+            out["index"][i] = index
+            out["n"][i] = n_vals
+            out["val"][i] = vals[n_vals // 2]
             if msid_is_numeric:
                 if n_vals <= 2:
                     dts = np.ones(n_vals, dtype=np.float64)
@@ -149,7 +149,7 @@ def calc_stats_vals(msid, rows, indexes, interval):
                             for t, dt in zip(times[negs], dts[negs])
                         ]
                         logger.warning(
-                            'WARNING - negative dts in {} at {}'.format(
+                            "WARNING - negative dts in {} at {}".format(
                                 msid.MSID, times_dts
                             )
                         )
@@ -162,42 +162,42 @@ def calc_stats_vals(msid, rows, indexes, interval):
                     dts.clip(0.001, 300.0, out=dts)
                 sum_dts = np.sum(dts)
 
-                out['min'][i] = np.min(vals)
-                out['max'][i] = np.max(vals)
-                out['mean'][i] = np.sum(dts * vals) / sum_dts
-                if interval == 'daily':
+                out["min"][i] = np.min(vals)
+                out["max"][i] = np.max(vals)
+                out["mean"][i] = np.sum(dts * vals) / sum_dts
+                if interval == "daily":
                     # biased weighted estimator of variance (N should be big enough)
                     # http://en.wikipedia.org/wiki/Mean_square_weighted_deviation
-                    sigma_sq = np.sum(dts * (vals - out['mean'][i]) ** 2) / sum_dts
-                    out['std'][i] = np.sqrt(sigma_sq)
+                    sigma_sq = np.sum(dts * (vals - out["mean"][i]) ** 2) / sum_dts
+                    out["std"][i] = np.sqrt(sigma_sq)
                     quant_vals = scipy.stats.mstats.mquantiles(
                         vals, np.array(quantiles) / 100.0
                     )
                     for quant_val, quantile in zip(quant_vals, quantiles):
-                        out['p%02d' % quantile][i] = quant_val
+                        out["p%02d" % quantile][i] = quant_val
             i += 1
 
     return np.rec.fromarrays([out[x][:i] for x in cols_stats], names=cols_stats)
 
 
 def fix_stats_h5(msid, tstart, tstop, interval):
-    dt = {'5min': 328, 'daily': 86400}[interval]
+    dt = {"5min": 328, "daily": 86400}[interval]
 
-    ft['msid'] = msid
-    ft['interval'] = interval
+    ft["msid"] = msid
+    ft["interval"] = interval
     datestart = DateTime(tstart).date
     with _set_msid_files_basedir(datestart):
-        stats_file = msid_files['stats'].abs
-    logger.info('Updating stats file {}'.format(stats_file))
+        stats_file = msid_files["stats"].abs
+    logger.info("Updating stats file {}".format(stats_file))
 
     index0 = int(tstart // dt)
     index1 = int(tstop // dt) + 1
     indexes = np.arange(index0, index1 + 1, dtype=np.int32)
     times = indexes * dt
-    logger.info('Indexes = {}:{}'.format(index0, index1))
+    logger.info("Indexes = {}:{}".format(index0, index1))
 
     logger.info(
-        'Fetching {} data between {} to {}'.format(
+        "Fetching {} data between {} to {}".format(
             msid, DateTime(times[0] - 500).date, DateTime(times[-1] + 500).date
         )
     )
@@ -206,7 +206,7 @@ def fix_stats_h5(msid, tstart, tstop, interval):
     # Check within each stat interval?
     if len(dat.times) == 0:
         logger.info(
-            'Skipping: No values within interval {} to {}'.format(
+            "Skipping: No values within interval {} to {}".format(
                 DateTime(times[0] - 500).date, DateTime(times[-1] + 500).date
             )
         )
@@ -216,34 +216,34 @@ def fix_stats_h5(msid, tstart, tstop, interval):
     vals_stats = calc_stats_vals(dat, rows, indexes, interval)
 
     try:
-        h5 = tables.openFile(stats_file, 'a')
+        h5 = tables.openFile(stats_file, "a")
         table = h5.root.data
-        row0, row1 = np.searchsorted(table.col('index'), [index0, index1])
+        row0, row1 = np.searchsorted(table.col("index"), [index0, index1])
         for row_idx, vals_stat in itertools.izip(range(row0, row1), vals_stats):
             if row1 - row0 < 50 or row_idx == row0 or row_idx == row1 - 1:
-                logger.info('Row index = {}'.format(row_idx))
-                logger.info('  ORIGINAL: %s', table[row_idx])
-                logger.info('  UPDATED : %s', vals_stat)
+                logger.info("Row index = {}".format(row_idx))
+                logger.info("  ORIGINAL: %s", table[row_idx])
+                logger.info("  UPDATED : %s", vals_stat)
             if opt.run:
                 table[row_idx] = tuple(vals_stat)
     finally:
         h5.close()
 
-    logger.info('')
+    logger.info("")
 
 
 def fix_msid_h5(msid, tstart, tstop):
     """
     Fix the msid full-resolution HDF5 data file
     """
-    logger.info('Fixing MSID {} h5 file'.format(msid))
-    row_slice = fetch.get_interval(ft['content'].val, tstart, tstop)
+    logger.info("Fixing MSID {} h5 file".format(msid))
+    row_slice = fetch.get_interval(ft["content"].val, tstart, tstop)
 
     # Load the time values and find indexes corresponding to start / stop times
-    ft['msid'] = 'TIME'
+    ft["msid"] = "TIME"
 
-    filename = msid_files['data'].abs
-    logger.info('Reading TIME file {}'.format(filename))
+    filename = msid_files["data"].abs
+    logger.info("Reading TIME file {}".format(filename))
 
     h5 = tables.openFile(filename)
     times = h5.root.data[row_slice]
@@ -254,16 +254,16 @@ def fix_msid_h5(msid, tstart, tstop):
     fix_idxs = np.flatnonzero((tstart <= times) & (times <= tstop)) + row_slice.start
 
     # Open the msid HDF5 data file and set the corresponding quality flags to True (=> bad)
-    ft['msid'] = msid
-    filename = msid_files['msid'].abs
-    logger.info('Reading msid file {}'.format(filename))
+    ft["msid"] = msid
+    filename = msid_files["msid"].abs
+    logger.info("Reading msid file {}".format(filename))
 
-    h5 = tables.openFile(filename, 'a')
+    h5 = tables.openFile(filename, "a")
     try:
         if opt.value is not None:
             # Set data to <value> over the specified time range
             i0, i1 = fix_idxs[0], fix_idxs[-1] + 1
-            logger.info('Changing {}.data[{}:{}] to {}'.format(msid, i0, i1, opt.value))
+            logger.info("Changing {}.data[{}:{}] to {}".format(msid, i0, i1, opt.value))
             if opt.run:
                 h5.root.data[i0:i1] = opt.value
         else:
@@ -271,13 +271,13 @@ def fix_msid_h5(msid, tstart, tstop):
                 quality = h5.root.quality[idx]
                 if quality:
                     logger.info(
-                        'Skipping idx={} because quality is already True'.format(idx)
+                        "Skipping idx={} because quality is already True".format(idx)
                     )
                     continue
                 if len(fix_idxs) < 100 or idx == fix_idxs[0] or idx == fix_idxs[-1]:
-                    logger.info('{}.data[{}] = {}'.format(msid, idx, h5.root.data[idx]))
+                    logger.info("{}.data[{}] = {}".format(msid, idx, h5.root.data[idx]))
                     logger.info(
-                        'Changing {}.quality[{}] from {} to True'.format(
+                        "Changing {}.quality[{}] from {} to True".format(
                             msid, idx, quality
                         )
                     )
@@ -285,7 +285,7 @@ def fix_msid_h5(msid, tstart, tstop):
                     h5.root.quality[idx] = True
     finally:
         h5.close()
-    logger.info('')
+    logger.info("")
 
 
 def main():
@@ -297,7 +297,7 @@ def main():
 
     # Set up infrastructure to directly access HDF5 files
     msid_files = pyyaks.context.ContextDict(
-        'msid_files', basedir=(opt.data_root or file_defs.msid_root)
+        "msid_files", basedir=(opt.data_root or file_defs.msid_root)
     )
     msid_files.update(file_defs.msid_files)
 
@@ -307,20 +307,20 @@ def main():
     # Set up logging
     loglevel = pyyaks.logger.INFO
     logger = pyyaks.logger.get_logger(
-        name='fix_bad_values', level=loglevel, format="%(message)s"
+        name="fix_bad_values", level=loglevel, format="%(message)s"
     )
 
     logger.info(
-        '** If something gets corrupted then there is the NetApp snapshot for'
-        ' recovery **'
+        "** If something gets corrupted then there is the NetApp snapshot for"
+        " recovery **"
     )
-    logger.info('')
+    logger.info("")
     if not opt.run:
-        logger.info('** DRY RUN **')
-        logger.info('')
+        logger.info("** DRY RUN **")
+        logger.info("")
 
     msid = opt.msid.upper()
-    ft['content'] = fetch.content[msid]
+    ft["content"] = fetch.content[msid]
 
     # Get the relevant row slice covering the requested time span for this content type
     tstart = DateTime(opt.start).secs - 0.001
@@ -333,9 +333,9 @@ def main():
         fix_msid_h5(msid, tstart, tstop)
 
     # Now fix stats files
-    fix_stats_h5(msid, tstart, tstop, '5min')
-    fix_stats_h5(msid, tstart, tstop, 'daily')
+    fix_stats_h5(msid, tstart, tstop, "5min")
+    fix_stats_h5(msid, tstart, tstop, "daily")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/Ska/engarchive/fix_bad_values.py
+++ b/Ska/engarchive/fix_bad_values.py
@@ -40,18 +40,18 @@ Example::
 """
 
 import argparse
-import itertools
 import contextlib
+import itertools
 
 import numpy as np
-import tables
-import scipy.stats.mstats
-
 import pyyaks.context
 import pyyaks.logger
-from Ska.engarchive import fetch
-import Ska.engarchive.file_defs as file_defs
+import scipy.stats.mstats
+import tables
 from Chandra.Time import DateTime
+
+import Ska.engarchive.file_defs as file_defs
+from Ska.engarchive import fetch
 
 ft = fetch.ft
 opt = None

--- a/Ska/engarchive/get_telem.py
+++ b/Ska/engarchive/get_telem.py
@@ -20,19 +20,19 @@ Examples
 Arguments
 =========
 """
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
 
-import ast
 import argparse
+import ast
 import re
 import shlex
 from itertools import count
-from six.moves import zip
-import six
 
 import numpy as np
-
+import six
 from Chandra.Time import DateTime
+from six.moves import zip
+
 from . import fetch, utils
 
 

--- a/Ska/engarchive/get_telem.py
+++ b/Ska/engarchive/get_telem.py
@@ -154,10 +154,21 @@ def get_queryset(expr):
     return eval(queryset_expr)
 
 
-def get_telem(msids, start=None, stop=None, sampling='full', unit_system='eng',
-              interpolate_dt=None, remove_events=None, select_events=None,
-              time_format=None, outfile=None, quiet=False,
-              max_fetch_Mb=None, max_output_Mb=None):
+def get_telem(
+    msids,
+    start=None,
+    stop=None,
+    sampling='full',
+    unit_system='eng',
+    interpolate_dt=None,
+    remove_events=None,
+    select_events=None,
+    time_format=None,
+    outfile=None,
+    quiet=False,
+    max_fetch_Mb=None,
+    max_output_Mb=None,
+):
     """
     High-level routine to get telemetry for one or more MSIDs and perform
     common post-processing functions.
@@ -169,6 +180,7 @@ def get_telem(msids, start=None, stop=None, sampling='full', unit_system='eng',
     """
     # Set up output logging
     from pyyaks.logger import get_logger
+
     logger = get_logger(name='Ska.engarchive.get_telem', level=(100 if quiet else -100))
 
     # Set defaults and translate to fetch keywords
@@ -179,23 +191,31 @@ def get_telem(msids, start=None, stop=None, sampling='full', unit_system='eng',
     if isinstance(msids, six.string_types):
         msids = [msids]
 
-    logger.info('Fetching {}-resolution data for MSIDS={}\n  from {} to {}'
-                .format(sampling, msids, start.date, stop.date))
+    logger.info(
+        'Fetching {}-resolution data for MSIDS={}\n  from {} to {}'.format(
+            sampling, msids, start.date, stop.date
+        )
+    )
 
     fetch.set_units(unit_system)
 
     # Make sure that the dataset being fetched is reasonable (if checking requested)
     if max_fetch_Mb is not None or max_output_Mb is not None:
-        fetch_Mb, output_Mb = utils.get_fetch_size(msids, start, stop, stat=stat,
-                                                   interpolate_dt=interpolate_dt, fast=True)
+        fetch_Mb, output_Mb = utils.get_fetch_size(
+            msids, start, stop, stat=stat, interpolate_dt=interpolate_dt, fast=True
+        )
         if max_fetch_Mb is not None and fetch_Mb > max_fetch_Mb:
-            raise MemoryError('Requested fetch requires {:.2f} Mb vs. limit of {:.2f} Mb'
-                              .format(fetch_Mb, max_fetch_Mb))
+            raise MemoryError(
+                'Requested fetch requires {:.2f} Mb vs. limit of {:.2f} Mb'.format(
+                    fetch_Mb, max_fetch_Mb
+                )
+            )
         # If outputting to a file then check output size
         if outfile and max_output_Mb is not None and output_Mb > max_output_Mb:
-            raise MemoryError('Requested fetch (interpolated) requires {:.2f} Mb '
-                              'vs. limit of {:.2f} Mb'
-                              .format(output_Mb, max_output_Mb))
+            raise MemoryError(
+                'Requested fetch (interpolated) requires {:.2f} Mb '
+                'vs. limit of {:.2f} Mb'.format(output_Mb, max_output_Mb)
+            )
 
     dat = fetch.MSIDset(msids, start, stop, stat=stat, filter_bad=filter_bad)
 
@@ -217,7 +237,9 @@ def get_telem(msids, start=None, stop=None, sampling='full', unit_system='eng',
 
     if time_format not in (None, 'secs'):
         for dat_msid in dat.values():
-            dat_msid.times = getattr(DateTime(dat_msid.times, format='secs'), time_format)
+            dat_msid.times = getattr(
+                DateTime(dat_msid.times, format='secs'), time_format
+            )
 
     if outfile:
         logger.info('Writing data to {}'.format(outfile))
@@ -227,66 +249,79 @@ def get_telem(msids, start=None, stop=None, sampling='full', unit_system='eng',
 
 
 def get_opt():
-    parser = argparse.ArgumentParser(description=__doc__,
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('--start',
-                        type=str,
-                        help='Start time for data fetch (default=<stop> - 30 days)')
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        '--start', type=str, help='Start time for data fetch (default=<stop> - 30 days)'
+    )
 
-    parser.add_argument('--stop',
-                        type=str,
-                        help='Stop time for data fetch (default=NOW)')
+    parser.add_argument(
+        '--stop', type=str, help='Stop time for data fetch (default=NOW)'
+    )
 
-    parser.add_argument('--sampling',
-                        type=str,
-                        default='5min',
-                        help='Data sampling (full|5min|daily) (default=5min)')
+    parser.add_argument(
+        '--sampling',
+        type=str,
+        default='5min',
+        help='Data sampling (full|5min|daily) (default=5min)',
+    )
 
-    parser.add_argument('--unit-system',
-                        type=str,
-                        default='eng',
-                        help='Unit system for data (eng|sci|cxc) (default=eng)')
+    parser.add_argument(
+        '--unit-system',
+        type=str,
+        default='eng',
+        help='Unit system for data (eng|sci|cxc) (default=eng)',
+    )
 
-    parser.add_argument('--interpolate-dt',
-                        type=float,
-                        help='Interpolate to uniform time steps (secs, default=None)')
+    parser.add_argument(
+        '--interpolate-dt',
+        type=float,
+        help='Interpolate to uniform time steps (secs, default=None)',
+    )
 
-    parser.add_argument('--remove-events',
-                        type=str,
-                        help='Remove kadi events expression (default=None)')
+    parser.add_argument(
+        '--remove-events', type=str, help='Remove kadi events expression (default=None)'
+    )
 
-    parser.add_argument('--select-events',
-                        type=str,
-                        help='Select kadi events expression (default=None)')
+    parser.add_argument(
+        '--select-events', type=str, help='Select kadi events expression (default=None)'
+    )
 
-    parser.add_argument('--time-format',
-                        type=str,
-                        help='Output time format (secs|date|greta|jd|frac_year|...)')
+    parser.add_argument(
+        '--time-format',
+        type=str,
+        help='Output time format (secs|date|greta|jd|frac_year|...)',
+    )
 
-    parser.add_argument('--outfile',
-                        default='fetch.zip',
-                        type=str,
-                        help='Output file name (default=fetch.zip)')
+    parser.add_argument(
+        '--outfile',
+        default='fetch.zip',
+        type=str,
+        help='Output file name (default=fetch.zip)',
+    )
 
-    parser.add_argument('--quiet',
-                        action='store_true',
-                        help='Suppress run-time logging output')
+    parser.add_argument(
+        '--quiet', action='store_true', help='Suppress run-time logging output'
+    )
 
-    parser.add_argument('--max-fetch-Mb',
-                        default=1000.0,
-                        type=float,
-                        help='Max allowed memory (Mb) for fetching (default=1000)')
+    parser.add_argument(
+        '--max-fetch-Mb',
+        default=1000.0,
+        type=float,
+        help='Max allowed memory (Mb) for fetching (default=1000)',
+    )
 
-    parser.add_argument('--max-output-Mb',
-                        default=100.0,
-                        type=float,
-                        help='Max allowed memory (Mb) for file output (default=100)')
+    parser.add_argument(
+        '--max-output-Mb',
+        default=100.0,
+        type=float,
+        help='Max allowed memory (Mb) for file output (default=100)',
+    )
 
-    parser.add_argument('msids',
-                        metavar='MSID',
-                        type=str,
-                        nargs='+',
-                        help='MSID to fetch')
+    parser.add_argument(
+        'msids', metavar='MSID', type=str, nargs='+', help='MSID to fetch'
+    )
 
     opt = parser.parse_args()
     return opt
@@ -297,14 +332,19 @@ def main():
     try:
         get_telem(**vars(opt))
     except MemoryError as err:
-        print('\n'.join(['',
-                         '*' * 80,
-                         'ERROR: {}'.format(err),
-                         '*' * 80, '']))
+        print('\n'.join(['', '*' * 80, 'ERROR: {}'.format(err), '*' * 80, '']))
     except Exception as err:
-        print('\n'.join(['',
-                         '*' * 80,
-                         'ERROR: {}'.format(err),
-                         'If necessary report the following traceback to aca@head.cfa.harvard.edu',
-                         '*' * 80, '']))
+        print(
+            '\n'.join(
+                [
+                    '',
+                    '*' * 80,
+                    'ERROR: {}'.format(err),
+                    'If necessary report the following traceback to'
+                    ' aca@head.cfa.harvard.edu',
+                    '*' * 80,
+                    '',
+                ]
+            )
+        )
         raise

--- a/Ska/engarchive/plot.py
+++ b/Ska/engarchive/plot.py
@@ -1,12 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
 
-import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.dates import num2epoch, epoch2num
-
-from Ska.Matplotlib import plot_cxctime
+import numpy as np
 from Chandra.Time import DateTime
+from matplotlib.dates import epoch2num, num2epoch
+from Ska.Matplotlib import plot_cxctime
 
 from . import __version__  # noqa
 

--- a/Ska/engarchive/plot.py
+++ b/Ska/engarchive/plot.py
@@ -85,8 +85,9 @@ class MsidPlot(object):
         # Make sure MSID is sampled at the correct density for initial plot
         stat = get_stat(self.tstart, self.tstop, self.npix)
         if stat != self.msid.stat:
-            self.msid = self.fetch.Msid(self.msidname, self.tstart, self.tstop,
-                                        stat=stat)
+            self.msid = self.fetch.Msid(
+                self.msidname, self.tstart, self.tstop, stat=stat
+            )
 
         self.ax.set_autoscale_on(True)
         self.draw_plot()
@@ -118,8 +119,11 @@ class MsidPlot(object):
             for _ in range(len(self.ax.lines)):
                 self.ax.lines.pop()
             self.plot_mins = not self.plot_mins
-            print('\nPlotting mins and maxes is {}'.format(
-                'enabled' if self.plot_mins else 'disabled'))
+            print(
+                '\nPlotting mins and maxes is {}'.format(
+                    'enabled' if self.plot_mins else 'disabled'
+                )
+            )
             self.draw_plot()
         elif event.key == 'a':
             # self.fig.clf()
@@ -130,11 +134,15 @@ class MsidPlot(object):
             self.xlim_changed(None)
         elif event.key == 'y':
             self.scaley = not self.scaley
-            print('Autoscaling y axis is {}'.format(
-                'enabled' if self.scaley else 'disabled'))
+            print(
+                'Autoscaling y axis is {}'.format(
+                    'enabled' if self.scaley else 'disabled'
+                )
+            )
             self.draw_plot()
         elif event.key == '?':
-            print("""
+            print(
+                """
 Interactive MSID plot keys:
 
   a: autoscale for full data range in x and y
@@ -143,7 +151,8 @@ Interactive MSID plot keys:
   y: toggle autoscaling of y-axis
   z: zoom at cursor x
   ?: print help
-""")
+"""
+            )
 
     def xlim_changed(self, event):
         x0, x1 = self.ax.get_xlim()
@@ -151,14 +160,17 @@ Interactive MSID plot keys:
         self.tstop = DateTime(num2epoch(x1), format='unix').secs
         stat = get_stat(self.tstart, self.tstop, self.npix)
 
-        if (self.tstart < self.msid.tstart or
-            self.tstop > self.msid.tstop or
-                stat != self.msid.stat):
+        if (
+            self.tstart < self.msid.tstart
+            or self.tstop > self.msid.tstop
+            or stat != self.msid.stat
+        ):
             dt = self.tstop - self.tstart
             self.tstart -= dt / 4
             self.tstop += dt / 4
-            self.msid = self.fetch.Msid(self.msidname, self.tstart, self.tstop,
-                                        stat=stat)
+            self.msid = self.fetch.Msid(
+                self.msidname, self.tstart, self.tstop, stat=stat
+            )
         self.draw_plot()
 
     def draw_plot(self):
@@ -172,8 +184,7 @@ Interactive MSID plot keys:
         if scaley:
             ymin = None
             ymax = None
-            ok = ((msid.times >= self.tstart) &
-                  (msid.times <= self.tstop))
+            ok = (msid.times >= self.tstart) & (msid.times <= self.tstop)
 
         try:
             self.ax.callbacks.disconnect(self.xlim_callback)
@@ -181,18 +192,36 @@ Interactive MSID plot keys:
             pass
 
         if self.plot_mins and hasattr(self.msid, 'mins'):
-            plot_cxctime(msid.times, msid.mins, self.fmt_minmax,
-                         ax=self.ax, fig=self.fig, **self.plot_kwargs)
-            plot_cxctime(msid.times, msid.maxes, self.fmt_minmax,
-                         ax=self.ax, fig=self.fig, **self.plot_kwargs)
+            plot_cxctime(
+                msid.times,
+                msid.mins,
+                self.fmt_minmax,
+                ax=self.ax,
+                fig=self.fig,
+                **self.plot_kwargs,
+            )
+            plot_cxctime(
+                msid.times,
+                msid.maxes,
+                self.fmt_minmax,
+                ax=self.ax,
+                fig=self.fig,
+                **self.plot_kwargs,
+            )
             if scaley:
                 ymin = np.min(msid.mins[ok])
                 ymax = np.max(msid.maxes[ok])
 
         vals = msid.raw_vals if msid.state_codes else msid.vals
-        plot_cxctime(msid.times, vals, self.fmt,
-                     ax=self.ax, fig=self.fig,
-                     state_codes=msid.state_codes, **self.plot_kwargs)
+        plot_cxctime(
+            msid.times,
+            vals,
+            self.fmt,
+            ax=self.ax,
+            fig=self.fig,
+            state_codes=msid.state_codes,
+            **self.plot_kwargs,
+        )
 
         if scaley:
             plotvals = vals[ok]
@@ -215,5 +244,6 @@ Interactive MSID plot keys:
         # Update the image object with our new data and extent
         self.ax.figure.canvas.draw_idle()
 
-        self.xlim_callback = self.ax.callbacks.connect('xlim_changed',
-                                                       self.xlim_changed)
+        self.xlim_callback = self.ax.callbacks.connect(
+            'xlim_changed', self.xlim_changed
+        )

--- a/Ska/engarchive/plot.py
+++ b/Ska/engarchive/plot.py
@@ -9,7 +9,7 @@ from Ska.Matplotlib import plot_cxctime
 
 from . import __version__  # noqa
 
-MIN_TSTART_UNIX = DateTime('1999:100').unix
+MIN_TSTART_UNIX = DateTime("1999:100").unix
 MAX_TSTOP_UNIX = DateTime().unix + 1e7
 
 
@@ -19,9 +19,9 @@ def get_stat(t0, t1, npix):
     dt_days = t1 - t0
 
     if dt_days > npix:
-        stat = 'daily'
+        stat = "daily"
     elif dt_days * (24 * 60 / 5) > npix:
-        stat = '5min'
+        stat = "5min"
     else:
         stat = None
     return stat
@@ -66,7 +66,7 @@ class MsidPlot(object):
 
     """
 
-    def __init__(self, msid, fmt='-b', fmt_minmax='-c', **plot_kwargs):
+    def __init__(self, msid, fmt="-b", fmt_minmax="-c", **plot_kwargs):
         self.fig = plt.gcf()
         self.fig.clf()
         self.ax = self.fig.gca()
@@ -93,7 +93,7 @@ class MsidPlot(object):
         self.draw_plot()
         self.ax.set_autoscale_on(False)
         plt.grid()
-        self.fig.canvas.mpl_connect('key_press_event', self.key_press)
+        self.fig.canvas.mpl_connect("key_press_event", self.key_press)
 
     @property
     def npix(self):
@@ -101,11 +101,11 @@ class MsidPlot(object):
         return int(dims[2] + 0.5)
 
     def key_press(self, event):
-        if event.key in ['z', 'p'] and event.inaxes:
+        if event.key in ["z", "p"] and event.inaxes:
             x0, x1 = self.ax.get_xlim()
             dx = x1 - x0
             xc = event.xdata
-            zoom = self.zoom if event.key == 'p' else 1.0 / self.zoom
+            zoom = self.zoom if event.key == "p" else 1.0 / self.zoom
             new_x1 = zoom * (x1 - xc) + xc
             new_x0 = new_x1 - zoom * dx
             tstart = max(num2epoch(new_x0), MIN_TSTART_UNIX)
@@ -115,32 +115,32 @@ class MsidPlot(object):
 
             self.ax.set_xlim(new_x0, new_x1)
             self.ax.figure.canvas.draw_idle()
-        elif event.key == 'm':
+        elif event.key == "m":
             for _ in range(len(self.ax.lines)):
                 self.ax.lines.pop()
             self.plot_mins = not self.plot_mins
             print(
-                '\nPlotting mins and maxes is {}'.format(
-                    'enabled' if self.plot_mins else 'disabled'
+                "\nPlotting mins and maxes is {}".format(
+                    "enabled" if self.plot_mins else "disabled"
                 )
             )
             self.draw_plot()
-        elif event.key == 'a':
+        elif event.key == "a":
             # self.fig.clf()
             # self.ax = self.fig.gca()
             self.ax.set_autoscale_on(True)
             self.draw_plot()
             self.ax.set_autoscale_on(False)
             self.xlim_changed(None)
-        elif event.key == 'y':
+        elif event.key == "y":
             self.scaley = not self.scaley
             print(
-                'Autoscaling y axis is {}'.format(
-                    'enabled' if self.scaley else 'disabled'
+                "Autoscaling y axis is {}".format(
+                    "enabled" if self.scaley else "disabled"
                 )
             )
             self.draw_plot()
-        elif event.key == '?':
+        elif event.key == "?":
             print(
                 """
 Interactive MSID plot keys:
@@ -156,8 +156,8 @@ Interactive MSID plot keys:
 
     def xlim_changed(self, event):
         x0, x1 = self.ax.get_xlim()
-        self.tstart = DateTime(num2epoch(x0), format='unix').secs
-        self.tstop = DateTime(num2epoch(x1), format='unix').secs
+        self.tstart = DateTime(num2epoch(x0), format="unix").secs
+        self.tstop = DateTime(num2epoch(x1), format="unix").secs
         stat = get_stat(self.tstart, self.tstop, self.npix)
 
         if (
@@ -191,7 +191,7 @@ Interactive MSID plot keys:
         except AttributeError:
             pass
 
-        if self.plot_mins and hasattr(self.msid, 'mins'):
+        if self.plot_mins and hasattr(self.msid, "mins"):
             plot_cxctime(
                 msid.times,
                 msid.mins,
@@ -236,7 +236,7 @@ Interactive MSID plot keys:
 
         title = msid.msid.upper()
         if msid.stat:
-            title = f'{title} ({msid.stat})'
+            title = f"{title} ({msid.stat})"
         self.ax.set_title(title)
         if msid.unit:
             self.ax.set_ylabel(msid.unit)
@@ -245,5 +245,5 @@ Interactive MSID plot keys:
         self.ax.figure.canvas.draw_idle()
 
         self.xlim_callback = self.ax.callbacks.connect(
-            'xlim_changed', self.xlim_changed
+            "xlim_changed", self.xlim_changed
         )

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import ipyparallel as parallel
 
-IS_WINDOWS = platform.system() == 'Windows'
+IS_WINDOWS = platform.system() == "Windows"
 
 
 def get_data_access_info(is_windows=IS_WINDOWS):
@@ -36,9 +36,9 @@ def get_data_access_info(is_windows=IS_WINDOWS):
     # or looking in the standard SKA place.  In the case of accessing data remotely this is all
     # moot (and SKA is not required to be defined), so just make sure this bit runs without
     # failing.
-    ska = os.getenv('SKA')
-    ska_eng_path = None if (ska is None) else os.path.join(ska, 'data', 'eng_archive')
-    eng_archive = os.getenv('ENG_ARCHIVE')
+    ska = os.getenv("SKA")
+    ska_eng_path = None if (ska is None) else os.path.join(ska, "data", "eng_archive")
+    eng_archive = os.getenv("ENG_ARCHIVE")
     if eng_archive is None and ska_eng_path is not None:
         eng_archive = ska_eng_path
 
@@ -56,24 +56,24 @@ def get_data_access_info(is_windows=IS_WINDOWS):
     else:
         has_ska_data = False
 
-    if 'SKA_ACCESS_REMOTELY' in os.environ:
+    if "SKA_ACCESS_REMOTELY" in os.environ:
         # User explicitly specified, so that is the end of the story.
         import ast
 
-        ska_access_remotely = ast.literal_eval(os.environ['SKA_ACCESS_REMOTELY'])
+        ska_access_remotely = ast.literal_eval(os.environ["SKA_ACCESS_REMOTELY"])
     else:
         ska_access_remotely = False if has_ska_data else is_windows
 
     if not ska_access_remotely and not has_ska_data:
         if eng_archive is None:
-            msg = 'need to define SKA or ENG_ARCHIVE environment variable'
+            msg = "need to define SKA or ENG_ARCHIVE environment variable"
         else:
-            msg = f'no {eng_archive} directory'
+            msg = f"no {eng_archive} directory"
         from astropy.utils.exceptions import AstropyUserWarning
 
         warnings.warn(
-            f'no local Ska data found and remote access is not selected: {msg}\n'
-            'You can still access MAUDE data by running '
+            f"no local Ska data found and remote access is not selected: {msg}\n"
+            "You can still access MAUDE data by running "
             '`fetch.data_source.set("maude")`',
             AstropyUserWarning,
         )
@@ -82,13 +82,13 @@ def get_data_access_info(is_windows=IS_WINDOWS):
         # If accessing remotely, then hardwire eng_archive to the linux path where
         # the data are stored on the server.  This prevents a local SKA repository
         # from getting used on the remote server.
-        ska_eng_path = '/proj/sot/ska/data/eng_archive'
+        ska_eng_path = "/proj/sot/ska/data/eng_archive"
         eng_archive = ska_eng_path
 
     # Warn the user if eng data path is non-standard.  Note: if no SKA then
     # any path is non-standard.
     if eng_archive != ska_eng_path:
-        print(f'fetch: using ENG_ARCHIVE={eng_archive} for archive path')
+        print(f"fetch: using ENG_ARCHIVE={eng_archive} for archive path")
 
     return eng_archive, ska_access_remotely
 
@@ -140,25 +140,25 @@ def establish_connection():
 
         # Get the username and password if not already set
         hostname = hostname or input(
-            'Enter hostname (or IP) of Ska ' + 'server (enter to cancel):'
+            "Enter hostname (or IP) of Ska " + "server (enter to cancel):"
         )
         if hostname == "":
             break
         default_username = getpass.getuser()
         username = username or input(
-            'Enter your login username [' + default_username + ']:'
+            "Enter your login username [" + default_username + "]:"
         )
-        password = password or getpass.getpass('Enter your password:')
+        password = password or getpass.getpass("Enter your password:")
 
         # Open the connection to the server
-        print('Establishing connection to ' + hostname + '...')
+        print("Establishing connection to " + hostname + "...")
         sys.stdout.flush()
         try:
             _remote_client = parallel.Client(
-                client_key_file, sshserver=f'{username}@{hostname}', password=password
+                client_key_file, sshserver=f"{username}@{hostname}", password=password
             )
         except Exception:
-            print('Error connecting to server ', hostname, ': ', sys.exc_info()[0])
+            print("Error connecting to server ", hostname, ": ", sys.exc_info()[0])
             sys.stdout.flush()
             _remote_client = None
             # Clear out information so the user can try again

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -59,6 +59,7 @@ def get_data_access_info(is_windows=IS_WINDOWS):
     if 'SKA_ACCESS_REMOTELY' in os.environ:
         # User explicitly specified, so that is the end of the story.
         import ast
+
         ska_access_remotely = ast.literal_eval(os.environ['SKA_ACCESS_REMOTELY'])
     else:
         ska_access_remotely = False if has_ska_data else is_windows
@@ -69,9 +70,13 @@ def get_data_access_info(is_windows=IS_WINDOWS):
         else:
             msg = f'no {eng_archive} directory'
         from astropy.utils.exceptions import AstropyUserWarning
-        warnings.warn(f'no local Ska data found and remote access is not selected: {msg}\n'
-                      'You can still access MAUDE data by running '
-                      '`fetch.data_source.set("maude")`', AstropyUserWarning)
+
+        warnings.warn(
+            f'no local Ska data found and remote access is not selected: {msg}\n'
+            'You can still access MAUDE data by running '
+            '`fetch.data_source.set("maude")`',
+            AstropyUserWarning,
+        )
 
     if ska_access_remotely:
         # If accessing remotely, then hardwire eng_archive to the linux path where
@@ -130,25 +135,28 @@ def establish_connection():
             # Deal with an obscure problem in remote access on Windows.
             # See https://github.com/tornadoweb/tornado/issues/2608#issuecomment-491489432
             import asyncio
+
             asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
         # Get the username and password if not already set
-        hostname = hostname or input('Enter hostname (or IP) of Ska ' +
-                                     'server (enter to cancel):')
+        hostname = hostname or input(
+            'Enter hostname (or IP) of Ska ' + 'server (enter to cancel):'
+        )
         if hostname == "":
             break
         default_username = getpass.getuser()
-        username = username or input('Enter your login username [' +
-                                     default_username + ']:')
+        username = username or input(
+            'Enter your login username [' + default_username + ']:'
+        )
         password = password or getpass.getpass('Enter your password:')
 
         # Open the connection to the server
         print('Establishing connection to ' + hostname + '...')
         sys.stdout.flush()
         try:
-            _remote_client = parallel.Client(client_key_file,
-                                             sshserver=f'{username}@{hostname}',
-                                             password=password)
+            _remote_client = parallel.Client(
+                client_key_file, sshserver=f'{username}@{hostname}', password=password
+            )
         except Exception:
             print('Error connecting to server ', hostname, ': ', sys.exc_info()[0])
             sys.stdout.flush()
@@ -186,9 +194,12 @@ def test_connection():
     Function to perform a quick test of the connection to the
     remote server
     """
+
     def remote_fcn():
         import os
+
         return os.sys.version
+
     return execute_remotely(remote_fcn)
 
 

--- a/Ska/engarchive/remote_access.py
+++ b/Ska/engarchive/remote_access.py
@@ -5,14 +5,14 @@ Settings and functions for remotely accessing an engineering archive.
 NOTE: see test_remote_access.py for useful information about doing functional
 testing of this code.
 """
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
 
-import sys
-import os
 import getpass
-from pathlib import Path
+import os
 import platform
+import sys
 import warnings
+from pathlib import Path
 
 import ipyparallel as parallel
 

--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -3,10 +3,11 @@
 """Test that computed MSIDs work as expected."""
 
 import numpy as np
-from Quaternion import Quat
 import pytest
+from Quaternion import Quat
 
-from .. import fetch_eng, fetch_sci, fetch as fetch_cxc
+from .. import fetch as fetch_cxc
+from .. import fetch_eng, fetch_sci
 from ..derived.base import DerivedParameter
 from ..derived.comps import ComputedMsid
 

--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -14,9 +14,9 @@ from ..derived.comps import ComputedMsid
 try:
     import maude
 
-    date1 = '2016:001:00:00:00.1'
-    date2 = '2016:001:00:00:02.0'
-    maude.get_msids(msids='ccsdsid', start=date1, stop=date2)
+    date1 = "2016:001:00:00:00.1"
+    date2 = "2016:001:00:00:02.0"
+    maude.get_msids(msids="ccsdsid", start=date1, stop=date2)
 except Exception:
     HAS_MAUDE = False
 else:
@@ -26,28 +26,28 @@ else:
 class Comp_Passthru(ComputedMsid):
     """Pass MSID through unchanged (for checking that stats work)"""
 
-    msid_match = r'passthru_(\w+)'
+    msid_match = r"passthru_(\w+)"
 
     def get_msid_attrs(self, tstart, tstop, msid, msid_args):
         dat = self.fetch_eng.MSID(msid_args[0], tstart, tstop)
 
-        out = {'vals': dat.vals, 'bads': dat.bads, 'times': dat.times, 'unit': dat.unit}
+        out = {"vals": dat.vals, "bads": dat.bads, "times": dat.times, "unit": dat.unit}
         return out
 
 
 class Comp_Val_Plus_Five(ComputedMsid):
     """Silly base comp to add 5 to the value"""
 
-    msid_match = r'comp_(\w+)_plus_five'
+    msid_match = r"comp_(\w+)_plus_five"
 
     def get_msid_attrs(self, tstart, tstop, msid, msid_args):
         dat = self.fetch_sys.MSID(msid_args[0], tstart, tstop)
 
         out = {
-            'vals': dat.vals + 5,
-            'bads': dat.bads,
-            'times': dat.times,
-            'unit': dat.unit,
+            "vals": dat.vals + 5,
+            "bads": dat.bads,
+            "times": dat.times,
+            "unit": dat.unit,
         }
         return out
 
@@ -61,27 +61,27 @@ class Comp_CSS1_NPM_SUN(ComputedMsid, DerivedParameter):
 
     """
 
-    rootparams = ['aocssi1', 'aopcadmd', 'aosaillm']
+    rootparams = ["aocssi1", "aopcadmd", "aosaillm"]
     time_step = 1.025
     max_gap = 10.0
-    msid_match = 'comp_css1_npm_sun'
+    msid_match = "comp_css1_npm_sun"
 
     def get_msid_attrs(self, tstart, tstop, msid, msid_args):
         # Get an interpolated MSIDset for rootparams
         msids = self.fetch(tstart, tstop)
 
         # Do the computation and set bad values
-        npm_sun = (msids['aopcadmd'].vals == 'NPNT') & (
-            msids['aosaillm'].vals == 'ILLM'
+        npm_sun = (msids["aopcadmd"].vals == "NPNT") & (
+            msids["aosaillm"].vals == "ILLM"
         )
         msids.bads = msids.bads | ~npm_sun
-        css1_npm_sun = msids['aocssi1'].vals * 4095 / 5.49549
+        css1_npm_sun = msids["aocssi1"].vals * 4095 / 5.49549
 
         out = {
-            'vals': css1_npm_sun,
-            'times': msids.times,
-            'bads': msids.bads,
-            'unit': None,
+            "vals": css1_npm_sun,
+            "times": msids.times,
+            "bads": msids.bads,
+            "unit": None,
         }
         return out
 
@@ -90,19 +90,19 @@ def test_comp_from_derived_parameter():
     """Test that on-the-fly comp gives same result as derived parameter from
     same code.
     """
-    dat1 = fetch_eng.Msid('comp_css1_npm_sun', '2020:001', '2020:010')
-    dat2 = fetch_eng.Msid('dp_css1_npm_sun', '2020:001', '2020:010')
+    dat1 = fetch_eng.Msid("comp_css1_npm_sun", "2020:001", "2020:010")
+    dat2 = fetch_eng.Msid("dp_css1_npm_sun", "2020:001", "2020:010")
 
-    for attr in ('vals', 'times', 'bads', 'unit'):
+    for attr in ("vals", "times", "bads", "unit"):
         assert np.all(getattr(dat1, attr) == getattr(dat2, attr))
 
 
 @pytest.mark.parametrize(
-    'fetch,unit', [(fetch_eng, 'DEGF'), (fetch_sci, 'DEGC'), (fetch_cxc, 'K')]
+    "fetch,unit", [(fetch_eng, "DEGF"), (fetch_sci, "DEGC"), (fetch_cxc, "K")]
 )
 def test_simple_comp(fetch, unit):
-    dat1 = fetch.Msid('tephin', '2020:001', '2020:010')
-    dat2 = fetch.Msid('comp_tephin_plus_five', '2020:001', '2020:010')
+    dat1 = fetch.Msid("tephin", "2020:001", "2020:010")
+    dat2 = fetch.Msid("comp_tephin_plus_five", "2020:001", "2020:010")
     assert np.all(dat1.vals + 5 == dat2.vals)
     assert np.all(dat1.times == dat2.times)
     assert np.all(dat1.bads == dat2.bads)
@@ -112,12 +112,12 @@ def test_simple_comp(fetch, unit):
 
 @pytest.mark.skipif("not HAS_MAUDE")
 @pytest.mark.parametrize(
-    'fetch,unit', [(fetch_eng, 'DEGF'), (fetch_sci, 'DEGC'), (fetch_cxc, 'K')]
+    "fetch,unit", [(fetch_eng, "DEGF"), (fetch_sci, "DEGC"), (fetch_cxc, "K")]
 )
 def test_simple_comp_with_maude(fetch, unit):
-    with fetch.data_source('maude'):
-        dat1 = fetch.Msid('tephin', '2020:001', '2020:003')
-        dat2 = fetch.Msid('comp_tephin_plus_five', '2020:001', '2020:003')
+    with fetch.data_source("maude"):
+        dat1 = fetch.Msid("tephin", "2020:001", "2020:003")
+        dat2 = fetch.Msid("comp_tephin_plus_five", "2020:001", "2020:003")
         assert np.all(dat1.vals + 5 == dat2.vals)
         assert np.all(dat1.times == dat2.times)
         assert np.all(dat1.bads == dat2.bads)
@@ -127,14 +127,14 @@ def test_simple_comp_with_maude(fetch, unit):
 
 def test_mups_valve():
     colnames = [
-        'vals',
-        'times',
-        'bads',
-        'vals_raw',
-        'vals_nan',
-        'vals_corr',
-        'vals_model',
-        'source',
+        "vals",
+        "times",
+        "bads",
+        "vals_raw",
+        "vals_nan",
+        "vals_corr",
+        "vals_model",
+        "source",
     ]
 
     # Use the chandra_models 6854df4d commit for testing. This is a commit of
@@ -142,9 +142,9 @@ def test_mups_valve():
     # like 2017:123:12:00:00 (instead of 2017:123). This allows these regression
     # tests to pass with Chandra.Time 3.x or 4.0+.
     dat = fetch_eng.MSID(
-        'PM2THV1T_clean_6854df4d', '2020:001:12:00:00', '2020:010:12:00:00'
+        "PM2THV1T_clean_6854df4d", "2020:001:12:00:00", "2020:010:12:00:00"
     )
-    assert dat.unit == 'DEGF'
+    assert dat.unit == "DEGF"
     assert len(dat.vals) == 36661
     ok = dat.source != 0
     # Temps are reasonable for degF
@@ -155,20 +155,20 @@ def test_mups_valve():
         assert len(dat.vals) == len(getattr(dat, attr))
 
     dat = fetch_sci.Msid(
-        'PM2THV1T_clean_6854df4d', '2020:001:12:00:00', '2020:010:12:00:00'
+        "PM2THV1T_clean_6854df4d", "2020:001:12:00:00", "2020:010:12:00:00"
     )
-    assert dat.unit == 'DEGC'
+    assert dat.unit == "DEGC"
     ok = dat.source != 0
     # Temps are reasonable for degC
     assert np.all((dat.vals[ok] > 10) & (dat.vals[ok] < 110))
     assert len(dat.vals) == 31524  # Some bad values
     assert dat.colnames == colnames
     for attr in colnames:
-        if attr != 'bads':
+        if attr != "bads":
             assert len(dat.vals) == len(getattr(dat, attr))
 
     dat = fetch_cxc.MSID(
-        'PM1THV2T_clean_6854df4d', '2020:001:12:00:00', '2020:010:12:00:00'
+        "PM1THV2T_clean_6854df4d", "2020:001:12:00:00", "2020:010:12:00:00"
     )
     ok = dat.source != 0
     # Temps are reasonable for K
@@ -179,18 +179,18 @@ def test_mups_valve():
         assert len(dat.vals) == len(getattr(dat, attr))
 
     # Check using default master branch
-    dat = fetch_eng.Msid('pm1thv2t_clean', '2020:001:12:00:00', '2020:010:12:00:00')
+    dat = fetch_eng.Msid("pm1thv2t_clean", "2020:001:12:00:00", "2020:010:12:00:00")
     assert len(dat.vals) < 36661  # Some bad values (36661 is number of raw samples)
     assert len(dat.source) == len(dat.vals)  # Filtering applies to sources
     assert dat.colnames == colnames
     for attr in colnames:
-        if attr != 'bads':
+        if attr != "bads":
             assert len(dat.vals) == len(getattr(dat, attr))
 
 
 def test_cmd_states():
-    start, stop = '2020:002:08:00:00', '2020:002:10:00:00'
-    dat = fetch_eng.Msid('cmd_state_pitch_1000', start, stop)
+    start, stop = "2020:002:08:00:00", "2020:002:10:00:00"
+    dat = fetch_eng.Msid("cmd_state_pitch_1000", start, stop)
     exp_vals = np.array(
         [
             55.99128956,
@@ -209,54 +209,54 @@ def test_cmd_states():
     assert not np.any(dat.bads)
     assert dat.unit is None
 
-    dat = fetch_eng.Msid('cmd_state_pcad_mode_1000', start, stop)
+    dat = fetch_eng.Msid("cmd_state_pcad_mode_1000", start, stop)
     exp_vals = np.array(
-        ['NPNT', 'NPNT', 'NPNT', 'NMAN', 'NMAN', 'NPNT', 'NPNT', 'NPNT']
+        ["NPNT", "NPNT", "NPNT", "NMAN", "NMAN", "NPNT", "NPNT", "NPNT"]
     )
     assert np.all(dat.vals == exp_vals)
     assert type(dat.vals) is np.ndarray
     assert np.allclose(np.diff(dat.times), 1025.0)
 
 
-@pytest.mark.parametrize('stat', ['5min', 'daily'])
+@pytest.mark.parametrize("stat", ["5min", "daily"])
 def test_stats(stat):
-    start, stop = '2020:001:12:00:00', '2020:010:12:00:00'
+    start, stop = "2020:001:12:00:00", "2020:010:12:00:00"
 
-    dat = fetch_eng.Msid('pitch', start, stop, stat=stat)
-    datc = fetch_eng.Msid('passthru_pitch', start, stop, stat=stat)
+    dat = fetch_eng.Msid("pitch", start, stop, stat=stat)
+    datc = fetch_eng.Msid("passthru_pitch", start, stop, stat=stat)
 
     for attr in datc.colnames:
         val = getattr(dat, attr)
         valc = getattr(datc, attr)
-        if attr == 'bads':
+        if attr == "bads":
             assert val == valc
             continue
         assert val.dtype == valc.dtype
-        if val.dtype.kind == 'f':
+        if val.dtype.kind == "f":
             assert np.allclose(val, valc)
         else:
             assert np.all(val == valc)
 
 
-@pytest.mark.parametrize('msid', ['aoattqt', 'aoatupq', 'aocmdqt', 'aotarqt'])
+@pytest.mark.parametrize("msid", ["aoattqt", "aoatupq", "aocmdqt", "aotarqt"])
 def test_quat_comp(msid):
-    start, stop = '2022:002', '2022:003'
-    datq = fetch_eng.MSID(f'quat_{msid}', start, stop)
-    dats = fetch_eng.MSIDset([f'{msid}*'], start, stop)
+    start, stop = "2022:002", "2022:003"
+    datq = fetch_eng.MSID(f"quat_{msid}", start, stop)
+    dats = fetch_eng.MSIDset([f"{msid}*"], start, stop)
     n_comp = len(dats)
     for ii in range(n_comp):
         vq = datq.vals.q[:, ii]
-        vn = dats[f'{msid}{ii + 1}'].vals
+        vn = dats[f"{msid}{ii + 1}"].vals
         # Code handles q1**2 + q2**2 + q3**2 > 1 by clipping the norm and renormalizing
         # the quaternion. This generates a significant difference for the cmd quat.
-        ok = np.isclose(vq, vn, rtol=0, atol=(1e-4 if msid == 'aocmdqt' else 1e-8))
+        ok = np.isclose(vq, vn, rtol=0, atol=(1e-4 if msid == "aocmdqt" else 1e-8))
         assert np.all(ok)
     assert isinstance(datq.vals, Quat)
 
 
-@pytest.mark.parametrize('msid', ['aoattqt', 'aoatupq', 'aocmdqt', 'aotarqt'])
+@pytest.mark.parametrize("msid", ["aoattqt", "aoatupq", "aocmdqt", "aotarqt"])
 def test_quat_comp_exception(msid):
-    start, stop = '2022:002', '2022:003'
-    with pytest.raises(ValueError, match=f'quat_{msid} is not available from MAUDE'):
-        with fetch_eng.data_source('maude'):
-            fetch_eng.MSID(f'quat_{msid}', start, stop)
+    start, stop = "2022:002", "2022:003"
+    with pytest.raises(ValueError, match=f"quat_{msid} is not available from MAUDE"):
+        with fetch_eng.data_source("maude"):
+            fetch_eng.MSID(f"quat_{msid}", start, stop)

--- a/Ska/engarchive/tests/test_data_source.py
+++ b/Ska/engarchive/tests/test_data_source.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import pytest
 
+from .. import fetch, fetch_eng, fetch_sci
 
-from .. import fetch, fetch_sci, fetch_eng
 fetch_cxc = fetch
 
 

--- a/Ska/engarchive/tests/test_data_source.py
+++ b/Ska/engarchive/tests/test_data_source.py
@@ -9,16 +9,16 @@ from .. import fetch, fetch_eng, fetch_sci
 fetch_cxc = fetch
 
 
-date1 = '2016:001:00:00:00.1'
-date2 = '2016:001:00:00:02.0'
-date3 = '2016:001:00:00:05.0'
-date4 = '2016:001:00:00:35.0'
+date1 = "2016:001:00:00:00.1"
+date2 = "2016:001:00:00:02.0"
+date3 = "2016:001:00:00:05.0"
+date4 = "2016:001:00:00:35.0"
 
 
 try:
     import maude
 
-    maude.get_msids(msids='ccsdsid', start=date1, stop=date2)
+    maude.get_msids(msids="ccsdsid", start=date1, stop=date2)
 except Exception:
     HAS_MAUDE = False
 else:
@@ -27,82 +27,82 @@ else:
 
 def test_data_source():
     """Unit test of _DataSource class"""
-    assert fetch.data_source.sources() == ('cxc',)
+    assert fetch.data_source.sources() == ("cxc",)
 
     # Context manager
-    with fetch.data_source('maude'):
-        assert fetch.data_source.sources() == ('maude',)
-    assert fetch.data_source.sources() == ('cxc',)
+    with fetch.data_source("maude"):
+        assert fetch.data_source.sources() == ("maude",)
+    assert fetch.data_source.sources() == ("cxc",)
 
-    with fetch.data_source('cxc', 'maude'):
+    with fetch.data_source("cxc", "maude"):
         assert fetch.data_source.sources() == (
-            'cxc',
-            'maude',
+            "cxc",
+            "maude",
         )
-    assert fetch.data_source.sources() == ('cxc',)
+    assert fetch.data_source.sources() == ("cxc",)
 
-    fetch.data_source.set('maude')
-    assert fetch.data_source.sources() == ('maude',)
-    fetch.data_source.set('cxc')
-    assert fetch.data_source.sources() == ('cxc',)
+    fetch.data_source.set("maude")
+    assert fetch.data_source.sources() == ("maude",)
+    fetch.data_source.set("cxc")
+    assert fetch.data_source.sources() == ("cxc",)
 
     with pytest.raises(ValueError) as err:
-        fetch.data_source.set('blah')
-    assert 'not in allowed set' in str(err.value)
+        fetch.data_source.set("blah")
+    assert "not in allowed set" in str(err.value)
 
     with pytest.raises(ValueError) as err:
         with fetch.data_source():
             pass
-    assert 'must select at least' in str(err.value)
+    assert "must select at least" in str(err.value)
 
 
 def test_options():
-    with fetch.data_source('cxc', 'maude allow_subset=False param=1'):
+    with fetch.data_source("cxc", "maude allow_subset=False param=1"):
         assert fetch.data_source.options() == {
-            'cxc': {},
-            'maude': {'allow_subset': False, 'param': 1},
+            "cxc": {},
+            "maude": {"allow_subset": False, "param": 1},
         }
-        assert fetch.data_source.sources() == ('cxc', 'maude')
+        assert fetch.data_source.sources() == ("cxc", "maude")
 
 
 @pytest.mark.skipif("not HAS_MAUDE")
 def test_maude_data_source():
     """Fetch data from MAUDE"""
-    with fetch.data_source('cxc'):
-        datc = fetch.Msid('aogyrct1', date1, date3)
+    with fetch.data_source("cxc"):
+        datc = fetch.Msid("aogyrct1", date1, date3)
         assert len(datc.vals) == 19
         assert datc.data_source == {
-            'cxc': {'start': '2016:001:00:00:00.287', 'stop': '2016:001:00:00:04.900'}
+            "cxc": {"start": "2016:001:00:00:00.287", "stop": "2016:001:00:00:04.900"}
         }
 
-    with fetch.data_source('maude'):
-        datm = fetch.Msid('aogyrct1', date1, date3)
+    with fetch.data_source("maude"):
+        datm = fetch.Msid("aogyrct1", date1, date3)
         assert np.all(datm.vals == datc.vals)
         assert not np.all(datm.times == datc.times)
         assert datm.data_source == {
-            'maude': {
-                'start': '2016:001:00:00:00.287',
-                'stop': '2016:001:00:00:04.900',
-                'flags': {
-                    'allpoints_incomplete': False,
-                    'tolerance': False,
-                    'subset': False,
+            "maude": {
+                "start": "2016:001:00:00:00.287",
+                "stop": "2016:001:00:00:04.900",
+                "flags": {
+                    "allpoints_incomplete": False,
+                    "tolerance": False,
+                    "subset": False,
                 },
             }
         }
 
-    with fetch.data_source('cxc', 'maude', 'test-drop-half'):
-        datcm = fetch.Msid('aogyrct1', date1, date3)
+    with fetch.data_source("cxc", "maude", "test-drop-half"):
+        datcm = fetch.Msid("aogyrct1", date1, date3)
         assert np.all(datcm.vals == datc.vals)
         assert datcm.data_source == {
-            'cxc': {'start': '2016:001:00:00:00.287', 'stop': '2016:001:00:00:02.337'},
-            'maude': {
-                'start': '2016:001:00:00:02.593',
-                'stop': '2016:001:00:00:04.900',
-                'flags': {
-                    'allpoints_incomplete': False,
-                    'tolerance': False,
-                    'subset': False,
+            "cxc": {"start": "2016:001:00:00:00.287", "stop": "2016:001:00:00:02.337"},
+            "maude": {
+                "start": "2016:001:00:00:02.593",
+                "stop": "2016:001:00:00:04.900",
+                "flags": {
+                    "allpoints_incomplete": False,
+                    "tolerance": False,
+                    "subset": False,
                 },
             },
         }
@@ -111,16 +111,16 @@ def test_maude_data_source():
 @pytest.mark.skipif("not HAS_MAUDE")
 def test_maude_allow_subset_false():
     """Fetch data from MAUDE with allow_subset false"""
-    with fetch.data_source('maude allow_subset=False'):
-        datm = fetch.Msid('aogyrct1', '2016:001:00:00:00.1', '2016:001:12:00:00')
+    with fetch.data_source("maude allow_subset=False"):
+        datm = fetch.Msid("aogyrct1", "2016:001:00:00:00.1", "2016:001:12:00:00")
         ds = datm.data_source
-        assert list(ds.keys()) == ['maude']
-        assert ds['maude']['flags']['subset'] is False
+        assert list(ds.keys()) == ["maude"]
+        assert ds["maude"]["flags"]["subset"] is False
 
-    with fetch.data_source('cxc'):
-        datc = fetch.Msid('aogyrct1', '2016:001:00:00:00.1', '2016:001:12:00:00')
+    with fetch.data_source("cxc"):
+        datc = fetch.Msid("aogyrct1", "2016:001:00:00:00.1", "2016:001:12:00:00")
         ds = datc.data_source
-        assert list(ds.keys()) == ['cxc']
+        assert list(ds.keys()) == ["cxc"]
 
     assert len(datc.vals) == len(datm.vals)
     assert np.all(datc.vals == datm.vals)
@@ -129,12 +129,12 @@ def test_maude_allow_subset_false():
 @pytest.mark.skipif("not HAS_MAUDE")
 def test_units_eng_to_other():
     for fetch_ in fetch_sci, fetch_eng, fetch_cxc:
-        dat1 = fetch_.Msid('tephin', date1, date4)
-        with fetch_.data_source('maude'):
-            dat2 = fetch_.Msid('tephin', date1, date4)
+        dat1 = fetch_.Msid("tephin", date1, date4)
+        with fetch_.data_source("maude"):
+            dat2 = fetch_.Msid("tephin", date1, date4)
 
-        assert 'cxc' in dat1.data_source
-        assert 'maude' in dat2.data_source
+        assert "cxc" in dat1.data_source
+        assert "maude" in dat2.data_source
         assert dat1.unit == dat2.unit
         assert np.allclose(dat1.vals, dat2.vals)
 
@@ -145,55 +145,55 @@ def test_msid_resolution():
     Make sure that MSIDs that might be in one data source or the other
     are handled properly.
     """
-    with fetch.data_source('cxc', 'maude', 'test-drop-half'):
+    with fetch.data_source("cxc", "maude", "test-drop-half"):
         # dp_pitch only in CXC but this succeeds anyway
-        dat = fetch.Msid('dp_pitch', date1, date4)
-        assert list(dat.data_source.keys()) == ['cxc']
+        dat = fetch.Msid("dp_pitch", date1, date4)
+        assert list(dat.data_source.keys()) == ["cxc"]
         print(len(dat.vals))
 
         # Not in either
         with pytest.raises(ValueError) as err:
-            fetch.Msid('asdfasdfasdf', date1, date4)
+            fetch.Msid("asdfasdfasdf", date1, date4)
         assert "MSID 'asdfasdfasdf' is not in CXC or MAUDE" in str(err.value)
 
         # ACIMG1D1 only in MAUDE
-        dat = fetch.Msid('ACIMG1D1', date1, date4)
-        assert list(dat.data_source.keys()) == ['maude']
+        dat = fetch.Msid("ACIMG1D1", date1, date4)
+        assert list(dat.data_source.keys()) == ["maude"]
         print(len(dat.vals))
 
-    with fetch.data_source('cxc'):
+    with fetch.data_source("cxc"):
         # In MAUDE but this is not selected
         with pytest.raises(ValueError):
-            fetch.Msid('ACIMG1D1', date1, date4)
+            fetch.Msid("ACIMG1D1", date1, date4)
 
 
 @pytest.mark.skipif("not HAS_MAUDE")
 def test_no_stats_maude():
     """Cannot select stats='5min' or 'daily' with MAUDE data source"""
-    with fetch.data_source('maude'):
+    with fetch.data_source("maude"):
         with pytest.raises(ValueError) as err:
-            fetch.Msid('TEPHIN', date1, date4, stat='5min')
-        assert 'MAUDE data source does not support' in str(err.value)
+            fetch.Msid("TEPHIN", date1, date4, stat="5min")
+        assert "MAUDE data source does not support" in str(err.value)
 
 
 def test_zero_length_fetch_cxc():
     """Zero length fetch gives a data source with empty dict"""
-    with fetch.data_source('cxc'):
-        dat = fetch.Msid('tephin', '2015:001', '2015:001')
-    assert dat.data_source == {'cxc': {}}
+    with fetch.data_source("cxc"):
+        dat = fetch.Msid("tephin", "2015:001", "2015:001")
+    assert dat.data_source == {"cxc": {}}
 
 
 @pytest.mark.skipif("not HAS_MAUDE")
 def test_zero_length_fetch_maude():
     """Zero length fetch gives a data source with empty dict"""
-    with fetch.data_source('maude'):
-        dat = fetch.Msid('tephin', '2015:001', '2015:001')
+    with fetch.data_source("maude"):
+        dat = fetch.Msid("tephin", "2015:001", "2015:001")
     assert dat.data_source == {
-        'maude': {
-            'flags': {
-                'allpoints_incomplete': False,
-                'tolerance': False,
-                'subset': False,
+        "maude": {
+            "flags": {
+                "allpoints_incomplete": False,
+                "tolerance": False,
+                "subset": False,
             }
         }
     }

--- a/Ska/engarchive/tests/test_data_source.py
+++ b/Ska/engarchive/tests/test_data_source.py
@@ -17,6 +17,7 @@ date4 = '2016:001:00:00:35.0'
 
 try:
     import maude
+
     maude.get_msids(msids='ccsdsid', start=date1, stop=date2)
 except Exception:
     HAS_MAUDE = False
@@ -34,7 +35,10 @@ def test_data_source():
     assert fetch.data_source.sources() == ('cxc',)
 
     with fetch.data_source('cxc', 'maude'):
-        assert fetch.data_source.sources() == ('cxc', 'maude',)
+        assert fetch.data_source.sources() == (
+            'cxc',
+            'maude',
+        )
     assert fetch.data_source.sources() == ('cxc',)
 
     fetch.data_source.set('maude')
@@ -54,10 +58,10 @@ def test_data_source():
 
 def test_options():
     with fetch.data_source('cxc', 'maude allow_subset=False param=1'):
-        assert fetch.data_source.options() == {'cxc': {},
-                                               'maude': {'allow_subset': False,
-                                                         'param': 1}
-                                               }
+        assert fetch.data_source.options() == {
+            'cxc': {},
+            'maude': {'allow_subset': False, 'param': 1},
+        }
         assert fetch.data_source.sources() == ('cxc', 'maude')
 
 
@@ -67,40 +71,40 @@ def test_maude_data_source():
     with fetch.data_source('cxc'):
         datc = fetch.Msid('aogyrct1', date1, date3)
         assert len(datc.vals) == 19
-        assert datc.data_source == {'cxc': {'start': '2016:001:00:00:00.287',
-                                            'stop': '2016:001:00:00:04.900'}}
+        assert datc.data_source == {
+            'cxc': {'start': '2016:001:00:00:00.287', 'stop': '2016:001:00:00:04.900'}
+        }
 
     with fetch.data_source('maude'):
         datm = fetch.Msid('aogyrct1', date1, date3)
         assert np.all(datm.vals == datc.vals)
         assert not np.all(datm.times == datc.times)
-        assert datm.data_source == {'maude': {
-            'start': '2016:001:00:00:00.287',
-            'stop': '2016:001:00:00:04.900',
-            'flags': {
-                'allpoints_incomplete': False,
-                'tolerance': False,
-                'subset': False
+        assert datm.data_source == {
+            'maude': {
+                'start': '2016:001:00:00:00.287',
+                'stop': '2016:001:00:00:04.900',
+                'flags': {
+                    'allpoints_incomplete': False,
+                    'tolerance': False,
+                    'subset': False,
+                },
             }
-        }}
+        }
 
     with fetch.data_source('cxc', 'maude', 'test-drop-half'):
         datcm = fetch.Msid('aogyrct1', date1, date3)
         assert np.all(datcm.vals == datc.vals)
         assert datcm.data_source == {
-            'cxc': {
-                'start': '2016:001:00:00:00.287',
-                'stop': '2016:001:00:00:02.337'
-            },
+            'cxc': {'start': '2016:001:00:00:00.287', 'stop': '2016:001:00:00:02.337'},
             'maude': {
                 'start': '2016:001:00:00:02.593',
                 'stop': '2016:001:00:00:04.900',
                 'flags': {
                     'allpoints_incomplete': False,
                     'tolerance': False,
-                    'subset': False
-                }
-            }
+                    'subset': False,
+                },
+            },
         }
 
 
@@ -186,6 +190,10 @@ def test_zero_length_fetch_maude():
         dat = fetch.Msid('tephin', '2015:001', '2015:001')
     assert dat.data_source == {
         'maude': {
-            'flags': {'allpoints_incomplete': False, 'tolerance': False, 'subset': False}
+            'flags': {
+                'allpoints_incomplete': False,
+                'tolerance': False,
+                'subset': False,
+            }
         }
     }

--- a/Ska/engarchive/tests/test_fetch.py
+++ b/Ska/engarchive/tests/test_fetch.py
@@ -4,11 +4,10 @@ from copy import deepcopy
 
 import numpy as np
 import pytest
-
-from .. import fetch
-from .. import fetch_eng
 from Chandra.Time import DateTime
 from cxotime import CxoTime
+
+from .. import fetch, fetch_eng
 
 print(fetch.__file__)
 

--- a/Ska/engarchive/tests/test_fetch.py
+++ b/Ska/engarchive/tests/test_fetch.py
@@ -11,31 +11,61 @@ from .. import fetch, fetch_eng
 
 print(fetch.__file__)
 
-DATES_EXPECT1 = np.array(['2008:291:23:59:58.987', '2008:291:23:59:59.244',
-                          '2008:291:23:59:59.500', '2008:291:23:59:59.756',
-                          '2008:297:00:00:00.121', '2008:297:00:00:00.378',
-                          '2008:297:00:00:00.634'])
+DATES_EXPECT1 = np.array(
+    [
+        '2008:291:23:59:58.987',
+        '2008:291:23:59:59.244',
+        '2008:291:23:59:59.500',
+        '2008:291:23:59:59.756',
+        '2008:297:00:00:00.121',
+        '2008:297:00:00:00.378',
+        '2008:297:00:00:00.634',
+    ]
+)
 
-DATES_EXPECT2 = np.array(['2008:291:23:59:54.119', '2008:291:23:59:55.144',
-                          '2008:291:23:59:56.169', '2008:291:23:59:57.194',
-                          '2008:291:23:59:58.219', '2008:291:23:59:59.244',
-                          '2008:297:00:00:00.890', '2008:297:00:00:01.915',
-                          '2008:297:00:00:02.940', '2008:297:00:00:03.965'])
+DATES_EXPECT2 = np.array(
+    [
+        '2008:291:23:59:54.119',
+        '2008:291:23:59:55.144',
+        '2008:291:23:59:56.169',
+        '2008:291:23:59:57.194',
+        '2008:291:23:59:58.219',
+        '2008:291:23:59:59.244',
+        '2008:297:00:00:00.890',
+        '2008:297:00:00:01.915',
+        '2008:297:00:00:02.940',
+        '2008:297:00:00:03.965',
+    ]
+)
 
-DATES_EXPECT3 = np.array(['2008:002:21:48:10.000', '2008:002:21:48:20.000',
-                          '2008:002:21:48:30.000', '2008:002:21:48:40.000',
-                          '2008:002:21:48:50.000', '2008:002:21:49:00.000',
-                          '2008:002:21:49:10.000', '2008:002:21:49:20.000',
-                          '2008:002:21:49:30.000', '2008:002:21:49:40.000',
-                          '2008:002:21:49:50.000'])
+DATES_EXPECT3 = np.array(
+    [
+        '2008:002:21:48:10.000',
+        '2008:002:21:48:20.000',
+        '2008:002:21:48:30.000',
+        '2008:002:21:48:40.000',
+        '2008:002:21:48:50.000',
+        '2008:002:21:49:00.000',
+        '2008:002:21:49:10.000',
+        '2008:002:21:49:20.000',
+        '2008:002:21:49:30.000',
+        '2008:002:21:49:40.000',
+        '2008:002:21:49:50.000',
+    ]
+)
 
-BAD_TIMES = ['2008:292:00:00:00 2008:297:00:00:00',
-             '2008:305:00:12:00 2008:305:00:12:03',
-             '2010:101:00:01:12 2010:101:00:01:25']
+BAD_TIMES = [
+    '2008:292:00:00:00 2008:297:00:00:00',
+    '2008:305:00:12:00 2008:305:00:12:03',
+    '2010:101:00:01:12 2010:101:00:01:25',
+]
 
 try:
     import maude
-    maude.get_msids(msids='ccsdsid', start='2016:001:00:00:00.1', stop='2016:001:00:00:02.0')
+
+    maude.get_msids(
+        msids='ccsdsid', start='2016:001:00:00:00.1', stop='2016:001:00:00:02.0'
+    )
 except Exception:
     HAS_MAUDE = False
 else:
@@ -54,8 +84,11 @@ def test_filter_bad_times_overlap():
     fetch.msid_bad_times = msid_bad_times_cache
 
     # Test repr, len, and dtype attribute here where we have an MSID object handy
-    assert repr(dat) == ('<MSID AOGBIAS1 start=2008:290:12:00:00.000 stop=2008:300:12:00:00.000'
-                         ' len=5 dtype=float32 unit=rad/s stat=daily>')
+    assert (
+        repr(dat)
+        == '<MSID AOGBIAS1 start=2008:290:12:00:00.000 stop=2008:300:12:00:00.000'
+        ' len=5 dtype=float32 unit=rad/s stat=daily>'
+    )
     assert dat.dtype.name == 'float32'
     assert len(dat) == 5
 
@@ -63,8 +96,11 @@ def test_filter_bad_times_overlap():
 def test_filter_bad_times_list():
     dat = fetch.MSID('aogyrct1', '2008:291:12:00:00', '2008:298:12:00:00')
     # 2nd test of repr here where we have an MSID object handy
-    assert repr(dat) == ('<MSID AOGYRCT1 start=2008:291:12:00:00.000 '
-                         'stop=2008:298:12:00:00.000 len=2360195 dtype=int16>')
+    assert (
+        repr(dat)
+        == '<MSID AOGYRCT1 start=2008:291:12:00:00.000 '
+        'stop=2008:298:12:00:00.000 len=2360195 dtype=int16>'
+    )
 
     dat.filter_bad_times(table=BAD_TIMES)
     dates = DateTime(dat.times[168581:168588]).date
@@ -165,12 +201,14 @@ def test_filter_bad_times_default_copy():
 def test_fetch_derived_param_aliases(msid, sources):
     cxc_tstop = fetch.get_time_range('dp_pitch_css', 'secs')[1]
     dt = 2000  # seconds
-    msg = (f'{CxoTime(cxc_tstop).date=} {dt=}\n'
-           f'{CxoTime(cxc_tstop - dt).date=}\n'
-           f'{CxoTime(cxc_tstop + dt).date=}\n'
-           f'{CxoTime.now().date=}\n'
-           f'{CxoTime.now().iso=}\n'
-           f'{sources=} {msid=}')
+    msg = (
+        f'{CxoTime(cxc_tstop).date=} {dt=}\n'
+        f'{CxoTime(cxc_tstop - dt).date=}\n'
+        f'{CxoTime(cxc_tstop + dt).date=}\n'
+        f'{CxoTime.now().date=}\n'
+        f'{CxoTime.now().iso=}\n'
+        f'{sources=} {msid=}'
+    )
     print(msg)  # stdout gets reported for test failures
     with fetch.data_source(*sources):
         # Get data within `dt` secs of end of CXC data
@@ -184,25 +222,71 @@ def test_fetch_derived_param_aliases(msid, sources):
 
 
 def test_interpolate():
-    dat = fetch.MSIDset(['aoattqt1', 'aogyrct1', 'aopcadmd'],
-                        '2008:002:21:48:00', '2008:002:21:50:00')
+    dat = fetch.MSIDset(
+        ['aoattqt1', 'aogyrct1', 'aopcadmd'], '2008:002:21:48:00', '2008:002:21:50:00'
+    )
     dat.interpolate(10.0)
 
-    assert np.allclose(dat['aoattqt1'].vals,
-                       np.array([-0.33072645, -0.33072633, -0.33072634,
-                                 -0.33072632, -0.33072705,
-                                 -0.33073644, -0.33076456, -0.33081424,
-                                 -0.33090285, -0.33088904,
-                                 -0.33099454, -0.33128471]))
+    assert np.allclose(
+        dat['aoattqt1'].vals,
+        np.array(
+            [
+                -0.33072645,
+                -0.33072633,
+                -0.33072634,
+                -0.33072632,
+                -0.33072705,
+                -0.33073644,
+                -0.33076456,
+                -0.33081424,
+                -0.33090285,
+                -0.33088904,
+                -0.33099454,
+                -0.33128471,
+            ]
+        ),
+    )
 
-    assert np.all(dat['aopcadmd'].vals ==
-                  np.array(['NPNT', 'NPNT', 'NPNT', 'NMAN', 'NMAN', 'NMAN',
-                            'NMAN', 'NMAN', 'NMAN', 'NMAN', 'NMAN', 'NMAN']))
+    assert np.all(
+        dat['aopcadmd'].vals
+        == np.array(
+            [
+                'NPNT',
+                'NPNT',
+                'NPNT',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+            ]
+        )
+    )
 
-    assert np.all(dat['aogyrct1'].vals ==
-                  np.array([-23261, -22131, -21000, -19878, -18714, -17301,
-                            -15379, -12674, -8914, -3398, 3514, 11486],
-                           dtype=np.int16))
+    assert np.all(
+        dat['aogyrct1'].vals
+        == np.array(
+            [
+                -23261,
+                -22131,
+                -21000,
+                -19878,
+                -18714,
+                -17301,
+                -15379,
+                -12674,
+                -8914,
+                -3398,
+                3514,
+                11486,
+            ],
+            dtype=np.int16,
+        )
+    )
 
 
 def test_interpolate_msid():
@@ -210,27 +294,70 @@ def test_interpolate_msid():
     stop = '2008:002:21:50:00'
     dat = fetch.MSID('aoattqt1', start, stop)
     dat.interpolate(10.0, start, stop)
-    assert np.allclose(dat.vals,
-                       np.array([-0.33072645, -0.33072633, -0.33072634,
-                                 -0.33072632, -0.33072705,
-                                 -0.33073644, -0.33076456, -0.33081424,
-                                 -0.33090285, -0.33088904,
-                                 -0.33099454, -0.33128471]))
+    assert np.allclose(
+        dat.vals,
+        np.array(
+            [
+                -0.33072645,
+                -0.33072633,
+                -0.33072634,
+                -0.33072632,
+                -0.33072705,
+                -0.33073644,
+                -0.33076456,
+                -0.33081424,
+                -0.33090285,
+                -0.33088904,
+                -0.33099454,
+                -0.33128471,
+            ]
+        ),
+    )
 
     dat = fetch.MSID('aogyrct1', start, stop)
     dat.interpolate(10.0, start, stop)
-    assert np.all(dat.vals ==
-                  np.array([-23349, -22219, -21087, -19960, -18810, -17425,
-                            -15551, -12919,
-                            -9252, -3887, 2943, 10858],
-                           dtype=np.int16))
+    assert np.all(
+        dat.vals
+        == np.array(
+            [
+                -23349,
+                -22219,
+                -21087,
+                -19960,
+                -18810,
+                -17425,
+                -15551,
+                -12919,
+                -9252,
+                -3887,
+                2943,
+                10858,
+            ],
+            dtype=np.int16,
+        )
+    )
 
     dat = fetch.MSID('aopcadmd', start, stop)
     dat.interpolate(10.0, start, stop)
-    assert np.all(dat.vals ==
-                  np.array(['NPNT', 'NPNT', 'NPNT', 'NMAN',
-                            'NMAN', 'NMAN', 'NMAN', 'NMAN',
-                            'NMAN', 'NMAN', 'NMAN', 'NMAN']))
+    assert np.all(
+        dat.vals
+        == np.array(
+            [
+                'NPNT',
+                'NPNT',
+                'NPNT',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+                'NMAN',
+            ]
+        )
+    )
 
 
 def test_interpolate_times_raise():
@@ -242,26 +369,65 @@ def test_interpolate_times_raise():
 
 
 def test_interpolate_times():
-    dat = fetch.MSIDset(['aoattqt1', 'aogyrct1', 'aopcadmd'],
-                        '2008:002:21:48:00', '2008:002:21:50:00')
+    dat = fetch.MSIDset(
+        ['aoattqt1', 'aogyrct1', 'aopcadmd'], '2008:002:21:48:00', '2008:002:21:50:00'
+    )
     dt = 10.0
     times = dat.tstart + np.arange((dat.tstop - dat.tstart) // dt + 3) * dt
     dat.interpolate(times=times)
 
     assert np.all(DateTime(dat.times).date == DATES_EXPECT3)
 
-    assert np.allclose(dat['aoattqt1'].vals,
-                       [-0.33072634, -0.33072637, -0.33072674, -0.33072665, -0.33073477,
-                        -0.330761, -0.33080694, -0.33089434, -0.33089264, -0.33097442,
-                        -0.33123678])
+    assert np.allclose(
+        dat['aoattqt1'].vals,
+        [
+            -0.33072634,
+            -0.33072637,
+            -0.33072674,
+            -0.33072665,
+            -0.33073477,
+            -0.330761,
+            -0.33080694,
+            -0.33089434,
+            -0.33089264,
+            -0.33097442,
+            -0.33123678,
+        ],
+    )
 
-    assert np.all(dat['aopcadmd'].vals ==
-                  ['NPNT', 'NPNT', 'NMAN', 'NMAN', 'NMAN', 'NMAN', 'NMAN', 'NMAN',
-                   'NMAN', 'NMAN', 'NMAN'])
+    assert np.all(
+        dat['aopcadmd'].vals
+        == [
+            'NPNT',
+            'NPNT',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+        ]
+    )
 
-    assert np.all(dat['aogyrct1'].vals ==
-                  [-22247, -21117, -19988, -18839, -17468, -15605, -13000, -9360,
-                   -4052, 2752, 10648])
+    assert np.all(
+        dat['aogyrct1'].vals
+        == [
+            -22247,
+            -21117,
+            -19988,
+            -18839,
+            -17468,
+            -15605,
+            -13000,
+            -9360,
+            -4052,
+            2752,
+            10648,
+        ]
+    )
 
 
 def test_interpolate_msid_times():
@@ -271,26 +437,64 @@ def test_interpolate_msid_times():
     dt = 10.0
     times = dat.tstart + np.arange((dat.tstop - dat.tstart) // dt + 3) * dt
     dat.interpolate(times=times)
-    assert np.allclose(dat.vals,
-                       [-0.33072634, -0.33072637, -0.33072674, -0.33072665, -0.33073477,
-                        -0.330761, -0.33080694, -0.33089434, -0.33089264, -0.33097442,
-                        -0.33123678])
+    assert np.allclose(
+        dat.vals,
+        [
+            -0.33072634,
+            -0.33072637,
+            -0.33072674,
+            -0.33072665,
+            -0.33073477,
+            -0.330761,
+            -0.33080694,
+            -0.33089434,
+            -0.33089264,
+            -0.33097442,
+            -0.33123678,
+        ],
+    )
 
     assert np.all(DateTime(dat.times).date == DATES_EXPECT3)
 
     dat = fetch.MSID('aogyrct1', start, stop)
     dat.interpolate(times=times)
-    assert np.all(dat.vals ==
-                  [-22247, -21117, -19988, -18839, -17468, -15605, -13000, -9360,
-                   -4052, 2752, 10648])
+    assert np.all(
+        dat.vals
+        == [
+            -22247,
+            -21117,
+            -19988,
+            -18839,
+            -17468,
+            -15605,
+            -13000,
+            -9360,
+            -4052,
+            2752,
+            10648,
+        ]
+    )
 
     assert np.all(DateTime(dat.times).date == DATES_EXPECT3)
 
     dat = fetch.MSID('aopcadmd', start, stop)
     dat.interpolate(times=times)
-    assert np.all(dat.vals ==
-                  ['NPNT', 'NPNT', 'NMAN', 'NMAN', 'NMAN', 'NMAN', 'NMAN', 'NMAN',
-                   'NMAN', 'NMAN', 'NMAN'])
+    assert np.all(
+        dat.vals
+        == [
+            'NPNT',
+            'NPNT',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+            'NMAN',
+        ]
+    )
 
     assert np.all(DateTime(dat.times).date == DATES_EXPECT3)
 
@@ -336,7 +540,9 @@ def test_msid_copy():
 
 def test_msidset_copy():
     for MsidsetClass in (fetch.MSIDset, fetch.Msidset):
-        msidset1 = MsidsetClass(['aogbias1', 'aogbias2'], '2008:291:12:00:00', '2008:298:12:00:00')
+        msidset1 = MsidsetClass(
+            ['aogbias1', 'aogbias2'], '2008:291:12:00:00', '2008:298:12:00:00'
+        )
         msidset2 = msidset1.copy()
 
         for attr in ('tstart', 'tstop', 'datestart', 'datestop'):
@@ -364,7 +570,9 @@ def test_MSIDset_interpolate_filtering():
     Filtering and interpolation
     """
     # Bung up some data same as documentation example
-    dat = fetch.MSIDset(['aosares1', 'pitch_fss'], '2010:001:00:00:00', '2010:001:00:00:20')
+    dat = fetch.MSIDset(
+        ['aosares1', 'pitch_fss'], '2010:001:00:00:00', '2010:001:00:00:20'
+    )
     dat['aosares1'].bads[2] = True
     dat['pitch_fss'].bads[6] = True
 
@@ -415,10 +623,12 @@ def test_MSIDset_interpolate_filtering():
 
 
 def test_1999_fetch():
-    for start, stop in (('1999:363:00:00:00', '2000:005:00:00:00'),  # Covering deadband
-                        ('1999:363:00:00:00', '2000:002:00:00:00'),  # Stop within deadband
-                        ('2000:002:00:00:00', '2000:004:00:00:00'),  # Start within deadband
-                        ('1999:360:00:00:00', '1999:361:00:00:00')):  # 1999 before deadband
+    for start, stop in (
+        ('1999:363:00:00:00', '2000:005:00:00:00'),  # Covering deadband
+        ('1999:363:00:00:00', '2000:002:00:00:00'),  # Stop within deadband
+        ('2000:002:00:00:00', '2000:004:00:00:00'),  # Start within deadband
+        ('1999:360:00:00:00', '1999:361:00:00:00'),
+    ):  # 1999 before deadband
         dat = fetch.MSID('aopcadmd', start, stop)
         assert np.allclose(np.diff(dat.times), 1.025, atol=0.01)
 
@@ -431,18 +641,33 @@ def test_intervals_fetch_unit():
     """
     Test that fetches with multiple intervals get the units right
     """
-    dat = fetch_eng.Msid('tephin', [('1999:350:12:00:00', '1999:355:12:00:00'),
-                                    ('2000:010:12:00:00', '2000:015:12:00:00')])
+    dat = fetch_eng.Msid(
+        'tephin',
+        [
+            ('1999:350:12:00:00', '1999:355:12:00:00'),
+            ('2000:010:12:00:00', '2000:015:12:00:00'),
+        ],
+    )
     assert np.allclose(np.mean(dat.vals), 41.713467)
 
-    dat = fetch_eng.Msid('tephin', [('1999:350:12:00:00', '1999:355:12:00:00'),
-                                    ('2000:010:12:00:00', '2000:015:12:00:00')],
-                         stat='5min')
+    dat = fetch_eng.Msid(
+        'tephin',
+        [
+            ('1999:350:12:00:00', '1999:355:12:00:00'),
+            ('2000:010:12:00:00', '2000:015:12:00:00'),
+        ],
+        stat='5min',
+    )
     assert np.allclose(np.mean(dat.vals), 40.290966)
 
-    dat = fetch_eng.Msid('tephin', [('1999:350:12:00:00', '1999:355:12:00:00'),
-                                    ('2000:010:12:00:00', '2000:015:12:00:00')],
-                         stat='daily')
+    dat = fetch_eng.Msid(
+        'tephin',
+        [
+            ('1999:350:12:00:00', '1999:355:12:00:00'),
+            ('2000:010:12:00:00', '2000:015:12:00:00'),
+        ],
+        stat='daily',
+    )
     assert np.allclose(np.mean(dat.vals), 40.303955)
 
     dat = fetch_eng.Msid('tephin', '1999:350:12:00:00', '2000:010:12:00:00')
@@ -471,10 +696,12 @@ def test_nonexistent_msids():
 
 def test_daily_state_bins():
     dat = fetch.Msid('aoacaseq', '2016:232:12:00:00', '2016:235:12:00:00', stat='daily')
-    for attr, val in (('n_BRITs', [0, 136, 0]),
-                      ('n_KALMs', [83994, 83812, 83996]),
-                      ('n_AQXNs', [159, 240, 113]),
-                      ('n_GUIDs', [140, 104, 184])):
+    for attr, val in (
+        ('n_BRITs', [0, 136, 0]),
+        ('n_KALMs', [83994, 83812, 83996]),
+        ('n_AQXNs', [159, 240, 113]),
+        ('n_GUIDs', [140, 104, 184]),
+    ):
         assert np.all(getattr(dat, attr) == val)
 
     dat = fetch.Msid('aoacaseq', '2016:234:12:00:00', '2016:234:12:30:00', stat='5min')

--- a/Ska/engarchive/tests/test_fetch.py
+++ b/Ska/engarchive/tests/test_fetch.py
@@ -13,58 +13,58 @@ print(fetch.__file__)
 
 DATES_EXPECT1 = np.array(
     [
-        '2008:291:23:59:58.987',
-        '2008:291:23:59:59.244',
-        '2008:291:23:59:59.500',
-        '2008:291:23:59:59.756',
-        '2008:297:00:00:00.121',
-        '2008:297:00:00:00.378',
-        '2008:297:00:00:00.634',
+        "2008:291:23:59:58.987",
+        "2008:291:23:59:59.244",
+        "2008:291:23:59:59.500",
+        "2008:291:23:59:59.756",
+        "2008:297:00:00:00.121",
+        "2008:297:00:00:00.378",
+        "2008:297:00:00:00.634",
     ]
 )
 
 DATES_EXPECT2 = np.array(
     [
-        '2008:291:23:59:54.119',
-        '2008:291:23:59:55.144',
-        '2008:291:23:59:56.169',
-        '2008:291:23:59:57.194',
-        '2008:291:23:59:58.219',
-        '2008:291:23:59:59.244',
-        '2008:297:00:00:00.890',
-        '2008:297:00:00:01.915',
-        '2008:297:00:00:02.940',
-        '2008:297:00:00:03.965',
+        "2008:291:23:59:54.119",
+        "2008:291:23:59:55.144",
+        "2008:291:23:59:56.169",
+        "2008:291:23:59:57.194",
+        "2008:291:23:59:58.219",
+        "2008:291:23:59:59.244",
+        "2008:297:00:00:00.890",
+        "2008:297:00:00:01.915",
+        "2008:297:00:00:02.940",
+        "2008:297:00:00:03.965",
     ]
 )
 
 DATES_EXPECT3 = np.array(
     [
-        '2008:002:21:48:10.000',
-        '2008:002:21:48:20.000',
-        '2008:002:21:48:30.000',
-        '2008:002:21:48:40.000',
-        '2008:002:21:48:50.000',
-        '2008:002:21:49:00.000',
-        '2008:002:21:49:10.000',
-        '2008:002:21:49:20.000',
-        '2008:002:21:49:30.000',
-        '2008:002:21:49:40.000',
-        '2008:002:21:49:50.000',
+        "2008:002:21:48:10.000",
+        "2008:002:21:48:20.000",
+        "2008:002:21:48:30.000",
+        "2008:002:21:48:40.000",
+        "2008:002:21:48:50.000",
+        "2008:002:21:49:00.000",
+        "2008:002:21:49:10.000",
+        "2008:002:21:49:20.000",
+        "2008:002:21:49:30.000",
+        "2008:002:21:49:40.000",
+        "2008:002:21:49:50.000",
     ]
 )
 
 BAD_TIMES = [
-    '2008:292:00:00:00 2008:297:00:00:00',
-    '2008:305:00:12:00 2008:305:00:12:03',
-    '2010:101:00:01:12 2010:101:00:01:25',
+    "2008:292:00:00:00 2008:297:00:00:00",
+    "2008:305:00:12:00 2008:305:00:12:03",
+    "2010:101:00:01:12 2010:101:00:01:25",
 ]
 
 try:
     import maude
 
     maude.get_msids(
-        msids='ccsdsid', start='2016:001:00:00:00.1', stop='2016:001:00:00:02.0'
+        msids="ccsdsid", start="2016:001:00:00:00.1", stop="2016:001:00:00:02.0"
     )
 except Exception:
     HAS_MAUDE = False
@@ -77,98 +77,97 @@ def test_filter_bad_times_overlap():
     OK to supply overlapping bad times
     """
     msid_bad_times_cache = deepcopy(fetch.msid_bad_times)
-    dat = fetch.MSID('aogbias1', '2008:290:12:00:00', '2008:300:12:00:00', stat='daily')
-    fetch.read_bad_times(['aogbias1 2008:292:00:00:00 2008:297:00:00:00'])
-    fetch.read_bad_times(['aogbias1 2008:292:00:00:00 2008:297:00:00:00'])
+    dat = fetch.MSID("aogbias1", "2008:290:12:00:00", "2008:300:12:00:00", stat="daily")
+    fetch.read_bad_times(["aogbias1 2008:292:00:00:00 2008:297:00:00:00"])
+    fetch.read_bad_times(["aogbias1 2008:292:00:00:00 2008:297:00:00:00"])
     dat.filter_bad_times()
     fetch.msid_bad_times = msid_bad_times_cache
 
     # Test repr, len, and dtype attribute here where we have an MSID object handy
     assert (
         repr(dat)
-        == '<MSID AOGBIAS1 start=2008:290:12:00:00.000 stop=2008:300:12:00:00.000'
-        ' len=5 dtype=float32 unit=rad/s stat=daily>'
+        == "<MSID AOGBIAS1 start=2008:290:12:00:00.000 stop=2008:300:12:00:00.000"
+        " len=5 dtype=float32 unit=rad/s stat=daily>"
     )
-    assert dat.dtype.name == 'float32'
+    assert dat.dtype.name == "float32"
     assert len(dat) == 5
 
 
 def test_filter_bad_times_list():
-    dat = fetch.MSID('aogyrct1', '2008:291:12:00:00', '2008:298:12:00:00')
+    dat = fetch.MSID("aogyrct1", "2008:291:12:00:00", "2008:298:12:00:00")
     # 2nd test of repr here where we have an MSID object handy
     assert (
-        repr(dat)
-        == '<MSID AOGYRCT1 start=2008:291:12:00:00.000 '
-        'stop=2008:298:12:00:00.000 len=2360195 dtype=int16>'
+        repr(dat) == "<MSID AOGYRCT1 start=2008:291:12:00:00.000 "
+        "stop=2008:298:12:00:00.000 len=2360195 dtype=int16>"
     )
 
     dat.filter_bad_times(table=BAD_TIMES)
     dates = DateTime(dat.times[168581:168588]).date
     assert np.all(dates == DATES_EXPECT1)
 
-    dat = fetch.Msid('aogyrct1', '2008:291:12:00:00', '2008:298:12:00:00')
+    dat = fetch.Msid("aogyrct1", "2008:291:12:00:00", "2008:298:12:00:00")
     dat.filter_bad_times(table=BAD_TIMES)
     dates = DateTime(dat.times[168581:168588]).date
     assert np.all(dates == DATES_EXPECT1)
 
 
-@pytest.mark.parametrize('stat', [None, '5min'])
+@pytest.mark.parametrize("stat", [None, "5min"])
 def test_pickle_MSID(stat):
     """Test pickling of MSID objects"""
-    msid = 'aoattqt1'
-    start, stop = '2022:001:00:00:00', '2022:001:00:15:00'
+    msid = "aoattqt1"
+    start, stop = "2022:001:00:00:00", "2022:001:00:15:00"
     dat = fetch.MSID(msid, start, stop, stat=stat)
     dat2 = pickle.loads(pickle.dumps(dat))
-    attrs = ('tstart', 'tstop', 'datestart', 'datestop', 'data_source', 'content')
+    attrs = ("tstart", "tstop", "datestart", "datestop", "data_source", "content")
     for attr in attrs:
         assert getattr(dat, attr) == getattr(dat2, attr)
-    for attr in ('times', 'vals'):
+    for attr in ("times", "vals"):
         assert np.all(getattr(dat, attr) == getattr(dat2, attr))
 
 
-@pytest.mark.parametrize('stat', [None, '5min'])
+@pytest.mark.parametrize("stat", [None, "5min"])
 def test_pickle_MSIDset(stat):
     """Test pickling of MSIDset objects"""
-    msid = 'aoattqt1'
-    start, stop = '2022:001:00:00:00', '2022:001:00:15:00'
+    msid = "aoattqt1"
+    start, stop = "2022:001:00:00:00", "2022:001:00:15:00"
     dat = fetch.MSIDset([msid], start, stop, stat=stat)
     dat2 = pickle.loads(pickle.dumps(dat))
-    attrs = ('tstart', 'tstop', 'datestart', 'datestop')
+    attrs = ("tstart", "tstop", "datestart", "datestop")
     assert dat.keys() == dat2.keys()
     for attr in attrs:
         assert getattr(dat, attr) == getattr(dat2, attr)
-    for attr in ('times', 'vals') + attrs:
+    for attr in ("times", "vals") + attrs:
         assert np.all(getattr(dat[msid], attr) == getattr(dat2[msid], attr))
 
 
 def test_msidset_filter_bad_times_list():
-    dat = fetch.MSIDset(['aogyrct1'], '2008:291:12:00:00', '2008:298:12:00:00')
+    dat = fetch.MSIDset(["aogyrct1"], "2008:291:12:00:00", "2008:298:12:00:00")
     dat.filter_bad_times(table=BAD_TIMES)
-    dates = DateTime(dat['aogyrct1'].times[168581:168588]).date
+    dates = DateTime(dat["aogyrct1"].times[168581:168588]).date
     assert np.all(dates == DATES_EXPECT1)
 
-    dat = fetch.Msidset(['aogyrct1'], '2008:291:12:00:00', '2008:298:12:00:00')
+    dat = fetch.Msidset(["aogyrct1"], "2008:291:12:00:00", "2008:298:12:00:00")
     dat.filter_bad_times(table=BAD_TIMES)
-    dates = DateTime(dat['aogyrct1'].times[168581:168588]).date
+    dates = DateTime(dat["aogyrct1"].times[168581:168588]).date
     assert np.all(dates == DATES_EXPECT1)
 
 
 def test_filter_bad_times_default():
     """Test bad times that come from msid_bad_times.dat"""
-    dat = fetch.MSID('aogbias1', '2008:291:12:00:00', '2008:298:12:00:00')
+    dat = fetch.MSID("aogbias1", "2008:291:12:00:00", "2008:298:12:00:00")
     dat.filter_bad_times()
     dates = DateTime(dat.times[42140:42150]).date
     assert np.all(dates == DATES_EXPECT2)
 
 
 def test_filter_bad_times_list_copy():
-    dat = fetch.MSID('aogyrct1', '2008:291:12:00:00', '2008:298:12:00:00')
+    dat = fetch.MSID("aogyrct1", "2008:291:12:00:00", "2008:298:12:00:00")
     dat2 = dat.filter_bad_times(table=BAD_TIMES, copy=True)
     dates = DateTime(dat2.times[168581:168588]).date
     assert np.all(dates == DATES_EXPECT1)
     assert len(dat.vals) != len(dat2.vals)
 
-    dat = fetch.Msid('aogyrct1', '2008:291:12:00:00', '2008:298:12:00:00')
+    dat = fetch.Msid("aogyrct1", "2008:291:12:00:00", "2008:298:12:00:00")
     dat2 = dat.filter_bad_times(table=BAD_TIMES, copy=True)
     dates = DateTime(dat2.times[168581:168588]).date
     assert np.all(dates == DATES_EXPECT1)
@@ -176,43 +175,43 @@ def test_filter_bad_times_list_copy():
 
 
 def test_msidset_filter_bad_times_list_copy():
-    dat = fetch.MSIDset(['aogyrct1'], '2008:291:12:00:00', '2008:298:12:00:00')
+    dat = fetch.MSIDset(["aogyrct1"], "2008:291:12:00:00", "2008:298:12:00:00")
     dat2 = dat.filter_bad_times(table=BAD_TIMES, copy=True)
-    dates = DateTime(dat2['aogyrct1'].times[168581:168588]).date
+    dates = DateTime(dat2["aogyrct1"].times[168581:168588]).date
     assert np.all(dates == DATES_EXPECT1)
 
-    dat = fetch.Msidset(['aogyrct1'], '2008:291:12:00:00', '2008:298:12:00:00')
+    dat = fetch.Msidset(["aogyrct1"], "2008:291:12:00:00", "2008:298:12:00:00")
     dat2 = dat.filter_bad_times(table=BAD_TIMES, copy=True)
-    dates = DateTime(dat2['aogyrct1'].times[168581:168588]).date
+    dates = DateTime(dat2["aogyrct1"].times[168581:168588]).date
     assert np.all(dates == DATES_EXPECT1)
 
 
 def test_filter_bad_times_default_copy():
     """Test bad times that come from msid_bad_times.dat"""
-    dat = fetch.MSID('aogbias1', '2008:291:12:00:00', '2008:298:12:00:00')
+    dat = fetch.MSID("aogbias1", "2008:291:12:00:00", "2008:298:12:00:00")
     dat2 = dat.filter_bad_times(copy=True)
     dates = DateTime(dat2.times[42140:42150]).date
     assert np.all(dates == DATES_EXPECT2)
 
 
-@pytest.mark.skipif(not HAS_MAUDE, reason='no MAUDE server available')
-@pytest.mark.parametrize('msid', ['DP_piTch_css', 'Calc_pitCH_css'])
-@pytest.mark.parametrize('sources', (('cxc',), ('maude',), ('cxc', 'maude')))
+@pytest.mark.skipif(not HAS_MAUDE, reason="no MAUDE server available")
+@pytest.mark.parametrize("msid", ["DP_piTch_css", "Calc_pitCH_css"])
+@pytest.mark.parametrize("sources", (("cxc",), ("maude",), ("cxc", "maude")))
 def test_fetch_derived_param_aliases(msid, sources):
-    cxc_tstop = fetch.get_time_range('dp_pitch_css', 'secs')[1]
+    cxc_tstop = fetch.get_time_range("dp_pitch_css", "secs")[1]
     dt = 2000  # seconds
     msg = (
-        f'{CxoTime(cxc_tstop).date=} {dt=}\n'
-        f'{CxoTime(cxc_tstop - dt).date=}\n'
-        f'{CxoTime(cxc_tstop + dt).date=}\n'
-        f'{CxoTime.now().date=}\n'
-        f'{CxoTime.now().iso=}\n'
-        f'{sources=} {msid=}'
+        f"{CxoTime(cxc_tstop).date=} {dt=}\n"
+        f"{CxoTime(cxc_tstop - dt).date=}\n"
+        f"{CxoTime(cxc_tstop + dt).date=}\n"
+        f"{CxoTime.now().date=}\n"
+        f"{CxoTime.now().iso=}\n"
+        f"{sources=} {msid=}"
     )
     print(msg)  # stdout gets reported for test failures
     with fetch.data_source(*sources):
         # Get data within `dt` secs of end of CXC data
-        d1 = fetch.MSID('piTCh_css', cxc_tstop - dt, cxc_tstop + dt)
+        d1 = fetch.MSID("piTCh_css", cxc_tstop - dt, cxc_tstop + dt)
         d2 = fetch.MSID(msid, cxc_tstop - dt, cxc_tstop + dt)
     assert d2.msid == msid  # version as the user provide
     assert d2.MSID == d1.MSID  # normalized version for accessing databases
@@ -223,12 +222,12 @@ def test_fetch_derived_param_aliases(msid, sources):
 
 def test_interpolate():
     dat = fetch.MSIDset(
-        ['aoattqt1', 'aogyrct1', 'aopcadmd'], '2008:002:21:48:00', '2008:002:21:50:00'
+        ["aoattqt1", "aogyrct1", "aopcadmd"], "2008:002:21:48:00", "2008:002:21:50:00"
     )
     dat.interpolate(10.0)
 
     assert np.allclose(
-        dat['aoattqt1'].vals,
+        dat["aoattqt1"].vals,
         np.array(
             [
                 -0.33072645,
@@ -248,27 +247,27 @@ def test_interpolate():
     )
 
     assert np.all(
-        dat['aopcadmd'].vals
+        dat["aopcadmd"].vals
         == np.array(
             [
-                'NPNT',
-                'NPNT',
-                'NPNT',
-                'NMAN',
-                'NMAN',
-                'NMAN',
-                'NMAN',
-                'NMAN',
-                'NMAN',
-                'NMAN',
-                'NMAN',
-                'NMAN',
+                "NPNT",
+                "NPNT",
+                "NPNT",
+                "NMAN",
+                "NMAN",
+                "NMAN",
+                "NMAN",
+                "NMAN",
+                "NMAN",
+                "NMAN",
+                "NMAN",
+                "NMAN",
             ]
         )
     )
 
     assert np.all(
-        dat['aogyrct1'].vals
+        dat["aogyrct1"].vals
         == np.array(
             [
                 -23261,
@@ -290,9 +289,9 @@ def test_interpolate():
 
 
 def test_interpolate_msid():
-    start = '2008:002:21:48:00'
-    stop = '2008:002:21:50:00'
-    dat = fetch.MSID('aoattqt1', start, stop)
+    start = "2008:002:21:48:00"
+    stop = "2008:002:21:50:00"
+    dat = fetch.MSID("aoattqt1", start, stop)
     dat.interpolate(10.0, start, stop)
     assert np.allclose(
         dat.vals,
@@ -314,7 +313,7 @@ def test_interpolate_msid():
         ),
     )
 
-    dat = fetch.MSID('aogyrct1', start, stop)
+    dat = fetch.MSID("aogyrct1", start, stop)
     dat.interpolate(10.0, start, stop)
     assert np.all(
         dat.vals
@@ -337,40 +336,40 @@ def test_interpolate_msid():
         )
     )
 
-    dat = fetch.MSID('aopcadmd', start, stop)
+    dat = fetch.MSID("aopcadmd", start, stop)
     dat.interpolate(10.0, start, stop)
     assert np.all(
         dat.vals
         == np.array(
             [
-                'NPNT',
-                'NPNT',
-                'NPNT',
-                'NMAN',
-                'NMAN',
-                'NMAN',
-                'NMAN',
-                'NMAN',
-                'NMAN',
-                'NMAN',
-                'NMAN',
-                'NMAN',
+                "NPNT",
+                "NPNT",
+                "NPNT",
+                "NMAN",
+                "NMAN",
+                "NMAN",
+                "NMAN",
+                "NMAN",
+                "NMAN",
+                "NMAN",
+                "NMAN",
+                "NMAN",
             ]
         )
     )
 
 
 def test_interpolate_times_raise():
-    start = '2008:002:21:48:00'
-    stop = '2008:002:21:50:00'
-    dat = fetch.MSID('aoattqt1', start, stop)
+    start = "2008:002:21:48:00"
+    stop = "2008:002:21:50:00"
+    dat = fetch.MSID("aoattqt1", start, stop)
     with pytest.raises(ValueError):
         dat.interpolate(10.0, times=[1, 2])
 
 
 def test_interpolate_times():
     dat = fetch.MSIDset(
-        ['aoattqt1', 'aogyrct1', 'aopcadmd'], '2008:002:21:48:00', '2008:002:21:50:00'
+        ["aoattqt1", "aogyrct1", "aopcadmd"], "2008:002:21:48:00", "2008:002:21:50:00"
     )
     dt = 10.0
     times = dat.tstart + np.arange((dat.tstop - dat.tstart) // dt + 3) * dt
@@ -379,7 +378,7 @@ def test_interpolate_times():
     assert np.all(DateTime(dat.times).date == DATES_EXPECT3)
 
     assert np.allclose(
-        dat['aoattqt1'].vals,
+        dat["aoattqt1"].vals,
         [
             -0.33072634,
             -0.33072637,
@@ -396,24 +395,24 @@ def test_interpolate_times():
     )
 
     assert np.all(
-        dat['aopcadmd'].vals
+        dat["aopcadmd"].vals
         == [
-            'NPNT',
-            'NPNT',
-            'NMAN',
-            'NMAN',
-            'NMAN',
-            'NMAN',
-            'NMAN',
-            'NMAN',
-            'NMAN',
-            'NMAN',
-            'NMAN',
+            "NPNT",
+            "NPNT",
+            "NMAN",
+            "NMAN",
+            "NMAN",
+            "NMAN",
+            "NMAN",
+            "NMAN",
+            "NMAN",
+            "NMAN",
+            "NMAN",
         ]
     )
 
     assert np.all(
-        dat['aogyrct1'].vals
+        dat["aogyrct1"].vals
         == [
             -22247,
             -21117,
@@ -431,9 +430,9 @@ def test_interpolate_times():
 
 
 def test_interpolate_msid_times():
-    start = '2008:002:21:48:00'
-    stop = '2008:002:21:50:00'
-    dat = fetch.MSID('aoattqt1', start, stop)
+    start = "2008:002:21:48:00"
+    stop = "2008:002:21:50:00"
+    dat = fetch.MSID("aoattqt1", start, stop)
     dt = 10.0
     times = dat.tstart + np.arange((dat.tstop - dat.tstart) // dt + 3) * dt
     dat.interpolate(times=times)
@@ -456,7 +455,7 @@ def test_interpolate_msid_times():
 
     assert np.all(DateTime(dat.times).date == DATES_EXPECT3)
 
-    dat = fetch.MSID('aogyrct1', start, stop)
+    dat = fetch.MSID("aogyrct1", start, stop)
     dat.interpolate(times=times)
     assert np.all(
         dat.vals
@@ -477,22 +476,22 @@ def test_interpolate_msid_times():
 
     assert np.all(DateTime(dat.times).date == DATES_EXPECT3)
 
-    dat = fetch.MSID('aopcadmd', start, stop)
+    dat = fetch.MSID("aopcadmd", start, stop)
     dat.interpolate(times=times)
     assert np.all(
         dat.vals
         == [
-            'NPNT',
-            'NPNT',
-            'NMAN',
-            'NMAN',
-            'NMAN',
-            'NMAN',
-            'NMAN',
-            'NMAN',
-            'NMAN',
-            'NMAN',
-            'NMAN',
+            "NPNT",
+            "NPNT",
+            "NMAN",
+            "NMAN",
+            "NMAN",
+            "NMAN",
+            "NMAN",
+            "NMAN",
+            "NMAN",
+            "NMAN",
+            "NMAN",
         ]
     )
 
@@ -503,7 +502,7 @@ def test_interpolate_time_precision():
     """
     Check that floating point error is < 0.01 msec over 100 days
     """
-    dat = fetch.Msid('tephin', '2010:001:12:00:00', '2010:100:12:00:00')
+    dat = fetch.Msid("tephin", "2010:001:12:00:00", "2010:100:12:00:00")
     dt = 60.06
     times = dat.tstart + np.arange((dat.tstop - dat.tstart) // dt + 3) * dt
 
@@ -512,7 +511,7 @@ def test_interpolate_time_precision():
     dt_frac = dt * 100 - round(dt * 100)
     assert abs(dt_frac) > 0.001
 
-    dat = fetch.Msid('tephin', '2010:001:12:00:00', '2010:100:12:00:00')
+    dat = fetch.Msid("tephin", "2010:001:12:00:00", "2010:100:12:00:00")
     dat.interpolate(times=times)
     dt = dat.times[-1] - dat.times[0]
     dt_frac = dt * 100 - round(dt * 100)
@@ -520,7 +519,7 @@ def test_interpolate_time_precision():
 
 
 def _assert_msid_equal(msid1, msid2):
-    for attr in ('tstart', 'tstop', 'datestart', 'datestop', 'units', 'unit', 'stat'):
+    for attr in ("tstart", "tstop", "datestart", "datestop", "units", "unit", "stat"):
         assert getattr(msid1, attr) == getattr(msid2, attr)
     assert np.all(msid1.times == msid2.times)
     assert np.all(msid1.vals == msid2.vals)
@@ -529,7 +528,7 @@ def _assert_msid_equal(msid1, msid2):
 
 def test_msid_copy():
     for MsidClass in (fetch.Msid, fetch.MSID):
-        msid1 = MsidClass('aogbias1', '2008:291:12:00:00', '2008:298:12:00:00')
+        msid1 = MsidClass("aogbias1", "2008:291:12:00:00", "2008:298:12:00:00")
         msid2 = msid1.copy()
         _assert_msid_equal(msid1, msid2)
 
@@ -541,11 +540,11 @@ def test_msid_copy():
 def test_msidset_copy():
     for MsidsetClass in (fetch.MSIDset, fetch.Msidset):
         msidset1 = MsidsetClass(
-            ['aogbias1', 'aogbias2'], '2008:291:12:00:00', '2008:298:12:00:00'
+            ["aogbias1", "aogbias2"], "2008:291:12:00:00", "2008:298:12:00:00"
         )
         msidset2 = msidset1.copy()
 
-        for attr in ('tstart', 'tstop', 'datestart', 'datestop'):
+        for attr in ("tstart", "tstop", "datestart", "datestop"):
             assert getattr(msidset1, attr) == getattr(msidset2, attr)
 
         assert list(msidset1.keys()) == list(msidset2.keys())
@@ -553,16 +552,16 @@ def test_msidset_copy():
             _assert_msid_equal(msidset1[name], msidset2[name])
 
 
-@pytest.mark.skipif(not HAS_MAUDE, reason='MAUDE server not available')
+@pytest.mark.skipif(not HAS_MAUDE, reason="MAUDE server not available")
 def test_msidset_filter_bad():
     """Fetch Msidset from MAUDE where data have different lengths and
     the same "content" (None). This is a test of the fix for #234
     Can't get Msidset with mismatches on shapes of bads. Prior to the
     fix this raised an exception."""
-    msids = ['ACA00110', 'ACA00758']
-    with fetch.data_source('maude allow_subset=False'):
-        dat = fetch.Msidset(msids, '2022:001', '2022:001:00:01:00')
-    assert len(dat['ACA00110'].vals) != len(dat['ACA00758'].vals)
+    msids = ["ACA00110", "ACA00758"]
+    with fetch.data_source("maude allow_subset=False"):
+        dat = fetch.Msidset(msids, "2022:001", "2022:001:00:01:00")
+    assert len(dat["ACA00110"].vals) != len(dat["ACA00758"].vals)
 
 
 def test_MSIDset_interpolate_filtering():
@@ -571,70 +570,70 @@ def test_MSIDset_interpolate_filtering():
     """
     # Bung up some data same as documentation example
     dat = fetch.MSIDset(
-        ['aosares1', 'pitch_fss'], '2010:001:00:00:00', '2010:001:00:00:20'
+        ["aosares1", "pitch_fss"], "2010:001:00:00:00", "2010:001:00:00:20"
     )
-    dat['aosares1'].bads[2] = True
-    dat['pitch_fss'].bads[6] = True
+    dat["aosares1"].bads[2] = True
+    dat["pitch_fss"].bads[6] = True
 
     # Uninterpolated
-    assert np.sum(dat['aosares1'].bads == 1)
-    assert np.sum(dat['pitch_fss'].bads == 1)
-    assert len(dat['aosares1']) == 4
-    assert len(dat['pitch_fss']) == 20
+    assert np.sum(dat["aosares1"].bads == 1)
+    assert np.sum(dat["pitch_fss"].bads == 1)
+    assert len(dat["aosares1"]) == 4
+    assert len(dat["pitch_fss"]) == 20
 
     # False, False
     dati = dat.interpolate(dt=0.5, filter_bad=False, bad_union=False, copy=True)
 
-    assert np.sum(dati['aosares1'].bads) == 8
-    assert np.sum(dati['pitch_fss'].bads) == 2
-    assert len(dati['aosares1']) == 25
-    assert len(dati['pitch_fss']) == 25
+    assert np.sum(dati["aosares1"].bads) == 8
+    assert np.sum(dati["pitch_fss"].bads) == 2
+    assert len(dati["aosares1"]) == 25
+    assert len(dati["pitch_fss"]) == 25
 
     # False, True
     dati = dat.interpolate(dt=0.5, filter_bad=False, bad_union=True, copy=True)
 
-    assert np.sum(dati['aosares1'].bads) == 10  # same as below
-    assert np.sum(dati['pitch_fss'].bads) == 10
-    assert len(dati['aosares1']) == 25
-    assert len(dati['pitch_fss']) == 25
+    assert np.sum(dati["aosares1"].bads) == 10  # same as below
+    assert np.sum(dati["pitch_fss"].bads) == 10
+    assert len(dati["aosares1"]) == 25
+    assert len(dati["pitch_fss"]) == 25
 
     # True, False (default settings) returns all interpolated time samples
     dati = dat.interpolate(dt=0.5, filter_bad=True, bad_union=False, copy=True)
 
-    assert np.sum(dati['aosares1'].bads) is None  # same as below
-    assert np.sum(dati['pitch_fss'].bads) is None
-    assert len(dati['aosares1']) == 25
-    assert len(dati['pitch_fss']) == 25
+    assert np.sum(dati["aosares1"].bads) is None  # same as below
+    assert np.sum(dati["pitch_fss"].bads) is None
+    assert len(dati["aosares1"]) == 25
+    assert len(dati["pitch_fss"]) == 25
 
     # True, True returns only good (in union sense) interpolated time samples
     # so 25 - 10 bad samples = 15
     dati = dat.interpolate(dt=0.5, filter_bad=True, bad_union=True, copy=True)
 
-    assert np.sum(dati['aosares1'].bads) is None  # same as below
-    assert np.sum(dati['pitch_fss'].bads) is None
-    assert len(dati['aosares1']) == 15
-    assert len(dati['pitch_fss']) == 15
+    assert np.sum(dati["aosares1"].bads) is None  # same as below
+    assert np.sum(dati["pitch_fss"].bads) is None
+    assert len(dati["aosares1"]) == 15
+    assert len(dati["pitch_fss"]) == 15
 
     # Finally test that copy works (dat didn't change)
-    assert np.sum(dat['aosares1'].bads) == 1
-    assert np.sum(dat['pitch_fss'].bads) == 1
-    assert len(dat['aosares1']) == 4
-    assert len(dat['pitch_fss']) == 20
+    assert np.sum(dat["aosares1"].bads) == 1
+    assert np.sum(dat["pitch_fss"].bads) == 1
+    assert len(dat["aosares1"]) == 4
+    assert len(dat["pitch_fss"]) == 20
 
 
 def test_1999_fetch():
     for start, stop in (
-        ('1999:363:00:00:00', '2000:005:00:00:00'),  # Covering deadband
-        ('1999:363:00:00:00', '2000:002:00:00:00'),  # Stop within deadband
-        ('2000:002:00:00:00', '2000:004:00:00:00'),  # Start within deadband
-        ('1999:360:00:00:00', '1999:361:00:00:00'),
+        ("1999:363:00:00:00", "2000:005:00:00:00"),  # Covering deadband
+        ("1999:363:00:00:00", "2000:002:00:00:00"),  # Stop within deadband
+        ("2000:002:00:00:00", "2000:004:00:00:00"),  # Start within deadband
+        ("1999:360:00:00:00", "1999:361:00:00:00"),
     ):  # 1999 before deadband
-        dat = fetch.MSID('aopcadmd', start, stop)
+        dat = fetch.MSID("aopcadmd", start, stop)
         assert np.allclose(np.diff(dat.times), 1.025, atol=0.01)
 
-        dat = fetch.MSIDset(['aopcadmd', 'aoattqt1'], start, stop)
-        assert np.allclose(np.diff(dat['aopcadmd'].times), 1.025, atol=0.01)
-        assert np.allclose(np.diff(dat['aoattqt1'].times), 1.025, atol=0.01)
+        dat = fetch.MSIDset(["aopcadmd", "aoattqt1"], start, stop)
+        assert np.allclose(np.diff(dat["aopcadmd"].times), 1.025, atol=0.01)
+        assert np.allclose(np.diff(dat["aoattqt1"].times), 1.025, atol=0.01)
 
 
 def test_intervals_fetch_unit():
@@ -642,35 +641,35 @@ def test_intervals_fetch_unit():
     Test that fetches with multiple intervals get the units right
     """
     dat = fetch_eng.Msid(
-        'tephin',
+        "tephin",
         [
-            ('1999:350:12:00:00', '1999:355:12:00:00'),
-            ('2000:010:12:00:00', '2000:015:12:00:00'),
+            ("1999:350:12:00:00", "1999:355:12:00:00"),
+            ("2000:010:12:00:00", "2000:015:12:00:00"),
         ],
     )
     assert np.allclose(np.mean(dat.vals), 41.713467)
 
     dat = fetch_eng.Msid(
-        'tephin',
+        "tephin",
         [
-            ('1999:350:12:00:00', '1999:355:12:00:00'),
-            ('2000:010:12:00:00', '2000:015:12:00:00'),
+            ("1999:350:12:00:00", "1999:355:12:00:00"),
+            ("2000:010:12:00:00", "2000:015:12:00:00"),
         ],
-        stat='5min',
+        stat="5min",
     )
     assert np.allclose(np.mean(dat.vals), 40.290966)
 
     dat = fetch_eng.Msid(
-        'tephin',
+        "tephin",
         [
-            ('1999:350:12:00:00', '1999:355:12:00:00'),
-            ('2000:010:12:00:00', '2000:015:12:00:00'),
+            ("1999:350:12:00:00", "1999:355:12:00:00"),
+            ("2000:010:12:00:00", "2000:015:12:00:00"),
         ],
-        stat='daily',
+        stat="daily",
     )
     assert np.allclose(np.mean(dat.vals), 40.303955)
 
-    dat = fetch_eng.Msid('tephin', '1999:350:12:00:00', '2000:010:12:00:00')
+    dat = fetch_eng.Msid("tephin", "1999:350:12:00:00", "2000:010:12:00:00")
     assert np.allclose(np.mean(dat.vals), 41.646729)
 
 
@@ -679,30 +678,30 @@ def test_ctu_dwell_telem():
     Ensure that bad values are filtered appropriately for dwell mode telem.
     This
     """
-    dat = fetch_eng.Msid('dwell01', '2015:294:12:00:00', '2015:295:12:00:00')
+    dat = fetch_eng.Msid("dwell01", "2015:294:12:00:00", "2015:295:12:00:00")
     assert np.all(dat.vals < 190)
     assert np.all(dat.vals > 150)
 
-    dat = fetch_eng.Msid('airu1bt', '2015:294:12:00:00', '2015:295:12:00:00')
+    dat = fetch_eng.Msid("airu1bt", "2015:294:12:00:00", "2015:295:12:00:00")
     assert np.all(dat.vals < -4.95)
     assert np.all(dat.vals > -5.05)
 
 
 def test_nonexistent_msids():
     with pytest.raises(ValueError) as err:
-        fetch.Msid('asdfasdfasdfasdf', '2015:001:12:00:00', '2015:002:12:00:00')
+        fetch.Msid("asdfasdfasdfasdf", "2015:001:12:00:00", "2015:002:12:00:00")
     assert "MSID 'asdfasdfasdfasdf' is not" in str(err.value)
 
 
 def test_daily_state_bins():
-    dat = fetch.Msid('aoacaseq', '2016:232:12:00:00', '2016:235:12:00:00', stat='daily')
+    dat = fetch.Msid("aoacaseq", "2016:232:12:00:00", "2016:235:12:00:00", stat="daily")
     for attr, val in (
-        ('n_BRITs', [0, 136, 0]),
-        ('n_KALMs', [83994, 83812, 83996]),
-        ('n_AQXNs', [159, 240, 113]),
-        ('n_GUIDs', [140, 104, 184]),
+        ("n_BRITs", [0, 136, 0]),
+        ("n_KALMs", [83994, 83812, 83996]),
+        ("n_AQXNs", [159, 240, 113]),
+        ("n_GUIDs", [140, 104, 184]),
     ):
         assert np.all(getattr(dat, attr) == val)
 
-    dat = fetch.Msid('aoacaseq', '2016:234:12:00:00', '2016:234:12:30:00', stat='5min')
+    dat = fetch.Msid("aoacaseq", "2016:234:12:00:00", "2016:234:12:30:00", stat="5min")
     assert np.all(dat.n_BRITs == [0, 0, 51, 17, 0, 0])

--- a/Ska/engarchive/tests/test_intervals.py
+++ b/Ska/engarchive/tests/test_intervals.py
@@ -38,14 +38,14 @@ def test_fetch_MSID_intervals():
     fetching over the time range and selecting <some intervals>.
     """
     # Interval with a bad quality point around 2012:175:02:10:021.981
-    start, stop = '2012:175:02:00:00', '2012:175:03:00:00'
+    start, stop = "2012:175:02:00:00", "2012:175:03:00:00"
     for filter_bad in (True, False):
-        for stat in (None, '5min'):
-            dat = fetch.MSID('tephin', start, stop, filter_bad=filter_bad, stat=stat)
+        for stat in (None, "5min"):
+            dat = fetch.MSID("tephin", start, stop, filter_bad=filter_bad, stat=stat)
             dat.select_intervals(kadi.events.dwells)
 
             dat2 = fetch.MSID(
-                'tephin',
+                "tephin",
                 kadi.events.dwells.intervals(start, stop),
                 filter_bad=filter_bad,
                 stat=stat,
@@ -64,10 +64,10 @@ def test_fetch_MSIDset_intervals():
     fetching over the time range and selecting <some intervals>.
     """
     # Interval with a bad quality point around 2012:175:02:10:021.981
-    start, stop = '2012:175:02:00:00', '2012:175:03:00:00'
-    msids = ['tephin', 'aopcadmd']
+    start, stop = "2012:175:02:00:00", "2012:175:03:00:00"
+    msids = ["tephin", "aopcadmd"]
     for filter_bad in (True, False):
-        for stat in (None, '5min'):
+        for stat in (None, "5min"):
             dat = fetch.MSIDset(msids, start, stop, filter_bad=filter_bad, stat=stat)
             for msid in msids:
                 dat[msid].select_intervals(kadi.events.dwells)
@@ -96,8 +96,8 @@ def test_select_remove_interval():
     The latter is obtained from kadi.events.dwells.intervals, but this is the same format
     as the output from logical_intervals().
     """
-    start, stop = '2012:002:02:00:00', '2012:002:04:00:00'
-    dat = fetch.MSID('tephin', start, stop)
+    start, stop = "2012:002:02:00:00", "2012:002:04:00:00"
+    dat = fetch.MSID("tephin", start, stop)
     intervals = kadi.events.dwells.intervals(start, stop)
     for filt in (kadi.events.dwells, intervals):
         dat_r = dat.remove_intervals(filt, copy=True)
@@ -108,12 +108,12 @@ def test_select_remove_interval():
         assert len(dat_s) == 168
         dates_r = DateTime(dat_r.times).date
         assert (
-            dates_r[0] == '2012:002:02:49:39.317'
+            dates_r[0] == "2012:002:02:49:39.317"
         )  # First after '2012:002:02:49:27.017'
-        assert dates_r[15] == '2012:002:02:57:51.317'  # Gap '2012:002:02:58:11.817'
-        assert dates_r[16] == '2012:002:03:04:57.717'  # to '2012:002:03:04:39.267'
+        assert dates_r[15] == "2012:002:02:57:51.317"  # Gap '2012:002:02:58:11.817'
+        assert dates_r[16] == "2012:002:03:04:57.717"  # to '2012:002:03:04:39.267'
         assert (
-            dates_r[50] == '2012:002:03:23:32.917'
+            dates_r[50] == "2012:002:03:23:32.917"
         )  # last before '2012:002:03:23:45.217'
         assert set(dat_r.times).isdisjoint(dat_s.times)
 
@@ -124,8 +124,8 @@ def test_remove_subclassed_eventquery_interval():
     Test remove intervals functionality with an EventQuery subclass
     (LttBadsEventQuery).
     """
-    start, stop = '2010:002:02:00:00', '2013:002:04:00:00'
-    dat = fetch.MSID('tephin', start, stop, stat='daily')
+    start, stop = "2010:002:02:00:00", "2013:002:04:00:00"
+    dat = fetch.MSID("tephin", start, stop, stat="daily")
     assert len(dat) == 1096
     dat.remove_intervals(kadi.events.ltt_bads)
     assert len(dat) == 1026
@@ -133,27 +133,27 @@ def test_remove_subclassed_eventquery_interval():
 
 @pytest.mark.skipif("not HAS_EVENTS")
 def test_remove_intervals_stat():
-    start, stop = '2012:002:12:00:00', '2012:003:12:00:00'
-    for stat in (None, '5min'):
+    start, stop = "2012:002:12:00:00", "2012:003:12:00:00"
+    for stat in (None, "5min"):
         intervals = kadi.events.dwells.intervals(start, stop)
         for filt in (kadi.events.dwells, intervals):
-            dat = fetch.MSID('tephin', start, stop)
+            dat = fetch.MSID("tephin", start, stop)
             dat.remove_intervals(filt)
             attrs = [
                 attr
                 for attr in (
-                    'vals',
-                    'mins',
-                    'maxes',
-                    'means',
-                    'p01s',
-                    'p05s',
-                    'p16s',
-                    'p50s',
-                    'p84s',
-                    'p95s',
-                    'p99s',
-                    'midvals',
+                    "vals",
+                    "mins",
+                    "maxes",
+                    "means",
+                    "p01s",
+                    "p05s",
+                    "p16s",
+                    "p50s",
+                    "p84s",
+                    "p95s",
+                    "p99s",
+                    "midvals",
                 )
                 if hasattr(dat, attr)
             ]
@@ -167,7 +167,7 @@ def test_select_remove_all_interval():
     """
     Select or remove all data points via an event that entirely spans the MSID data.
     """
-    dat = fetch.Msid('tephin', '2012:001:20:00:00', '2012:001:21:00:00')
+    dat = fetch.Msid("tephin", "2012:001:20:00:00", "2012:001:21:00:00")
     dat_r = dat.remove_intervals(kadi.events.dwells, copy=True)
     dat_s = dat.select_intervals(kadi.events.dwells, copy=True)
     assert len(dat) == 110
@@ -179,24 +179,24 @@ def test_msid_logical_intervals():
     """
     Test MSID.logical_intervals()
     """
-    dat = fetch.Msid('aopcadmd', '2013:001:00:00:00', '2013:001:02:00:00')
+    dat = fetch.Msid("aopcadmd", "2013:001:00:00:00", "2013:001:02:00:00")
 
     # default complete_intervals=True
-    intervals = dat.logical_intervals('==', 'NPNT')
+    intervals = dat.logical_intervals("==", "NPNT")
     assert len(intervals) == 1
-    assert np.all(intervals['datestart'] == ['2013:001:01:03:37.032'])
-    assert np.all(intervals['datestop'] == ['2013:001:01:26:13.107'])
+    assert np.all(intervals["datestart"] == ["2013:001:01:03:37.032"])
+    assert np.all(intervals["datestop"] == ["2013:001:01:26:13.107"])
 
     # Now with incomplete intervals on each end
-    intervals = dat.logical_intervals('==', 'NPNT', complete_intervals=False)
+    intervals = dat.logical_intervals("==", "NPNT", complete_intervals=False)
     assert len(intervals) == 3
     assert np.all(
-        intervals['datestart']
-        == ['2012:366:23:59:59.932', '2013:001:01:03:37.032', '2013:001:01:59:06.233']
+        intervals["datestart"]
+        == ["2012:366:23:59:59.932", "2013:001:01:03:37.032", "2013:001:01:59:06.233"]
     )
     assert np.all(
-        intervals['datestop']
-        == ['2013:001:00:56:07.057', '2013:001:01:26:13.107', '2013:001:01:59:59.533']
+        intervals["datestop"]
+        == ["2013:001:00:56:07.057", "2013:001:01:26:13.107", "2013:001:01:59:59.533"]
     )
 
 
@@ -205,22 +205,22 @@ def test_util_logical_intervals():
     Test utils.logical_intervals()
     """
     dat = fetch.Msidset(
-        ['3tscmove', 'aorwbias', 'coradmen'], '2012:190:12:00:00', '2012:205:12:00:00'
+        ["3tscmove", "aorwbias", "coradmen"], "2012:190:12:00:00", "2012:205:12:00:00"
     )
     dat.interpolate(32.8)  # Sample MSIDs onto 32.8 second intervals (like 3TSCMOVE)
     scs107 = (
-        (dat['3tscmove'].vals == 'T')
-        & (dat['aorwbias'].vals == 'DISA')
-        & (dat['coradmen'].vals == 'DISA')
+        (dat["3tscmove"].vals == "T")
+        & (dat["aorwbias"].vals == "DISA")
+        & (dat["coradmen"].vals == "DISA")
     )
     scs107s = utils.logical_intervals(dat.times, scs107)
-    scs107s['duration'].format = '{:.1f}'
-    assert scs107s['datestart', 'datestop', 'duration'].pformat() == [
-        '      datestart              datestop       duration',
-        '--------------------- --------------------- --------',
-        '2012:194:20:00:48.052 2012:194:20:04:37.652    229.6',
-        '2012:196:21:07:52.852 2012:196:21:11:42.452    229.6',
-        '2012:201:11:46:03.252 2012:201:11:49:52.852    229.6',
+    scs107s["duration"].format = "{:.1f}"
+    assert scs107s["datestart", "datestop", "duration"].pformat() == [
+        "      datestart              datestop       duration",
+        "--------------------- --------------------- --------",
+        "2012:194:20:00:48.052 2012:194:20:04:37.652    229.6",
+        "2012:196:21:07:52.852 2012:196:21:11:42.452    229.6",
+        "2012:201:11:46:03.252 2012:201:11:49:52.852    229.6",
     ]
 
 
@@ -231,12 +231,12 @@ def test_util_logical_intervals_gap():
     times = np.array([1, 2, 3, 200, 201, 202])
     bools = np.ones(len(times), dtype=bool)
     out = utils.logical_intervals(times, bools, complete_intervals=False, max_gap=10)
-    assert np.allclose(out['tstart'], [0.5, 197.5])
-    assert np.allclose(out['tstop'], [5.5, 202.5])
+    assert np.allclose(out["tstart"], [0.5, 197.5])
+    assert np.allclose(out["tstop"], [5.5, 202.5])
 
     out = utils.logical_intervals(times, bools, complete_intervals=False)
-    assert np.allclose(out['tstart'], [0.5])
-    assert np.allclose(out['tstop'], [202.5])
+    assert np.allclose(out["tstart"], [0.5])
+    assert np.allclose(out["tstop"], [202.5])
 
 
 def test_msid_state_intervals():
@@ -244,20 +244,20 @@ def test_msid_state_intervals():
     Test MSID.state_intervals() - basic aliveness and regression test
     """
     expected = [
-        '      datestart              datestop       val ',
-        '--------------------- --------------------- ----',
-        '2012:366:23:59:59.932 2013:001:00:56:07.057 NPNT',
-        '2013:001:00:56:07.057 2013:001:01:03:37.032 NMAN',
-        '2013:001:01:03:37.032 2013:001:01:26:13.107 NPNT',
-        '2013:001:01:26:13.107 2013:001:01:59:06.233 NMAN',
-        '2013:001:01:59:06.233 2013:001:01:59:59.533 NPNT',
+        "      datestart              datestop       val ",
+        "--------------------- --------------------- ----",
+        "2012:366:23:59:59.932 2013:001:00:56:07.057 NPNT",
+        "2013:001:00:56:07.057 2013:001:01:03:37.032 NMAN",
+        "2013:001:01:03:37.032 2013:001:01:26:13.107 NPNT",
+        "2013:001:01:26:13.107 2013:001:01:59:06.233 NMAN",
+        "2013:001:01:59:06.233 2013:001:01:59:59.533 NPNT",
     ]
 
-    dat = fetch.Msid('aopcadmd', '2013:001:00:00:00', '2013:001:02:00:00')
-    intervals = dat.state_intervals()['datestart', 'datestop', 'val']
+    dat = fetch.Msid("aopcadmd", "2013:001:00:00:00", "2013:001:02:00:00")
+    intervals = dat.state_intervals()["datestart", "datestop", "val"]
     assert intervals.pformat() == expected
 
     intervals = utils.state_intervals(dat.times, dat.vals)[
-        'datestart', 'datestop', 'val'
+        "datestart", "datestop", "val"
     ]
     assert intervals.pformat() == expected

--- a/Ska/engarchive/tests/test_intervals.py
+++ b/Ska/engarchive/tests/test_intervals.py
@@ -7,6 +7,7 @@ from .. import fetch, utils
 
 try:
     import kadi.events
+
     HAS_EVENTS = True
 except ImportError:
     HAS_EVENTS = False
@@ -43,8 +44,12 @@ def test_fetch_MSID_intervals():
             dat = fetch.MSID('tephin', start, stop, filter_bad=filter_bad, stat=stat)
             dat.select_intervals(kadi.events.dwells)
 
-            dat2 = fetch.MSID('tephin', kadi.events.dwells.intervals(start, stop),
-                              filter_bad=filter_bad, stat=stat)
+            dat2 = fetch.MSID(
+                'tephin',
+                kadi.events.dwells.intervals(start, stop),
+                filter_bad=filter_bad,
+                stat=stat,
+            )
 
             assert np.all(dat.bads == dat2.bads)
             assert dat.colnames == dat2.colnames
@@ -67,8 +72,12 @@ def test_fetch_MSIDset_intervals():
             for msid in msids:
                 dat[msid].select_intervals(kadi.events.dwells)
 
-            dat2 = fetch.MSIDset(msids, kadi.events.dwells.intervals(start, stop),
-                                 filter_bad=filter_bad, stat=stat)
+            dat2 = fetch.MSIDset(
+                msids,
+                kadi.events.dwells.intervals(start, stop),
+                filter_bad=filter_bad,
+                stat=stat,
+            )
 
             for msid in msids:
                 dm = dat[msid]
@@ -98,10 +107,14 @@ def test_select_remove_interval():
         assert len(dat_r) == 51
         assert len(dat_s) == 168
         dates_r = DateTime(dat_r.times).date
-        assert dates_r[0] == '2012:002:02:49:39.317'  # First after '2012:002:02:49:27.017'
+        assert (
+            dates_r[0] == '2012:002:02:49:39.317'
+        )  # First after '2012:002:02:49:27.017'
         assert dates_r[15] == '2012:002:02:57:51.317'  # Gap '2012:002:02:58:11.817'
         assert dates_r[16] == '2012:002:03:04:57.717'  # to '2012:002:03:04:39.267'
-        assert dates_r[50] == '2012:002:03:23:32.917'  # last before '2012:002:03:23:45.217'
+        assert (
+            dates_r[50] == '2012:002:03:23:32.917'
+        )  # last before '2012:002:03:23:45.217'
         assert set(dat_r.times).isdisjoint(dat_s.times)
 
 
@@ -126,10 +139,24 @@ def test_remove_intervals_stat():
         for filt in (kadi.events.dwells, intervals):
             dat = fetch.MSID('tephin', start, stop)
             dat.remove_intervals(filt)
-            attrs = [attr for attr in ('vals', 'mins', 'maxes', 'means',
-                                       'p01s', 'p05s', 'p16s', 'p50s',
-                                       'p84s', 'p95s', 'p99s', 'midvals')
-                     if hasattr(dat, attr)]
+            attrs = [
+                attr
+                for attr in (
+                    'vals',
+                    'mins',
+                    'maxes',
+                    'means',
+                    'p01s',
+                    'p05s',
+                    'p16s',
+                    'p50s',
+                    'p84s',
+                    'p95s',
+                    'p99s',
+                    'midvals',
+                )
+                if hasattr(dat, attr)
+            ]
 
         for attr in attrs:
             assert len(dat) == len(getattr(dat, attr))
@@ -163,32 +190,38 @@ def test_msid_logical_intervals():
     # Now with incomplete intervals on each end
     intervals = dat.logical_intervals('==', 'NPNT', complete_intervals=False)
     assert len(intervals) == 3
-    assert np.all(intervals['datestart'] == ['2012:366:23:59:59.932',
-                                             '2013:001:01:03:37.032',
-                                             '2013:001:01:59:06.233'])
-    assert np.all(intervals['datestop'] == ['2013:001:00:56:07.057',
-                                            '2013:001:01:26:13.107',
-                                            '2013:001:01:59:59.533'])
+    assert np.all(
+        intervals['datestart']
+        == ['2012:366:23:59:59.932', '2013:001:01:03:37.032', '2013:001:01:59:06.233']
+    )
+    assert np.all(
+        intervals['datestop']
+        == ['2013:001:00:56:07.057', '2013:001:01:26:13.107', '2013:001:01:59:59.533']
+    )
 
 
 def test_util_logical_intervals():
     """
     Test utils.logical_intervals()
     """
-    dat = fetch.Msidset(['3tscmove', 'aorwbias', 'coradmen'],
-                        '2012:190:12:00:00', '2012:205:12:00:00')
+    dat = fetch.Msidset(
+        ['3tscmove', 'aorwbias', 'coradmen'], '2012:190:12:00:00', '2012:205:12:00:00'
+    )
     dat.interpolate(32.8)  # Sample MSIDs onto 32.8 second intervals (like 3TSCMOVE)
-    scs107 = ((dat['3tscmove'].vals == 'T')
-              & (dat['aorwbias'].vals == 'DISA')
-              & (dat['coradmen'].vals == 'DISA'))
+    scs107 = (
+        (dat['3tscmove'].vals == 'T')
+        & (dat['aorwbias'].vals == 'DISA')
+        & (dat['coradmen'].vals == 'DISA')
+    )
     scs107s = utils.logical_intervals(dat.times, scs107)
     scs107s['duration'].format = '{:.1f}'
-    assert (scs107s['datestart', 'datestop', 'duration'].pformat() ==
-            ['      datestart              datestop       duration',
-             '--------------------- --------------------- --------',
-             '2012:194:20:00:48.052 2012:194:20:04:37.652    229.6',
-             '2012:196:21:07:52.852 2012:196:21:11:42.452    229.6',
-             '2012:201:11:46:03.252 2012:201:11:49:52.852    229.6'])
+    assert scs107s['datestart', 'datestop', 'duration'].pformat() == [
+        '      datestart              datestop       duration',
+        '--------------------- --------------------- --------',
+        '2012:194:20:00:48.052 2012:194:20:04:37.652    229.6',
+        '2012:196:21:07:52.852 2012:196:21:11:42.452    229.6',
+        '2012:201:11:46:03.252 2012:201:11:49:52.852    229.6',
+    ]
 
 
 def test_util_logical_intervals_gap():
@@ -210,17 +243,21 @@ def test_msid_state_intervals():
     """
     Test MSID.state_intervals() - basic aliveness and regression test
     """
-    expected = ['      datestart              datestop       val ',
-                '--------------------- --------------------- ----',
-                '2012:366:23:59:59.932 2013:001:00:56:07.057 NPNT',
-                '2013:001:00:56:07.057 2013:001:01:03:37.032 NMAN',
-                '2013:001:01:03:37.032 2013:001:01:26:13.107 NPNT',
-                '2013:001:01:26:13.107 2013:001:01:59:06.233 NMAN',
-                '2013:001:01:59:06.233 2013:001:01:59:59.533 NPNT']
+    expected = [
+        '      datestart              datestop       val ',
+        '--------------------- --------------------- ----',
+        '2012:366:23:59:59.932 2013:001:00:56:07.057 NPNT',
+        '2013:001:00:56:07.057 2013:001:01:03:37.032 NMAN',
+        '2013:001:01:03:37.032 2013:001:01:26:13.107 NPNT',
+        '2013:001:01:26:13.107 2013:001:01:59:06.233 NMAN',
+        '2013:001:01:59:06.233 2013:001:01:59:59.533 NPNT',
+    ]
 
     dat = fetch.Msid('aopcadmd', '2013:001:00:00:00', '2013:001:02:00:00')
     intervals = dat.state_intervals()['datestart', 'datestop', 'val']
     assert intervals.pformat() == expected
 
-    intervals = utils.state_intervals(dat.times, dat.vals)['datestart', 'datestop', 'val']
+    intervals = utils.state_intervals(dat.times, dat.vals)[
+        'datestart', 'datestop', 'val'
+    ]
     assert intervals.pformat() == expected

--- a/Ska/engarchive/tests/test_intervals.py
+++ b/Ska/engarchive/tests/test_intervals.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 import pytest
-
 from Chandra.Time import DateTime
+
 from .. import fetch, utils
 
 try:

--- a/Ska/engarchive/tests/test_orbit.py
+++ b/Ska/engarchive/tests/test_orbit.py
@@ -22,13 +22,15 @@ def test_orbital_elements():
 
     out = orbit.calc_orbital_elements(x, y, z, vx, vy, vz)
 
-    expected = {'semi_major_axis': 7310.8163e3,
-                'orbit_period': 103.68323 * 60,
-                'eccentricity': 0.015985887,
-                'inclination': 71.048202,
-                'ascending_node': 211.28377,
-                'argument_perigee': 137.7561049,  # 137.75619 in reference (roundoff in example)
-                'mean_anomaly': 354.971325}  # 354.9724 in reference (roundoff in example)
+    expected = {
+        'semi_major_axis': 7310.8163e3,
+        'orbit_period': 103.68323 * 60,
+        'eccentricity': 0.015985887,
+        'inclination': 71.048202,
+        'ascending_node': 211.28377,
+        'argument_perigee': 137.7561049,  # 137.75619 in reference (roundoff in example)
+        'mean_anomaly': 354.971325,
+    }  # 354.9724 in reference (roundoff in example)
 
     for key in expected:
         assert np.allclose(out[key], expected[key], atol=0.0, rtol=1e-6)

--- a/Ska/engarchive/tests/test_orbit.py
+++ b/Ska/engarchive/tests/test_orbit.py
@@ -23,13 +23,13 @@ def test_orbital_elements():
     out = orbit.calc_orbital_elements(x, y, z, vx, vy, vz)
 
     expected = {
-        'semi_major_axis': 7310.8163e3,
-        'orbit_period': 103.68323 * 60,
-        'eccentricity': 0.015985887,
-        'inclination': 71.048202,
-        'ascending_node': 211.28377,
-        'argument_perigee': 137.7561049,  # 137.75619 in reference (roundoff in example)
-        'mean_anomaly': 354.971325,
+        "semi_major_axis": 7310.8163e3,
+        "orbit_period": 103.68323 * 60,
+        "eccentricity": 0.015985887,
+        "inclination": 71.048202,
+        "ascending_node": 211.28377,
+        "argument_perigee": 137.7561049,  # 137.75619 in reference (roundoff in example)
+        "mean_anomaly": 354.971325,
     }  # 354.9724 in reference (roundoff in example)
 
     for key in expected:

--- a/Ska/engarchive/tests/test_remote_access.py
+++ b/Ska/engarchive/tests/test_remote_access.py
@@ -79,10 +79,10 @@ from astropy.utils.exceptions import AstropyUserWarning
 
 from Ska.engarchive.remote_access import get_data_access_info
 
-INVALID_DIR = str(Path(__file__).parent / '__non_existent_invalid_directory____')
+INVALID_DIR = str(Path(__file__).parent / "__non_existent_invalid_directory____")
 
 ORIG_ENV = {
-    name: os.getenv(name) for name in ('SKA', 'ENG_ARCHIVE', 'SKA_ACCESS_REMOTELY')
+    name: os.getenv(name) for name in ("SKA", "ENG_ARCHIVE", "SKA_ACCESS_REMOTELY")
 }
 
 
@@ -102,13 +102,13 @@ def remote_setup_dirs(tmpdir):
     :param tmpdir: temp directory supplied by pytest
     """
     ska_dir = Path(tmpdir)
-    eng_archive_dir = ska_dir / 'data' / 'eng_archive'
-    (eng_archive_dir / 'data').mkdir(parents=True)
+    eng_archive_dir = ska_dir / "data" / "eng_archive"
+    (eng_archive_dir / "data").mkdir(parents=True)
 
     yield (ska_dir, eng_archive_dir)
 
     # Teardown: return environment to original
-    for name in 'SKA', 'ENG_ARCHIVE', 'SKA_ACCESS_REMOTELY':
+    for name in "SKA", "ENG_ARCHIVE", "SKA_ACCESS_REMOTELY":
         setenv(name, ORIG_ENV[name])
 
     shutil.rmtree(tmpdir)
@@ -119,13 +119,13 @@ def test_remote_access_get_data_access_info1(remote_setup_dirs):
     Unit test of the get_data_access_info() function with no env vars set.
     """
     # No env vars set
-    setenv('SKA', None)
-    setenv('ENG_ARCHIVE', None)  # I.e. not set
-    setenv('SKA_ACCESS_REMOTELY', None)
+    setenv("SKA", None)
+    setenv("ENG_ARCHIVE", None)  # I.e. not set
+    setenv("SKA_ACCESS_REMOTELY", None)
 
     # Windows
     eng_archive, ska_access_remotely = get_data_access_info(is_windows=True)
-    assert eng_archive == '/proj/sot/ska/data/eng_archive'
+    assert eng_archive == "/proj/sot/ska/data/eng_archive"
     assert ska_access_remotely is True
 
     # Not windows
@@ -141,9 +141,9 @@ def test_remote_access_get_data_access_info2(remote_setup_dirs):
     """
     ska_dir, eng_archive_dir = remote_setup_dirs
 
-    setenv('SKA', ska_dir)
-    setenv('ENG_ARCHIVE', None)  # I.e. not set
-    setenv('SKA_ACCESS_REMOTELY', None)
+    setenv("SKA", ska_dir)
+    setenv("ENG_ARCHIVE", None)  # I.e. not set
+    setenv("SKA_ACCESS_REMOTELY", None)
     for is_windows in True, False:
         eng_archive, ska_access_remotely = get_data_access_info(is_windows)
         assert eng_archive == str(eng_archive_dir.absolute())
@@ -158,9 +158,9 @@ def test_remote_access_get_data_access_info3(remote_setup_dirs):
     ska_dir, eng_archive_dir = remote_setup_dirs
 
     for ska_env in None, INVALID_DIR:
-        setenv('SKA', ska_env)
-        setenv('ENG_ARCHIVE', eng_archive_dir)
-        setenv('SKA_ACCESS_REMOTELY', None)
+        setenv("SKA", ska_env)
+        setenv("ENG_ARCHIVE", eng_archive_dir)
+        setenv("SKA_ACCESS_REMOTELY", None)
         for is_windows in True, False:
             eng_archive, ska_access_remotely = get_data_access_info(is_windows)
             assert eng_archive == str(eng_archive_dir.absolute())
@@ -171,20 +171,20 @@ def test_remote_access_get_data_access_info4(remote_setup_dirs):
     """
     ENG_ARCHIVE set to a non-existent directory
     """
-    setenv('SKA', None)
-    setenv('ENG_ARCHIVE', INVALID_DIR)
-    setenv('SKA_ACCESS_REMOTELY', None)
+    setenv("SKA", None)
+    setenv("ENG_ARCHIVE", INVALID_DIR)
+    setenv("SKA_ACCESS_REMOTELY", None)
 
     # Windows doesn't care about an invalid ENG_ARCHIVE, goes to remote access
     # with hardwired /proj/sot/ska root for remote data.
     eng_archive, ska_access_remotely = get_data_access_info(is_windows=True)
-    assert eng_archive == '/proj/sot/ska/data/eng_archive'
+    assert eng_archive == "/proj/sot/ska/data/eng_archive"
     assert ska_access_remotely is True
 
     # Not windows: raises RuntimeError because no local data around found
     with pytest.warns(
         AstropyUserWarning,
-        match='no local Ska data found and remote access is not selected',
+        match="no local Ska data found and remote access is not selected",
     ):
         get_data_access_info(is_windows=False)
 
@@ -195,14 +195,14 @@ def test_remote_access_get_data_access_info5(remote_setup_dirs):
 
     Raises RuntimeError on windows and not-windows.
     """
-    setenv('SKA', None)
-    setenv('ENG_ARCHIVE', None)
-    setenv('SKA_ACCESS_REMOTELY', False)
+    setenv("SKA", None)
+    setenv("ENG_ARCHIVE", None)
+    setenv("SKA_ACCESS_REMOTELY", False)
 
     for is_windows in True, False:
         with pytest.warns(
             AstropyUserWarning,
-            match='need to define SKA or ENG_ARCHIVE environment variable',
+            match="need to define SKA or ENG_ARCHIVE environment variable",
         ):
             out = get_data_access_info(is_windows)
         assert out == (None, False)
@@ -214,11 +214,11 @@ def test_remote_access_get_data_access_info6(remote_setup_dirs):
     """
     ska_dir, eng_archive_dir = remote_setup_dirs
 
-    setenv('SKA', ska_dir)
-    setenv('ENG_ARCHIVE', None)  # I.e. not set
-    setenv('SKA_ACCESS_REMOTELY', 'True')
+    setenv("SKA", ska_dir)
+    setenv("ENG_ARCHIVE", None)  # I.e. not set
+    setenv("SKA_ACCESS_REMOTELY", "True")
 
     for is_windows in True, False:
         eng_archive, ska_access_remotely = get_data_access_info(is_windows)
-        assert eng_archive == '/proj/sot/ska/data/eng_archive'
+        assert eng_archive == "/proj/sot/ska/data/eng_archive"
         assert ska_access_remotely is True

--- a/Ska/engarchive/tests/test_remote_access.py
+++ b/Ska/engarchive/tests/test_remote_access.py
@@ -81,8 +81,9 @@ from Ska.engarchive.remote_access import get_data_access_info
 
 INVALID_DIR = str(Path(__file__).parent / '__non_existent_invalid_directory____')
 
-ORIG_ENV = {name: os.getenv(name)
-            for name in ('SKA', 'ENG_ARCHIVE', 'SKA_ACCESS_REMOTELY')}
+ORIG_ENV = {
+    name: os.getenv(name) for name in ('SKA', 'ENG_ARCHIVE', 'SKA_ACCESS_REMOTELY')
+}
 
 
 def setenv(name, val):
@@ -181,8 +182,10 @@ def test_remote_access_get_data_access_info4(remote_setup_dirs):
     assert ska_access_remotely is True
 
     # Not windows: raises RuntimeError because no local data around found
-    with pytest.warns(AstropyUserWarning,
-                      match='no local Ska data found and remote access is not selected'):
+    with pytest.warns(
+        AstropyUserWarning,
+        match='no local Ska data found and remote access is not selected',
+    ):
         get_data_access_info(is_windows=False)
 
 
@@ -197,8 +200,10 @@ def test_remote_access_get_data_access_info5(remote_setup_dirs):
     setenv('SKA_ACCESS_REMOTELY', False)
 
     for is_windows in True, False:
-        with pytest.warns(AstropyUserWarning,
-                          match='need to define SKA or ENG_ARCHIVE environment variable'):
+        with pytest.warns(
+            AstropyUserWarning,
+            match='need to define SKA or ENG_ARCHIVE environment variable',
+        ):
             out = get_data_access_info(is_windows)
         assert out == (None, False)
 

--- a/Ska/engarchive/tests/test_remote_access.py
+++ b/Ska/engarchive/tests/test_remote_access.py
@@ -71,8 +71,8 @@ installation root directory (`python -c 'import sys; print(sys.prefix)'`) as
 `ska_remote_access.json`.
 """
 import os
-from pathlib import Path
 import shutil
+from pathlib import Path
 
 import pytest
 from astropy.utils.exceptions import AstropyUserWarning

--- a/Ska/engarchive/tests/test_sync.py
+++ b/Ska/engarchive/tests/test_sync.py
@@ -17,17 +17,17 @@ pytestmark = pytest.mark.skipif(sys.maxsize <= 2**32, reason="tests for 64-bit o
 
 # Covers safe mode and IRU swap activities around 2018:283.  This is a time
 # with rarely-seen telemetry.
-START, STOP = '2018:281', '2018:293'
+START, STOP = "2018:281", "2018:293"
 
 # Content types and associated MSIDs that will be tested
 CONTENTS = {
-    'acis4eng': ['1WRAT'],  # [float]
-    'dp_pcad32': ['DP_SYS_MOM_TOT'],  # Derived parameter [float]
-    'orbitephem0': ['ORBITEPHEM0_X'],  # Heavily overlapped [float]
-    'cpe1eng': ['6GYRCT1', '6RATE1'],  # Safe mode, [int, float]
-    'pcad13eng': ['ASPAGYC2A'],  # PCAD subformat and rarely sampled [int]
-    'sim_mrg': ['3TSCMOVE', '3TSCPOS'],  # [str, float]
-    'simcoor': ['SIM_Z_MOVED'],  # [bool]
+    "acis4eng": ["1WRAT"],  # [float]
+    "dp_pcad32": ["DP_SYS_MOM_TOT"],  # Derived parameter [float]
+    "orbitephem0": ["ORBITEPHEM0_X"],  # Heavily overlapped [float]
+    "cpe1eng": ["6GYRCT1", "6RATE1"],  # Safe mode, [int, float]
+    "pcad13eng": ["ASPAGYC2A"],  # PCAD subformat and rarely sampled [int]
+    "sim_mrg": ["3TSCMOVE", "3TSCPOS"],  # [str, float]
+    "simcoor": ["SIM_Z_MOVED"],  # [bool]
 }
 
 LOG_LEVEL = 50  # quiet
@@ -45,44 +45,44 @@ def make_linked_local_archive(outdir, content, msids):
     :return: None
     """
 
-    basedir_in = Path(fetch.msid_files.basedir) / 'data'
+    basedir_in = Path(fetch.msid_files.basedir) / "data"
     # Was: Path(os.environ['SKA']) / 'data' / 'eng_archive' / 'data' but that
     # doesn't respect possible ENG_ARCHIVE override
 
-    basedir_out = Path(outdir) / 'data'
+    basedir_out = Path(outdir) / "data"
     if basedir_out.exists():
         shutil.rmtree(basedir_out)
 
     (basedir_out / content).mkdir(parents=True)
-    (basedir_out / content / '5min').mkdir()
-    (basedir_out / content / 'daily').mkdir()
-    for file in 'archfiles.db3', 'colnames.pickle', 'TIME.h5':
+    (basedir_out / content / "5min").mkdir()
+    (basedir_out / content / "daily").mkdir()
+    for file in "archfiles.db3", "colnames.pickle", "TIME.h5":
         shutil.copy(basedir_in / content / file, basedir_out / content / file)
     for msid in msids:
-        file = f'{msid}.h5'
+        file = f"{msid}.h5"
         try:
             os.link(basedir_in / content / file, basedir_out / content / file)
         except OSError:
             os.symlink(basedir_in / content / file, basedir_out / content / file)
         try:
             os.link(
-                basedir_in / content / '5min' / file,
-                basedir_out / content / '5min' / file,
+                basedir_in / content / "5min" / file,
+                basedir_out / content / "5min" / file,
             )
         except OSError:
             os.symlink(
-                basedir_in / content / '5min' / file,
-                basedir_out / content / '5min' / file,
+                basedir_in / content / "5min" / file,
+                basedir_out / content / "5min" / file,
             )
         try:
             os.link(
-                basedir_in / content / 'daily' / file,
-                basedir_out / content / 'daily' / file,
+                basedir_in / content / "daily" / file,
+                basedir_out / content / "daily" / file,
             )
         except OSError:
             os.symlink(
-                basedir_in / content / 'daily' / file,
-                basedir_out / content / 'daily' / file,
+                basedir_in / content / "daily" / file,
+                basedir_out / content / "daily" / file,
             )
 
 
@@ -96,44 +96,44 @@ def make_sync_repo(outdir, content):
     date_start = (DateTime(START) - 8).date
     date_stop = (DateTime(STOP) + 2).date
 
-    print(f'Updating server sync for {content}')
+    print(f"Updating server sync for {content}")
     args = [
-        f'--sync-root={outdir}',
-        f'--date-start={date_start}',
-        f'--date-stop={date_stop}',
-        f'--log-level={LOG_LEVEL}',
-        f'--content={content}',
+        f"--sync-root={outdir}",
+        f"--date-start={date_start}",
+        f"--date-stop={date_stop}",
+        f"--log-level={LOG_LEVEL}",
+        f"--content={content}",
     ]
 
     update_server_sync.main(args)
 
 
 def make_stub_archfiles(date, basedir_ref, basedir_stub):
-    archfiles_def = (Path(fetch.__file__).parent / 'archfiles_def.sql').read_text()
+    archfiles_def = (Path(fetch.__file__).parent / "archfiles_def.sql").read_text()
 
     with set_fetch_basedir(basedir_ref):
-        filename = fetch.msid_files['archfiles'].abs
+        filename = fetch.msid_files["archfiles"].abs
 
-    with Ska.DBI.DBI(dbi='sqlite', server=filename) as db:
+    with Ska.DBI.DBI(dbi="sqlite", server=filename) as db:
         filetime = DateTime(date).secs
         # Last archfile that starts before date.
         last_row = db.fetchone(
-            'select * from archfiles '
-            f'where filetime < {filetime} '
-            'order by filetime desc'
+            "select * from archfiles "
+            f"where filetime < {filetime} "
+            "order by filetime desc"
         )
 
     with set_fetch_basedir(basedir_stub):
-        filename = fetch.msid_files['archfiles'].abs
+        filename = fetch.msid_files["archfiles"].abs
     if os.path.exists(filename):
         os.unlink(filename)
 
-    with Ska.DBI.DBI(dbi='sqlite', server=filename, autocommit=False) as db:
+    with Ska.DBI.DBI(dbi="sqlite", server=filename, autocommit=False) as db:
         db.execute(archfiles_def)
-        db.insert(last_row, 'archfiles')
+        db.insert(last_row, "archfiles")
         db.commit()
 
-    return last_row['rowstart'], last_row['rowstop']
+    return last_row["rowstart"], last_row["rowstop"]
 
 
 def make_stub_stats_col(msid, stat, row1, basedir_ref, basedir_stub, date_stop):
@@ -141,20 +141,20 @@ def make_stub_stats_col(msid, stat, row1, basedir_ref, basedir_stub, date_stop):
     tstop = DateTime(date_stop).secs
 
     with set_fetch_basedir(basedir_ref):
-        fetch.ft['msid'] = 'TIME'
-        file_time = fetch.msid_files['msid'].abs
+        fetch.ft["msid"] = "TIME"
+        file_time = fetch.msid_files["msid"].abs
 
-        fetch.ft['msid'] = msid
-        fetch.ft['interval'] = stat
-        file_stats_ref = fetch.msid_files['stats'].abs
+        fetch.ft["msid"] = msid
+        fetch.ft["interval"] = stat
+        file_stats_ref = fetch.msid_files["stats"].abs
 
     if not Path(file_stats_ref).exists():
         return
 
     with set_fetch_basedir(basedir_stub):
-        file_stats_stub = fetch.msid_files['stats'].abs
+        file_stats_stub = fetch.msid_files["stats"].abs
 
-    with tables.open_file(file_time, 'r') as h5:
+    with tables.open_file(file_time, "r") as h5:
         # Pad out tstop by DT in order to be sure that all records before a long
         # gap get found.  This comes into play for pcad13eng which is in PCAD subformat only.
         # In addition, do not select data beyond tstop (date_stop), which is the
@@ -164,9 +164,9 @@ def make_stub_stats_col(msid, stat, row1, basedir_ref, basedir_stub, date_stop):
         # Need at least 10 days of real values in stub file to start sync
         tstart = tstop - 10 * 86400
 
-    with tables.open_file(file_stats_ref, 'r') as h5:
+    with tables.open_file(file_stats_ref, "r") as h5:
         tbl = h5.root.data
-        times = (tbl.col('index') + 0.5) * STATS_DT[stat]
+        times = (tbl.col("index") + 0.5) * STATS_DT[stat]
         stat_row0, stat_row1 = np.searchsorted(times, [tstart, tstop])
         # Back up a bit to ensure getting something since an MSID that is not
         # typically sampled (because of subformat for instance) may show up
@@ -179,24 +179,24 @@ def make_stub_stats_col(msid, stat, row1, basedir_ref, basedir_stub, date_stop):
 
     Path(file_stats_stub).parent.mkdir(exist_ok=True, parents=True)
 
-    filters = tables.Filters(complevel=5, complib='zlib')
-    with tables.open_file(file_stats_stub, mode='a', filters=filters) as stats:
+    filters = tables.Filters(complevel=5, complib="zlib")
+    with tables.open_file(file_stats_stub, mode="a", filters=filters) as stats:
         stats.create_table(
-            stats.root, 'data', tbl_rows, f'{stat} sampling', expectedrows=1e5
+            stats.root, "data", tbl_rows, f"{stat} sampling", expectedrows=1e5
         )
         stats.root.data.flush()
 
 
 def make_stub_h5_col(msid, row0, row1, basedir_ref, basedir_stub):
-    fetch.ft['msid'] = msid
+    fetch.ft["msid"] = msid
 
     with set_fetch_basedir(basedir_ref):
-        file_ref = fetch.msid_files['data'].abs
+        file_ref = fetch.msid_files["data"].abs
 
     if not Path(file_ref).exists():
         return
 
-    with tables.open_file(file_ref, 'r') as h5:
+    with tables.open_file(file_ref, "r") as h5:
         data_stub = h5.root.data[row0:row1]
         qual_stub = h5.root.quality[row0:row1]
         n_rows = len(h5.root.data)
@@ -205,28 +205,28 @@ def make_stub_h5_col(msid, row0, row1, basedir_ref, basedir_stub):
     qual_fill = np.ones(row0, dtype=qual_stub.dtype)  # True => bad
 
     with set_fetch_basedir(basedir_stub):
-        file_stub = fetch.msid_files['data'].abs
+        file_stub = fetch.msid_files["data"].abs
 
     if os.path.exists(file_stub):
         os.unlink(file_stub)
 
-    filters = tables.Filters(complevel=5, complib='zlib')
-    with tables.open_file(file_stub, mode='w', filters=filters) as h5:
+    filters = tables.Filters(complevel=5, complib="zlib")
+    with tables.open_file(file_stub, mode="w", filters=filters) as h5:
         h5shape = (0,) + data_stub.shape[1:]
         h5type = tables.Atom.from_dtype(data_stub.dtype)
         h5.create_earray(
-            h5.root, 'data', h5type, h5shape, title=msid, expectedrows=n_rows
+            h5.root, "data", h5type, h5shape, title=msid, expectedrows=n_rows
         )
         h5.create_earray(
             h5.root,
-            'quality',
+            "quality",
             tables.BoolAtom(),
             (0,),
-            title='Quality',
+            title="Quality",
             expectedrows=n_rows,
         )
 
-    with tables.open_file(file_stub, mode='a') as h5:
+    with tables.open_file(file_stub, mode="a") as h5:
         h5.root.data.append(data_fill)
         h5.root.data.append(data_stub)
         h5.root.quality.append(qual_fill)
@@ -239,14 +239,14 @@ def make_stub_colnames(basedir_ref, basedir_stub):
     actually in the reference archive.
     """
     with set_fetch_basedir(basedir_ref):
-        file_ref = fetch.msid_files['colnames'].abs
+        file_ref = fetch.msid_files["colnames"].abs
 
     with set_fetch_basedir(basedir_stub):
-        file_stub = fetch.msid_files['colnames'].abs
+        file_stub = fetch.msid_files["colnames"].abs
 
     shutil.copy(file_ref, file_stub)
 
-    with open(file_stub, 'rb') as fh:
+    with open(file_stub, "rb") as fh:
         msids = pickle.load(fh)
 
     return msids
@@ -267,11 +267,11 @@ def make_stub_content(
         for msid in msids:
             assert fetch.content[msid.upper()] == content
 
-    print(f'Making stub archive for {content}')
+    print(f"Making stub archive for {content}")
 
-    fetch.ft['content'] = content
+    fetch.ft["content"] = content
     with set_fetch_basedir(basedir_stub):
-        dirname = Path(fetch.msid_files['contentdir'].abs)
+        dirname = Path(fetch.msid_files["contentdir"].abs)
     if dirname.exists():
         shutil.rmtree(dirname)
     dirname.mkdir(parents=True)
@@ -283,8 +283,8 @@ def make_stub_content(
         msids = msids_ref
     msids = msids.copy()
 
-    if 'TIME' not in msids:
-        msids.append('TIME')
+    if "TIME" not in msids:
+        msids.append("TIME")
 
     if msids_5min is None:
         msids_5min = msids
@@ -296,10 +296,10 @@ def make_stub_content(
         make_stub_h5_col(msid, row0, row1, basedir_ref, basedir_stub)
 
     for msid in msids_5min:
-        make_stub_stats_col(msid, '5min', row1, basedir_ref, basedir_stub, date)
+        make_stub_stats_col(msid, "5min", row1, basedir_ref, basedir_stub, date)
 
     for msid in msids_daily:
-        make_stub_stats_col(msid, 'daily', row1, basedir_ref, basedir_stub, date)
+        make_stub_stats_col(msid, "daily", row1, basedir_ref, basedir_stub, date)
 
 
 def check_content(outdir, content, msids=None):
@@ -308,13 +308,13 @@ def check_content(outdir, content, msids=None):
         shutil.rmtree(outdir)
 
     print()
-    print(f'Test dir: {outdir}')
+    print(f"Test dir: {outdir}")
 
     if msids is None:
         msids = CONTENTS[content]
 
-    basedir_ref = outdir / 'orig'
-    basedir_test = outdir / 'test'
+    basedir_ref = outdir / "orig"
+    basedir_test = outdir / "test"
 
     basedir_ref.mkdir(parents=True)
     basedir_test.mkdir(parents=True)
@@ -342,26 +342,26 @@ def check_content(outdir, content, msids=None):
 
     date_stop = (DateTime(STOP) + 2).date
 
-    print(f'Updating client archive {content}')
+    print(f"Updating client archive {content}")
     with set_fetch_basedir(basedir_test):
         update_client_archive.main(
             [
-                f'--content={content}',
-                f'--log-level={LOG_LEVEL}',
-                f'--date-stop={date_stop}',
-                f'--data-root={basedir_test}',
-                f'--sync-root={basedir_test}',
+                f"--content={content}",
+                f"--log-level={LOG_LEVEL}",
+                f"--date-stop={date_stop}",
+                f"--data-root={basedir_test}",
+                f"--sync-root={basedir_test}",
             ]
         )
 
-    print(f'Checking {content} {msids}')
-    for stat in None, '5min', 'daily':
+    print(f"Checking {content} {msids}")
+    for stat in None, "5min", "daily":
         for msid in msids:
-            fetch.times_cache['key'] = None
+            fetch.times_cache["key"] = None
             with set_fetch_basedir(basedir_test):
                 dat_stub = fetch.Msid(msid, START, STOP, stat=stat)
 
-            fetch.times_cache['key'] = None
+            fetch.times_cache["key"] = None
             with set_fetch_basedir(basedir_ref):
                 dat_orig = fetch.Msid(msid, START, STOP, stat=stat)
 
@@ -369,7 +369,7 @@ def check_content(outdir, content, msids=None):
                 assert np.all(getattr(dat_stub, attr) == getattr(dat_orig, attr))
 
 
-@pytest.mark.parametrize('content', list(CONTENTS))
+@pytest.mark.parametrize("content", list(CONTENTS))
 def test_sync(tmpdir, content):
     check_content(tmpdir, content)
 

--- a/Ska/engarchive/tests/test_sync.py
+++ b/Ska/engarchive/tests/test_sync.py
@@ -1,17 +1,16 @@
-import sys
 import os
 import pickle
 import shutil
+import sys
 from pathlib import Path
 
-import pytest
 import numpy as np
+import pytest
 import Ska.DBI
 import tables
 from Chandra.Time import DateTime
 
-from .. import fetch
-from .. import update_client_archive, update_server_sync
+from .. import fetch, update_client_archive, update_server_sync
 from ..utils import STATS_DT, set_fetch_basedir
 
 pytestmark = pytest.mark.skipif(sys.maxsize <= 2 ** 32, reason="tests for 64-bit only")

--- a/Ska/engarchive/tests/test_units.py
+++ b/Ska/engarchive/tests/test_units.py
@@ -6,70 +6,70 @@ from .. import fetch_eng as fetch_eng
 from .. import fetch_sci as fetch_sci
 from ..units import Units
 
-start = '2011:001:00:00:00'
-stop = '2011:001:00:30:00'
+start = "2011:001:00:00:00"
+stop = "2011:001:00:30:00"
 
 
 def test_initial_units():
-    assert fetch_cxc.get_units() == 'cxc'
-    assert fetch_eng.get_units() == 'eng'
-    assert fetch_sci.get_units() == 'sci'
+    assert fetch_cxc.get_units() == "cxc"
+    assert fetch_eng.get_units() == "eng"
+    assert fetch_sci.get_units() == "sci"
 
 
 def test_fetch_units_MSID():
-    cxc = fetch_cxc.MSID('tephin', start, stop)
-    sci = fetch_sci.MSID('tephin', start, stop)
-    eng = fetch_eng.MSID('tephin', start, stop)
+    cxc = fetch_cxc.MSID("tephin", start, stop)
+    sci = fetch_sci.MSID("tephin", start, stop)
+    eng = fetch_eng.MSID("tephin", start, stop)
 
-    assert cxc.unit == 'K'
-    assert sci.unit == 'DEGC'
-    assert eng.unit == 'DEGF'
+    assert cxc.unit == "K"
+    assert sci.unit == "DEGC"
+    assert eng.unit == "DEGF"
 
 
 def test_fetch_units_Msid():
-    cxc = fetch_cxc.Msid('tephin', start, stop)
-    sci = fetch_sci.Msid('tephin', start, stop)
-    eng = fetch_eng.Msid('tephin', start, stop)
+    cxc = fetch_cxc.Msid("tephin", start, stop)
+    sci = fetch_sci.Msid("tephin", start, stop)
+    eng = fetch_eng.Msid("tephin", start, stop)
 
-    assert cxc.unit == 'K'
-    assert sci.unit == 'DEGC'
-    assert eng.unit == 'DEGF'
+    assert cxc.unit == "K"
+    assert sci.unit == "DEGC"
+    assert eng.unit == "DEGF"
 
 
 def test_fetch_units_MSIDset():
-    cxc = fetch_cxc.MSIDset(['tephin'], start, stop)
-    sci = fetch_sci.MSIDset(['tephin'], start, stop)
-    eng = fetch_eng.MSIDset(['tephin'], start, stop)
+    cxc = fetch_cxc.MSIDset(["tephin"], start, stop)
+    sci = fetch_sci.MSIDset(["tephin"], start, stop)
+    eng = fetch_eng.MSIDset(["tephin"], start, stop)
 
-    assert cxc['tephin'].unit == 'K'
-    assert sci['tephin'].unit == 'DEGC'
-    assert eng['tephin'].unit == 'DEGF'
+    assert cxc["tephin"].unit == "K"
+    assert sci["tephin"].unit == "DEGC"
+    assert eng["tephin"].unit == "DEGF"
 
 
 def test_fetch_units_Msidset():
-    cxc = fetch_cxc.Msidset(['tephin'], start, stop)
-    sci = fetch_sci.Msidset(['tephin'], start, stop)
-    eng = fetch_eng.Msidset(['tephin'], start, stop)
+    cxc = fetch_cxc.Msidset(["tephin"], start, stop)
+    sci = fetch_sci.Msidset(["tephin"], start, stop)
+    eng = fetch_eng.Msidset(["tephin"], start, stop)
 
-    assert cxc['tephin'].unit == 'K'
-    assert sci['tephin'].unit == 'DEGC'
-    assert eng['tephin'].unit == 'DEGF'
+    assert cxc["tephin"].unit == "K"
+    assert sci["tephin"].unit == "DEGC"
+    assert eng["tephin"].unit == "DEGF"
 
 
 def test_change_units():
-    cxc1 = fetch_cxc.MSID('tephin', start, stop)
-    assert fetch_cxc.UNITS['system'] == 'cxc'
+    cxc1 = fetch_cxc.MSID("tephin", start, stop)
+    assert fetch_cxc.UNITS["system"] == "cxc"
 
-    fetch_cxc.set_units('eng')
-    cxc2 = fetch_cxc.MSID('tephin', start, stop)
+    fetch_cxc.set_units("eng")
+    cxc2 = fetch_cxc.MSID("tephin", start, stop)
 
-    assert fetch_cxc.UNITS['system'] == 'eng'
-    assert cxc1.units['system'] == 'cxc'
-    assert cxc1.unit == 'K'
-    assert cxc2.units['system'] == 'eng'
-    assert cxc2.unit == 'DEGF'
+    assert fetch_cxc.UNITS["system"] == "eng"
+    assert cxc1.units["system"] == "cxc"
+    assert cxc1.unit == "K"
+    assert cxc2.units["system"] == "eng"
+    assert cxc2.unit == "DEGF"
 
-    fetch_cxc.set_units('cxc')
+    fetch_cxc.set_units("cxc")
 
 
 def test_versions():
@@ -78,33 +78,33 @@ def test_versions():
 
 
 def test_deahk_units():
-    cxc = fetch_cxc.MSID('fptemp_11', start, stop)
-    sci = fetch_sci.MSID('fptemp_11', start, stop)
-    eng = fetch_eng.MSID('fptemp_11', start, stop)
-    assert cxc.unit == 'K'
-    assert sci.unit == 'DEGC'
-    assert eng.unit == 'DEGC'
+    cxc = fetch_cxc.MSID("fptemp_11", start, stop)
+    sci = fetch_sci.MSID("fptemp_11", start, stop)
+    eng = fetch_eng.MSID("fptemp_11", start, stop)
+    assert cxc.unit == "K"
+    assert sci.unit == "DEGC"
+    assert eng.unit == "DEGC"
     assert cxc.vals[0] > 100
     assert sci.vals[0] < -80
     assert eng.vals[0] < -80
 
 
 def test_from_units():
-    vals = Units('sci').convert('TEPHIN', np.array([32.0]), from_system='eng')
+    vals = Units("sci").convert("TEPHIN", np.array([32.0]), from_system="eng")
     assert np.allclose(vals, [0.0])
 
 
 def test_equiv_units():
-    cxc = fetch_cxc.MSID('aorate1', start, stop)
-    sci = fetch_sci.MSID('aorate1', start, stop)
-    eng = fetch_eng.MSID('aorate1', start, stop)
-    assert cxc.unit == 'rad/s'
-    assert sci.unit == 'rad/s'
-    assert eng.unit == 'RADPS'
+    cxc = fetch_cxc.MSID("aorate1", start, stop)
+    sci = fetch_sci.MSID("aorate1", start, stop)
+    eng = fetch_eng.MSID("aorate1", start, stop)
+    assert cxc.unit == "rad/s"
+    assert sci.unit == "rad/s"
+    assert eng.unit == "RADPS"
 
 
 def test_unit_name_value_types():
-    for system in ('eng', 'cxc', 'sci'):
+    for system in ("eng", "cxc", "sci"):
         units = fetch_cxc.Units()[system]
         for name, value in units.items():
             assert type(name) is str

--- a/Ska/engarchive/tests/test_units_reversed.py
+++ b/Ska/engarchive/tests/test_units_reversed.py
@@ -4,5 +4,4 @@
 from .. import fetch as fetch_cxc  # noqa
 from .. import fetch_eng as fetch_eng  # noqa
 from .. import fetch_sci as fetch_sci  # noqa
-
 from .test_units import *  # noqa

--- a/Ska/engarchive/tests/test_utils.py
+++ b/Ska/engarchive/tests/test_utils.py
@@ -12,10 +12,14 @@ def test_get_fetch_size_functionality():
     fetch_mb, out_mb = get_fetch_size('aopcadmd', '2010:001', '2011:001')
     assert fetch_mb, out_mb == (399.97, 399.97)
 
-    fetch_mb, out_mb = get_fetch_size('aopcadmd', '2010:001', '2011:001', interpolate_dt=1.025 * 10)
+    fetch_mb, out_mb = get_fetch_size(
+        'aopcadmd', '2010:001', '2011:001', interpolate_dt=1.025 * 10
+    )
     assert fetch_mb, out_mb == (399.97, 40.0)
 
-    fetch_mb, out_mb = get_fetch_size('aopcadmd', '2010:001', '2011:001', fast=False, stat='5min')
+    fetch_mb, out_mb = get_fetch_size(
+        'aopcadmd', '2010:001', '2011:001', fast=False, stat='5min'
+    )
     assert fetch_mb, out_mb == (1.92, 1.92)
 
     # 5min stat
@@ -35,8 +39,14 @@ def test_get_fetch_size_accuracy():
     dat = fetch.MSID('aopcadmd', '2010:001', '2011:001', stat='5min')
     fetch_bytes = sum(getattr(dat, attr).nbytes for attr in dat.colnames)
 
-    fetch_mb, out_mb = get_fetch_size('aopcadmd', '2010:001', '2011:001', stat='5min',
-                                      interpolate_dt=328 * 2, fast=False)
+    fetch_mb, out_mb = get_fetch_size(
+        'aopcadmd',
+        '2010:001',
+        '2011:001',
+        stat='5min',
+        interpolate_dt=328 * 2,
+        fast=False,
+    )
     assert np.isclose(fetch_mb, fetch_bytes / 1e6, rtol=0.0, atol=0.01)
 
     # Now interpolate to 10 minute intervals
@@ -48,8 +58,9 @@ def test_get_fetch_size_accuracy():
     dat = fetch.MSID('aopcadmd', '2011:001', '2011:010')
     fetch_bytes = sum(getattr(dat, attr).nbytes for attr in dat.colnames)
 
-    fetch_mb, out_mb = get_fetch_size('aopcadmd', '2011:001', '2011:010',
-                                      interpolate_dt=328 * 2, fast=False)
+    fetch_mb, out_mb = get_fetch_size(
+        'aopcadmd', '2011:001', '2011:010', interpolate_dt=328 * 2, fast=False
+    )
     assert np.isclose(fetch_mb, fetch_bytes / 1e6, rtol=0.0, atol=0.01)
 
     # Now interpolate to 10 minute intervals

--- a/Ska/engarchive/tests/test_utils.py
+++ b/Ska/engarchive/tests/test_utils.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 
-from ..utils import get_fetch_size
 from .. import fetch
+from ..utils import get_fetch_size
 
 
 def test_get_fetch_size_functionality():

--- a/Ska/engarchive/tests/test_utils.py
+++ b/Ska/engarchive/tests/test_utils.py
@@ -9,25 +9,25 @@ def test_get_fetch_size_functionality():
     """
     Various functionality tests for estimating fetch memory usage.
     """
-    fetch_mb, out_mb = get_fetch_size('aopcadmd', '2010:001', '2011:001')
+    fetch_mb, out_mb = get_fetch_size("aopcadmd", "2010:001", "2011:001")
     assert fetch_mb, out_mb == (399.97, 399.97)
 
     fetch_mb, out_mb = get_fetch_size(
-        'aopcadmd', '2010:001', '2011:001', interpolate_dt=1.025 * 10
+        "aopcadmd", "2010:001", "2011:001", interpolate_dt=1.025 * 10
     )
     assert fetch_mb, out_mb == (399.97, 40.0)
 
     fetch_mb, out_mb = get_fetch_size(
-        'aopcadmd', '2010:001', '2011:001', fast=False, stat='5min'
+        "aopcadmd", "2010:001", "2011:001", fast=False, stat="5min"
     )
     assert fetch_mb, out_mb == (1.92, 1.92)
 
     # 5min stat
-    fetch_mb, out_mb = get_fetch_size('aopcadmd', '2010:001', '2011:001', stat='5min')
+    fetch_mb, out_mb = get_fetch_size("aopcadmd", "2010:001", "2011:001", stat="5min")
     assert fetch_mb, out_mb == (-1, -1)
 
     # Too short
-    fetch_mb, out_mb = get_fetch_size('aopcadmd', '2010:001', '2010:030')
+    fetch_mb, out_mb = get_fetch_size("aopcadmd", "2010:001", "2010:030")
     assert fetch_mb, out_mb == (-1, -1)
 
 
@@ -36,14 +36,14 @@ def test_get_fetch_size_accuracy():
     Does it give the right answer?
     """
     # By hand for stat
-    dat = fetch.MSID('aopcadmd', '2010:001', '2011:001', stat='5min')
+    dat = fetch.MSID("aopcadmd", "2010:001", "2011:001", stat="5min")
     fetch_bytes = sum(getattr(dat, attr).nbytes for attr in dat.colnames)
 
     fetch_mb, out_mb = get_fetch_size(
-        'aopcadmd',
-        '2010:001',
-        '2011:001',
-        stat='5min',
+        "aopcadmd",
+        "2010:001",
+        "2011:001",
+        stat="5min",
         interpolate_dt=328 * 2,
         fast=False,
     )
@@ -55,11 +55,11 @@ def test_get_fetch_size_accuracy():
     assert np.isclose(out_mb, fetch_bytes / 1e6, rtol=0.0, atol=0.01)
 
     # By hand for full resolution
-    dat = fetch.MSID('aopcadmd', '2011:001', '2011:010')
+    dat = fetch.MSID("aopcadmd", "2011:001", "2011:010")
     fetch_bytes = sum(getattr(dat, attr).nbytes for attr in dat.colnames)
 
     fetch_mb, out_mb = get_fetch_size(
-        'aopcadmd', '2011:001', '2011:010', interpolate_dt=328 * 2, fast=False
+        "aopcadmd", "2011:001", "2011:010", interpolate_dt=328 * 2, fast=False
     )
     assert np.isclose(fetch_mb, fetch_bytes / 1e6, rtol=0.0, atol=0.01)
 

--- a/Ska/engarchive/units.py
+++ b/Ska/engarchive/units.py
@@ -52,38 +52,38 @@ class NullHandler(logging.Handler):
         pass
 
 
-logger = logging.getLogger('Ska.engarchive.units')
+logger = logging.getLogger("Ska.engarchive.units")
 logger.addHandler(NullHandler())
 logger.propagate = False
 
 # This is effectively a singleton class
-SYSTEMS = set(('cxc', 'eng', 'sci'))
+SYSTEMS = set(("cxc", "eng", "sci"))
 module_dir = os.path.dirname(__file__)
 
 units = {}
-units['system'] = 'cxc'
-units['cxc'] = pickle.load(open(os.path.join(module_dir, 'units_cxc.pkl'), 'rb'))
+units["system"] = "cxc"
+units["cxc"] = pickle.load(open(os.path.join(module_dir, "units_cxc.pkl"), "rb"))
 
 
 # Equivalent unit descriptors used in 'eng' and 'cxc' units
 equiv_units = set(
     [
-        ('AMP', 'A'),
-        ('ASEC', 'arcsec'),
-        ('DEG', 'deg'),
-        ('DEGPS', 'deg/s'),
-        ('KHZ', 'kHz'),
-        ('KM', 'km'),
-        ('KMPS', 'km/s'),
-        ('MAMP', 'mA'),
-        ('MSEC', 'ms'),
-        ('RAD', 'rad'),
-        ('RADPS', 'rad/s'),
-        ('RADSS', 'rad/s**2'),
-        ('SEC', 's'),
-        ('V', 'V'),
-        ('VDC', 'V'),
-        ('W', 'W'),
+        ("AMP", "A"),
+        ("ASEC", "arcsec"),
+        ("DEG", "deg"),
+        ("DEGPS", "deg/s"),
+        ("KHZ", "kHz"),
+        ("KM", "km"),
+        ("KMPS", "km/s"),
+        ("MAMP", "mA"),
+        ("MSEC", "ms"),
+        ("RAD", "rad"),
+        ("RADPS", "rad/s"),
+        ("RADSS", "rad/s**2"),
+        ("SEC", "s"),
+        ("V", "V"),
+        ("VDC", "V"),
+        ("W", "W"),
         (None, None),
     ]
 )
@@ -189,57 +189,57 @@ def divide(scale_factor, decimals=None):
 
 converters = {
     # CXC units to Eng or Sci
-    ('J', 'FTLB'): mult(0.7376),
-    ('J*s', 'FTLBSEC'): mult(0.7376),
-    ('K', 'DEGC'): K_to_C,
-    ('K', 'DEGF'): K_to_F,
-    ('deltaK', 'DEGF'): mult(1.8),
-    ('kPa', 'PSIA'): mult(0.145),
-    ('kPa', 'TORR'): mult(7.501),
-    ('mm', 'TSCSTEP'): mult(1.0 / 0.00251431530156, decimals=3),
-    ('mm', 'FASTEP'): mm_to_FASTEP,
-    ('PWM', 'PWMSTEP'): mult(16),
-    ('DEGC', 'DEGF'): C_to_F,
+    ("J", "FTLB"): mult(0.7376),
+    ("J*s", "FTLBSEC"): mult(0.7376),
+    ("K", "DEGC"): K_to_C,
+    ("K", "DEGF"): K_to_F,
+    ("deltaK", "DEGF"): mult(1.8),
+    ("kPa", "PSIA"): mult(0.145),
+    ("kPa", "TORR"): mult(7.501),
+    ("mm", "TSCSTEP"): mult(1.0 / 0.00251431530156, decimals=3),
+    ("mm", "FASTEP"): mm_to_FASTEP,
+    ("PWM", "PWMSTEP"): mult(16),
+    ("DEGC", "DEGF"): C_to_F,
     # Eng units to CXC or Sci
-    ('DEGC', 'K'): C_to_K,
-    ('DEGF', 'K'): F_to_K,
-    ('DEGF', 'deltaK'): divide(1.8),
-    ('DEGF', 'DEGC'): F_to_C,
-    ('FASTEP', 'mm'): FASTEP_to_mm,
-    ('FTLB', 'J'): divide(0.7376),
-    ('FTLBSEC', 'J*s'): divide(0.7376),
-    ('MIN', 's'): mult(60),
-    ('PSIA', 'kPa'): divide(0.145),
-    ('PWMSTEP', 'PWM'): divide(16),
-    ('TORR', 'kPa'): divide(7.501),
-    ('TSCSTEP', 'mm'): mult(0.00251431530156),
+    ("DEGC", "K"): C_to_K,
+    ("DEGF", "K"): F_to_K,
+    ("DEGF", "deltaK"): divide(1.8),
+    ("DEGF", "DEGC"): F_to_C,
+    ("FASTEP", "mm"): FASTEP_to_mm,
+    ("FTLB", "J"): divide(0.7376),
+    ("FTLBSEC", "J*s"): divide(0.7376),
+    ("MIN", "s"): mult(60),
+    ("PSIA", "kPa"): divide(0.145),
+    ("PWMSTEP", "PWM"): divide(16),
+    ("TORR", "kPa"): divide(7.501),
+    ("TSCSTEP", "mm"): mult(0.00251431530156),
 }
 
 
 def load_units(unit_system):
     """Load units definitions for unit_system if not already loaded."""
     if unit_system not in SYSTEMS:
-        raise ValueError('unit_system must be in {}'.format(SYSTEMS))
+        raise ValueError("unit_system must be in {}".format(SYSTEMS))
 
     if unit_system not in units:
-        filename = os.path.join(module_dir, 'units_{0}.pkl'.format(unit_system))
-        units[unit_system] = pickle.load(open(filename, 'rb'))
+        filename = os.path.join(module_dir, "units_{0}.pkl".format(unit_system))
+        units[unit_system] = pickle.load(open(filename, "rb"))
 
 
 def set_units(unit_system):
     """Set conversion unit system.  The input ``unit_system`` must be a string."""
     load_units(unit_system)
-    units['system'] = unit_system
+    units["system"] = unit_system
 
 
 def get_msid_unit(msid):
     MSID = msid.upper()
-    return units[units['system']].get(MSID)
+    return units[units["system"]].get(MSID)
 
 
 def convert(msid, vals, delta_val=False):
     MSID = msid.upper()
-    conversion = (units['cxc'].get(MSID), get_msid_unit(MSID))
+    conversion = (units["cxc"].get(MSID), get_msid_unit(MSID))
     try:
         vals = converters[conversion](vals, delta_val)
     except KeyError:
@@ -261,7 +261,7 @@ class Units(dict):
     It only allows a single key "system" to be set
     """
 
-    def __init__(self, system='cxc'):
+    def __init__(self, system="cxc"):
         super(Units, self).__init__(system=system)
 
     def __getitem__(self, item):
@@ -272,7 +272,7 @@ class Units(dict):
             return dict.__getitem__(self, item)
 
     def __setitem__(self, item, val):
-        if item == 'system':
+        if item == "system":
             load_units(val)
             dict.__setitem__(self, item, val)
         else:
@@ -282,16 +282,16 @@ class Units(dict):
         """Set conversion unit system.  The input ``unit_system`` must be a
         string.
         """
-        self['system'] = unit_system
+        self["system"] = unit_system
 
     def get_msid_unit(self, msid):
         MSID = msid.upper()
-        system = self['system']
-        cxc_unit = self['cxc'].get(MSID)
+        system = self["system"]
+        cxc_unit = self["cxc"].get(MSID)
         system_unit = self[system].get(MSID, cxc_unit)  # WHY this default of cxc_unit??
         return system_unit
 
-    def convert(self, msid, vals, delta_val=False, from_system='cxc'):
+    def convert(self, msid, vals, delta_val=False, from_system="cxc"):
         MSID = msid.upper()
         conversion = (self[from_system].get(MSID), self.get_msid_unit(MSID))
 
@@ -300,11 +300,11 @@ class Units(dict):
 
         if conversion not in converters:
             warnings.warn(
-                '\n\n\n**** WARNING ****\n'
-                'For MSID {} the requested unit conversion from {} to {}\n'
-                'does not have a defined transformation function.\n'
-                'You may be getting incorrect results now.\n\n'
-                'PLEASE REPORT THIS to the Ska developers!\n'.format(
+                "\n\n\n**** WARNING ****\n"
+                "For MSID {} the requested unit conversion from {} to {}\n"
+                "does not have a defined transformation function.\n"
+                "You may be getting incorrect results now.\n\n"
+                "PLEASE REPORT THIS to the Ska developers!\n".format(
                     MSID, conversion[0], conversion[1]
                 )
             )

--- a/Ska/engarchive/units.py
+++ b/Ska/engarchive/units.py
@@ -66,23 +66,27 @@ units['cxc'] = pickle.load(open(os.path.join(module_dir, 'units_cxc.pkl'), 'rb')
 
 
 # Equivalent unit descriptors used in 'eng' and 'cxc' units
-equiv_units = set([('AMP', 'A'),
-                   ('ASEC', 'arcsec'),
-                   ('DEG', 'deg'),
-                   ('DEGPS', 'deg/s'),
-                   ('KHZ', 'kHz'),
-                   ('KM', 'km'),
-                   ('KMPS', 'km/s'),
-                   ('MAMP', 'mA'),
-                   ('MSEC', 'ms'),
-                   ('RAD', 'rad'),
-                   ('RADPS', 'rad/s'),
-                   ('RADSS', 'rad/s**2'),
-                   ('SEC', 's'),
-                   ('V', 'V'),
-                   ('VDC', 'V'),
-                   ('W', 'W'),
-                   (None, None)])
+equiv_units = set(
+    [
+        ('AMP', 'A'),
+        ('ASEC', 'arcsec'),
+        ('DEG', 'deg'),
+        ('DEGPS', 'deg/s'),
+        ('KHZ', 'kHz'),
+        ('KM', 'km'),
+        ('KMPS', 'km/s'),
+        ('MAMP', 'mA'),
+        ('MSEC', 'ms'),
+        ('RAD', 'rad'),
+        ('RADPS', 'rad/s'),
+        ('RADSS', 'rad/s**2'),
+        ('SEC', 's'),
+        ('V', 'V'),
+        ('VDC', 'V'),
+        ('W', 'W'),
+        (None, None),
+    ]
+)
 equiv_units.update((u2, u1) for u1, u2 in list(equiv_units))
 
 
@@ -132,8 +136,14 @@ def FASTEP_to_mm(vals, delta_val=False):
     """
     Use CXC calibration value to convert from focus assembly steps to mm.
     """
-    fastep = (1.47906994e-3 * vals + 3.5723322e-8 * vals**2 + -1.08492544e-12 * vals**3 +
-              3.9803832e-17 * vals**4 + 5.29336e-21 * vals**5 + 1.020064e-25 * vals**6)
+    fastep = (
+        1.47906994e-3 * vals
+        + 3.5723322e-8 * vals**2
+        + -1.08492544e-12 * vals**3
+        + 3.9803832e-17 * vals**4
+        + 5.29336e-21 * vals**5
+        + 1.020064e-25 * vals**6
+    )
     return fastep
 
 
@@ -146,9 +156,19 @@ def mm_to_FASTEP(vals, delta_val=False):
          3.9803832e-17  *   x**4 +  5.29336e-21  *  x**5 +  1.020064e-25  *   x**6)
     r = np.polyfit(y, x, 8)
     """
-    r = np.array([-1.26507734e-05, -2.02499464e-04, -1.86504522e-03,
-                  -5.25689124e-03, -5.75639912e-02, 5.60935786e-01,
-                  -1.10595209e+01, 6.76094720e+02, -4.34121454e-04])
+    r = np.array(
+        [
+            -1.26507734e-05,
+            -2.02499464e-04,
+            -1.86504522e-03,
+            -5.25689124e-03,
+            -5.75639912e-02,
+            5.60935786e-01,
+            -1.10595209e01,
+            6.76094720e02,
+            -4.34121454e-04,
+        ]
+    )
     x_step = np.round(np.polyval(r, vals), decimals=2)
     return x_step
 
@@ -159,6 +179,7 @@ def mult(scale_factor, decimals=None):
         if decimals is not None:
             result = np.round(result, decimals=decimals)
         return result
+
     return convert
 
 
@@ -179,7 +200,6 @@ converters = {
     ('mm', 'FASTEP'): mm_to_FASTEP,
     ('PWM', 'PWMSTEP'): mult(16),
     ('DEGC', 'DEGF'): C_to_F,
-
     # Eng units to CXC or Sci
     ('DEGC', 'K'): C_to_K,
     ('DEGF', 'K'): F_to_K,
@@ -197,20 +217,17 @@ converters = {
 
 
 def load_units(unit_system):
-    """Load units definitions for unit_system if not already loaded.
-    """
+    """Load units definitions for unit_system if not already loaded."""
     if unit_system not in SYSTEMS:
         raise ValueError('unit_system must be in {}'.format(SYSTEMS))
 
     if unit_system not in units:
-        filename = os.path.join(module_dir,
-                                'units_{0}.pkl'.format(unit_system))
+        filename = os.path.join(module_dir, 'units_{0}.pkl'.format(unit_system))
         units[unit_system] = pickle.load(open(filename, 'rb'))
 
 
 def set_units(unit_system):
-    """Set conversion unit system.  The input ``unit_system`` must be a string.
-    """
+    """Set conversion unit system.  The input ``unit_system`` must be a string."""
     load_units(unit_system)
     units['system'] = unit_system
 
@@ -282,12 +299,15 @@ class Units(dict):
             return vals
 
         if conversion not in converters:
-            warnings.warn('\n\n\n**** WARNING ****\n'
-                          'For MSID {} the requested unit conversion from {} to {}\n'
-                          'does not have a defined transformation function.\n'
-                          'You may be getting incorrect results now.\n\n'
-                          'PLEASE REPORT THIS to the Ska developers!\n'
-                          .format(MSID, conversion[0], conversion[1]))
+            warnings.warn(
+                '\n\n\n**** WARNING ****\n'
+                'For MSID {} the requested unit conversion from {} to {}\n'
+                'does not have a defined transformation function.\n'
+                'You may be getting incorrect results now.\n\n'
+                'PLEASE REPORT THIS to the Ska developers!\n'.format(
+                    MSID, conversion[0], conversion[1]
+                )
+            )
 
         vals = converters[conversion](vals, delta_val)
 

--- a/Ska/engarchive/units.py
+++ b/Ska/engarchive/units.py
@@ -37,14 +37,14 @@ Basic units handling and conversion.
  ('VDC', 'V'),
  ('W', 'W')}
 """
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
 
-import os
-from six.moves import cPickle as pickle
 import logging
+import os
 import warnings
 
 import numpy as np
+from six.moves import cPickle as pickle
 
 
 class NullHandler(logging.Handler):

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -33,63 +33,83 @@ import Ska.engarchive.file_defs as file_defs
 
 def get_options(args=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument("--dry-run",
-                        action="store_true",
-                        help="Dry run (no actual file or database updatees)")
-    parser.add_argument("--no-full",
-                        action="store_false",
-                        dest="update_full",
-                        default=True,
-                        help=("Do not fetch files from archive and update "
-                              "full-resolution MSID archive"))
-    parser.add_argument("--no-stats",
-                        action="store_false",
-                        dest="update_stats",
-                        default=True,
-                        help="Do not update 5 minute and daily stats archive")
-    parser.add_argument("--create",
-                        action="store_true",
-                        help="Create the MSID H5 files from scratch")
-    parser.add_argument("--fix-misorders",
-                        action="store_true",
-                        default=False,
-                        help="Fix errors in ingest file order")
-    parser.add_argument("--state-codes-only",
-                        action="store_true",
-                        default=False,
-                        help="Only process MSIDs that have state codes")
-    parser.add_argument("--truncate",
-                        help="Truncate archive after <date> (CAUTION!!)")
-    parser.add_argument("--max-lookback-time",
-                        type=float,
-                        default=60,
-                        help="Maximum look back time for updating statistics (days)")
-    parser.add_argument("--date-now",
-                        default=DateTime().date,
-                        help="Set effective processing date for testing (default=NOW)")
-    parser.add_argument("--date-start",
-                        default=None,
-                        help=("Processing start date (loops by max-lookback-time "
-                              "until date-now if set)"))
-    parser.add_argument("--max-gap",
-                        type=float,
-                        help="Maximum time gap between archive files")
-    parser.add_argument("--allow-gap-after-days",
-                        type=float,
-                        default=4,
-                        help="Allow archive file gap when file is this old (days, default=4)")
-    parser.add_argument("--max-arch-files",
-                        type=int,
-                        default=500,
-                        help="Maximum number of archive files to ingest at once")
-    parser.add_argument("--data-root",
-                        default=".",
-                        help="Engineering archive root directory for MSID and arch files")
-    parser.add_argument("--content",
-                        action='append',
-                        help="Content type to process [match regex] (default = all)")
-    parser.add_argument("--log-level",
-                        help="Logging level")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Dry run (no actual file or database updatees)",
+    )
+    parser.add_argument(
+        "--no-full",
+        action="store_false",
+        dest="update_full",
+        default=True,
+        help="Do not fetch files from archive and update full-resolution MSID archive",
+    )
+    parser.add_argument(
+        "--no-stats",
+        action="store_false",
+        dest="update_stats",
+        default=True,
+        help="Do not update 5 minute and daily stats archive",
+    )
+    parser.add_argument(
+        "--create", action="store_true", help="Create the MSID H5 files from scratch"
+    )
+    parser.add_argument(
+        "--fix-misorders",
+        action="store_true",
+        default=False,
+        help="Fix errors in ingest file order",
+    )
+    parser.add_argument(
+        "--state-codes-only",
+        action="store_true",
+        default=False,
+        help="Only process MSIDs that have state codes",
+    )
+    parser.add_argument("--truncate", help="Truncate archive after <date> (CAUTION!!)")
+    parser.add_argument(
+        "--max-lookback-time",
+        type=float,
+        default=60,
+        help="Maximum look back time for updating statistics (days)",
+    )
+    parser.add_argument(
+        "--date-now",
+        default=DateTime().date,
+        help="Set effective processing date for testing (default=NOW)",
+    )
+    parser.add_argument(
+        "--date-start",
+        default=None,
+        help="Processing start date (loops by max-lookback-time until date-now if set)",
+    )
+    parser.add_argument(
+        "--max-gap", type=float, help="Maximum time gap between archive files"
+    )
+    parser.add_argument(
+        "--allow-gap-after-days",
+        type=float,
+        default=4,
+        help="Allow archive file gap when file is this old (days, default=4)",
+    )
+    parser.add_argument(
+        "--max-arch-files",
+        type=int,
+        default=500,
+        help="Maximum number of archive files to ingest at once",
+    )
+    parser.add_argument(
+        "--data-root",
+        default=".",
+        help="Engineering archive root directory for MSID and arch files",
+    )
+    parser.add_argument(
+        "--content",
+        action='append',
+        help="Content type to process [match regex] (default = all)",
+    )
+    parser.add_argument("--log-level", help="Logging level")
     return parser.parse_args(args)
 
 
@@ -102,11 +122,13 @@ if opt.create:
     opt.update_stats = False
 
 ft = fetch.ft
-msid_files = pyyaks.context.ContextDict('update_archive.msid_files',
-                                        basedir=opt.data_root)
+msid_files = pyyaks.context.ContextDict(
+    'update_archive.msid_files', basedir=opt.data_root
+)
 msid_files.update(file_defs.msid_files)
-arch_files = pyyaks.context.ContextDict('update_archive.arch_files',
-                                        basedir=opt.data_root)
+arch_files = pyyaks.context.ContextDict(
+    'update_archive.arch_files', basedir=opt.data_root
+)
 arch_files.update(file_defs.arch_files)
 
 # Set up fetch so it will first try to read from opt.data_root if that is
@@ -117,21 +139,35 @@ if opt.data_root:
 
 # Set up logging
 loglevel = pyyaks.logger.VERBOSE if opt.log_level is None else int(opt.log_level)
-logger = pyyaks.logger.get_logger(name='engarchive', level=loglevel,
-                                  format="%(asctime)s %(message)s")
+logger = pyyaks.logger.get_logger(
+    name='engarchive', level=loglevel, format="%(asctime)s %(message)s"
+)
 
 # Also adjust fetch logging if non-default log-level supplied (mostly for debug)
 if opt.log_level is not None:
     fetch.add_logging_handler(level=int(opt.log_level))
 
-archfiles_hdr_cols = ('tstart', 'tstop', 'startmjf', 'startmnf', 'stopmjf', 'stopmnf',
-                      'tlmver', 'ascdsver', 'revision', 'date')
+archfiles_hdr_cols = (
+    'tstart',
+    'tstop',
+    'startmjf',
+    'startmnf',
+    'stopmjf',
+    'stopmnf',
+    'tlmver',
+    'ascdsver',
+    'revision',
+    'date',
+)
 
 
 def get_colnames():
     """Get column names for the current content type (defined by ft['content'])"""
-    colnames = [x for x in pickle.load(open(msid_files['colnames'].abs, 'rb'))
-                if x not in fetch.IGNORE_COLNAMES]
+    colnames = [
+        x
+        for x in pickle.load(open(msid_files['colnames'].abs, 'rb'))
+        if x not in fetch.IGNORE_COLNAMES
+    ]
     return colnames
 
 
@@ -178,10 +214,12 @@ def fix_state_code(state_code):
         out = _fix_state_code_cache[state_code]
     except KeyError:
         out = state_code
-        for sub_in, sub_out in ((r'\+', 'PLUS_'),
-                                (r'\-', 'MINUS_'),
-                                (r'>', '_GREATER_'),
-                                (r'/', '_DIV_')):
+        for sub_in, sub_out in (
+            (r'\+', 'PLUS_'),
+            (r'\-', 'MINUS_'),
+            (r'>', '_GREATER_'),
+            (r'/', '_DIV_'),
+        ):
             out = re.sub(sub_in, sub_out, out)
         _fix_state_code_cache[state_code] = out
 
@@ -202,8 +240,9 @@ def main_loop():
     filetypes = fetch.filetypes
     if opt.content:
         contents = [x.upper() for x in opt.content]
-        filetypes = [x for x in filetypes
-                     if any(re.match(y, x.content) for y in contents)]
+        filetypes = [
+            x for x in filetypes if any(re.match(y, x.content) for y in contents)
+        ]
 
     # Update archive currently cannot create derived parameter content types
     if opt.create:
@@ -226,8 +265,11 @@ def main_loop():
             continue
 
         # Column names for stats updates (without TIME, MJF, MNF, TLM_FMT)
-        colnames = [x for x in pickle.load(open(msid_files['colnames'].abs, 'rb'))
-                    if x not in fetch.IGNORE_COLNAMES]
+        colnames = [
+            x
+            for x in pickle.load(open(msid_files['colnames'].abs, 'rb'))
+            if x not in fetch.IGNORE_COLNAMES
+        ]
 
         logger.info('Processing %s content type', ft['content'])
 
@@ -299,8 +341,8 @@ def fix_misorders(filetype):
         return
 
     for bad in np.flatnonzero(bads):
-        i2_0, i1_0 = archfiles['rowstart'][bad:bad + 2]
-        i2_1, i1_1 = archfiles['rowstop'][bad:bad + 2]
+        i2_0, i1_0 = archfiles['rowstart'][bad : bad + 2]
+        i2_1, i1_1 = archfiles['rowstop'][bad : bad + 2]
 
         # Update hdf5 file for each column (MSIDs + TIME, MJF, etc)
         for colname in colnames:
@@ -313,13 +355,13 @@ def fix_misorders(filetype):
 
                 hrd1 = hrd[i1_0:i1_1]
                 hrd2 = hrd[i2_0:i2_1]
-                hrd[i1_0:i1_0 + len(hrd2)] = hrd2
-                hrd[i1_0 + len(hrd2): i2_1] = hrd1
+                hrd[i1_0 : i1_0 + len(hrd2)] = hrd2
+                hrd[i1_0 + len(hrd2) : i2_1] = hrd1
 
                 hrq1 = hrq[i1_0:i1_1]
                 hrq2 = hrq[i2_0:i2_1]
-                hrq[i1_0:i1_0 + len(hrq2)] = hrq2
-                hrq[i1_0 + len(hrq2): i2_1] = hrq1
+                hrq[i1_0 : i1_0 + len(hrq2)] = hrq2
+                hrq[i1_0 + len(hrq2) : i2_1] = hrq1
 
                 h5.close()
 
@@ -337,8 +379,10 @@ def fix_misorders(filetype):
         logger.info('Running %s %s', cmd, vals1)
         logger.info('Running %s %s', cmd, vals2)
 
-        logger.info('Swapping rows %s for %s', [i1_0, i1_1, i2_0, i2_1], filetype.content)
-        logger.info('%s', archfiles[bad - 3:bad + 5])
+        logger.info(
+            'Swapping rows %s for %s', [i1_0, i1_1, i2_0, i2_1], filetype.content
+        )
+        logger.info('%s', archfiles[bad - 3 : bad + 5])
         logger.info('')
 
         if not opt.dry_run:
@@ -355,8 +399,7 @@ def del_stats(colname, time0, interval):
     that result from a file misorder.  Subsequent runs of update_stats will
     refresh the values correctly.
     """
-    dt = {'5min': 328,
-          'daily': 86400}[interval]
+    dt = {'5min': 328, 'daily': 86400}[interval]
 
     ft['msid'] = colname
     ft['interval'] = interval
@@ -366,8 +409,9 @@ def del_stats(colname, time0, interval):
 
     logger.info('Fixing stats file %s after time %s', stats_file, DateTime(time0).date)
 
-    stats = tables_open_file(stats_file, mode='a',
-                             filters=tables.Filters(complevel=5, complib='zlib'))
+    stats = tables_open_file(
+        stats_file, mode='a', filters=tables.Filters(complevel=5, complib='zlib')
+    )
     index0 = time0 // dt - 1
     indexes = stats.root.data.col('index')[:]
     row0 = np.searchsorted(indexes, [index0])[0]
@@ -377,8 +421,12 @@ def del_stats(colname, time0, interval):
             n_del = len_data - row0
         else:
             n_del = stats.root.data.remove_rows(row0, len_data)
-        logger.info('Deleted %d rows from row %s (%s) to end', n_del, row0,
-                    DateTime(indexes[row0] * dt).date)
+        logger.info(
+            'Deleted %d rows from row %s (%s) to end',
+            n_del,
+            row0,
+            DateTime(indexes[row0] * dt).date,
+        )
     else:
         logger.info('No rows of stats data to delete - skipping')
     stats.close()
@@ -445,14 +493,20 @@ def calc_stats_vals(msid, rows, indexes, interval):
                     dts = np.empty(n_vals, dtype=np.float64)
                     dts[0] = times[1] - times[0]
                     dts[-1] = times[-1] - times[-2]
-                    dts[1:-1] = ((times[1:-1] - times[:-2]) +
-                                 (times[2:] - times[1:-1])) / 2.0
+                    dts[1:-1] = (
+                        (times[1:-1] - times[:-2]) + (times[2:] - times[1:-1])
+                    ) / 2.0
                     negs = dts < 0.0
                     if np.any(negs):
-                        times_dts = [(DateTime(t).date, dt)
-                                     for t, dt in zip(times[negs], dts[negs])]
-                        logger.warning('WARNING - negative dts in {} at {}'
-                                       .format(msid.MSID, times_dts))
+                        times_dts = [
+                            (DateTime(t).date, dt)
+                            for t, dt in zip(times[negs], dts[negs])
+                        ]
+                        logger.warning(
+                            'WARNING - negative dts in {} at {}'.format(
+                                msid.MSID, times_dts
+                            )
+                        )
 
                     # Clip to range 0.001 to 300.0.  The low bound is just there
                     # for data with identical time stamps.  This shouldn't happen
@@ -479,7 +533,9 @@ def calc_stats_vals(msid, rows, indexes, interval):
                             logger.warning(f'{vals_minus_mean.dtype=}')
 
                     out['std'][i] = np.sqrt(sigma_sq)
-                    quant_vals = scipy.stats.mstats.mquantiles(vals, np.array(quantiles) / 100.0)
+                    quant_vals = scipy.stats.mstats.mquantiles(
+                        vals, np.array(quantiles) / 100.0
+                    )
                     for quant_val, quantile in zip(quant_vals, quantiles):
                         out['p%02d' % quantile][i] = quant_val
 
@@ -487,7 +543,9 @@ def calc_stats_vals(msid, rows, indexes, interval):
                 # If MSID has state codes then count the number of values in each state
                 # and store.  The MSID values can have trailing spaces to fill out to a
                 # uniform length, so state_code is right padded accordingly.
-                max_len = max(len(state_code) for raw_count, state_code in msid.state_codes)
+                max_len = max(
+                    len(state_code) for raw_count, state_code in msid.state_codes
+                )
                 fmtstr = '{:' + str(max_len) + 's}'
                 for raw_count, state_code in msid.state_codes:
                     state_count = np.count_nonzero(vals == fmtstr.format(state_code))
@@ -499,8 +557,7 @@ def calc_stats_vals(msid, rows, indexes, interval):
 
 
 def update_stats(colname, interval, msid=None):
-    dt = {'5min': 328,
-          'daily': 86400}[interval]
+    dt = {'5min': 328, 'daily': 86400}[interval]
 
     ft['msid'] = colname
     ft['interval'] = interval
@@ -511,8 +568,9 @@ def update_stats(colname, interval, msid=None):
         logger.info('Making stats dir {}'.format(msid_files['statsdir'].abs))
         os.makedirs(msid_files['statsdir'].abs)
 
-    stats = tables_open_file(stats_file, mode='a',
-                             filters=tables.Filters(complevel=5, complib='zlib'))
+    stats = tables_open_file(
+        stats_file, mode='a', filters=tables.Filters(complevel=5, complib='zlib')
+    )
 
     # INDEX0 is somewhat before any CXC archive data (which starts around 1999:205)
     INDEX0 = DateTime('1999:200:00:00:00').secs // dt
@@ -527,8 +585,10 @@ def update_stats(colname, interval, msid=None):
     # up to date then do not look back beyond a certain point.
     if msid is None:
         # fetch telemetry plus a little extra
-        time0 = max(DateTime(opt.date_now).secs - opt.max_lookback_time * 86400,
-                    index0 * dt - 500)
+        time0 = max(
+            DateTime(opt.date_now).secs - opt.max_lookback_time * 86400,
+            index0 * dt - 500,
+        )
         time1 = DateTime(opt.date_now).secs
         msid = fetch.MSID(colname, time0, time1, filter_bad=True)
 
@@ -553,17 +613,25 @@ def update_stats(colname, interval, msid=None):
                         stats.root.data.append(vals_stats)
                         logger.info('  Adding %d records', len(vals_stats))
                     except tables.NoSuchNodeError:
-                        logger.info('  Creating table with %d records ...', len(vals_stats))
-                        stats.create_table(stats.root, 'data', vals_stats,
-                                           "{} sampling".format(interval), expectedrows=2e7)
+                        logger.info(
+                            '  Creating table with %d records ...', len(vals_stats)
+                        )
+                        stats.create_table(
+                            stats.root,
+                            'data',
+                            vals_stats,
+                            "{} sampling".format(interval),
+                            expectedrows=2e7,
+                        )
                     stats.root.data.flush()
             else:
                 logger.info('  No stat records within available fetched values')
         else:
             logger.info('  No full stat intervals within fetched values')
     else:
-        logger.info('  No MSID data found within {} to {}'
-                    .format(msid.datestart, msid.datestop))
+        logger.info(
+            '  No MSID data found within {} to {}'.format(msid.datestart, msid.datestop)
+        )
 
     stats.close()
 
@@ -571,8 +639,7 @@ def update_stats(colname, interval, msid=None):
 
 
 def update_derived(filetype):
-    """Update full resolution MSID archive files for derived parameters with ``filetype``
-    """
+    """Update full resolution MSID archive files for derived parameters with ``filetype``"""
     # Get the last H5 table row from archfiles table for this content type
     db = Ska.DBI.DBI(dbi='sqlite', server=msid_files['archfiles'].abs)
     last_row = db.fetchone('SELECT * FROM archfiles ORDER BY filetime DESC')
@@ -630,8 +697,11 @@ def update_derived(filetype):
         archfiles.append('{}:{}:{}'.format(filetype['content'], index0, index1))
         if len(archfiles) == max_archfiles or index1 == indexes[-1]:
             update_msid_files(filetype, archfiles)
-            logger.verbose('update_msid_files(filetype={}, archfiles={})'
-                           .format(str(filetype), archfiles))
+            logger.verbose(
+                'update_msid_files(filetype={}, archfiles={})'.format(
+                    str(filetype), archfiles
+                )
+            )
             archfiles = []
 
 
@@ -667,12 +737,22 @@ def make_h5_col_file(dats, colname):
     col = dats[-1][colname]
     h5shape = (0,) + col.shape[1:]
     h5type = tables.Atom.from_dtype(col.dtype)
-    h5.create_earray(h5.root, 'data', h5type, h5shape, title=colname,
-                     expectedrows=n_rows)
-    h5.create_earray(h5.root, 'quality', tables.BoolAtom(), (0,), title='Quality',
-                     expectedrows=n_rows)
-    logger.verbose('WARNING: made new file {} for column {!r} shape={} with n_rows(1e6)={}'
-                   .format(filename, colname, h5shape, n_rows / 1.0e6))
+    h5.create_earray(
+        h5.root, 'data', h5type, h5shape, title=colname, expectedrows=n_rows
+    )
+    h5.create_earray(
+        h5.root,
+        'quality',
+        tables.BoolAtom(),
+        (0,),
+        title='Quality',
+        expectedrows=n_rows,
+    )
+    logger.verbose(
+        'WARNING: made new file {} for column {!r} shape={} with n_rows(1e6)={}'.format(
+            filename, colname, h5shape, n_rows / 1.0e6
+        )
+    )
     h5.close()
 
 
@@ -714,6 +794,7 @@ def append_h5_col(dats, colname, files_overlaps):
     :param dats: List of pyfits HDU data objects
     :param colname: column name
     """
+
     def i_colname(dat):
         """Return the index for `colname` in `dat`"""
         return list(dat.dtype.names).index(colname)
@@ -721,7 +802,9 @@ def append_h5_col(dats, colname, files_overlaps):
     h5 = tables_open_file(msid_files['msid'].abs, mode='a')
     stacked_data = np.hstack([x[colname] for x in dats])
     stacked_quality = np.hstack([x['QUALITY'][:, i_colname(x)] for x in dats])
-    logger.verbose('Appending %d items to %s' % (len(stacked_data), msid_files['msid'].abs))
+    logger.verbose(
+        'Appending %d items to %s' % (len(stacked_data), msid_files['msid'].abs)
+    )
 
     if not opt.dry_run:
         h5.root.data.append(stacked_data)
@@ -733,12 +816,15 @@ def append_h5_col(dats, colname, files_overlaps):
     # overlap.
     if colname == 'TIME':
         for file0, file1 in files_overlaps:
-            times = h5.root.data[file0['rowstart']:file0['rowstop']]
+            times = h5.root.data[file0['rowstart'] : file0['rowstop']]
             bad_rowstart = np.searchsorted(times, file1['tstart']) + file0['rowstart']
             bad_rowstop = file0['rowstop']
             if not opt.dry_run:
-                logger.verbose('Removing overlapping data in rows {0}:{1}'.format(
-                    bad_rowstart, bad_rowstop))
+                logger.verbose(
+                    'Removing overlapping data in rows {0}:{1}'.format(
+                        bad_rowstart, bad_rowstop
+                    )
+                )
                 if bad_rowstop > bad_rowstart:
                     h5.root.quality[bad_rowstart:bad_rowstop] = True
                 else:
@@ -749,8 +835,10 @@ def append_h5_col(dats, colname, files_overlaps):
                     # record.  Thus file0['tstop'] is generally very close to file1['tstart'],
                     # but in this case there can a tiny overlap (<< 1 ms) that triggers an
                     # overlap entry.
-                    logger.verbose('INFO: Unexpected null file overlap file0=%s file1=%s'
-                                   % (file0, file1))
+                    logger.verbose(
+                        'INFO: Unexpected null file overlap file0=%s file1=%s'
+                        % (file0, file1)
+                    )
 
     data_len = len(h5.root.data)
     h5.close()
@@ -772,8 +860,9 @@ def truncate_archive(filetype, date):
     db = Ska.DBI.DBI(dbi='sqlite', server=msid_files['archfiles'].abs, autocommit=False)
 
     # Get the earliest row number from the archfiles table where year>=year and doy=>doy
-    out = db.fetchall('SELECT rowstart FROM archfiles '
-                      'WHERE year>={0} AND doy>={1}'.format(year, doy))
+    out = db.fetchall(
+        'SELECT rowstart FROM archfiles WHERE year>={0} AND doy>={1}'.format(year, doy)
+    )
     if len(out) == 0:
         logger.verbose(f'No rows to delete - skipping')
         db.conn.close()
@@ -791,8 +880,11 @@ def truncate_archive(filetype, date):
                 h5.root.data.truncate(rowstart)
                 h5.root.quality.truncate(rowstart)
                 h5.close()
-            logger.verbose('Removed rows from {0} for filetype {1}:{2}'.format(
-                rowstart, filetype['content'], colname))
+            logger.verbose(
+                'Removed rows from {0} for filetype {1}:{2}'.format(
+                    rowstart, filetype['content'], colname
+                )
+            )
         else:
             logger.debug('MSID file {} not found - skipping'.format(filename))
 
@@ -819,7 +911,9 @@ def truncate_archive(filetype, date):
             os.unlink(filename)
             logger.info(f'Removed {filename}')
 
-    cmd = 'DELETE FROM archfiles WHERE (year>={0} AND doy>={1}) OR year>{0}'.format(year, doy)
+    cmd = 'DELETE FROM archfiles WHERE (year>={0} AND doy>={1}) OR year>{0}'.format(
+        year, doy
+    )
     if not opt.dry_run:
         db.execute(cmd)
         db.commit()
@@ -856,8 +950,11 @@ def read_archfile(i, f, filetype, row, colnames, archfiles, db):
 
     except converters.DataShapeError as err:
         hdus.close()
-        logger.warning('WARNING: skipping file {} with bad data shape: ASCDSVER={} {}'
-                       .format(filename, hdu.header['ASCDSVER'], err))
+        logger.warning(
+            'WARNING: skipping file {} with bad data shape: ASCDSVER={} {}'.format(
+                filename, hdu.header['ASCDSVER'], err
+            )
+        )
         return None, None
 
     # Accumlate relevant info about archfile that will be ingested into
@@ -868,7 +965,9 @@ def read_archfile(i, f, filetype, row, colnames, archfiles, db):
     archfiles_row['rowstart'] = row
     archfiles_row['rowstop'] = row + len(dat)
     archfiles_row['filename'] = filename
-    archfiles_row['filetime'] = int(re.search(r'(\d+)', archfiles_row['filename']).group(1))
+    archfiles_row['filetime'] = int(
+        re.search(r'(\d+)', archfiles_row['filename']).group(1)
+    )
     filedate = DateTime(archfiles_row['filetime']).date
     year, doy = (int(x) for x in re.search(r'(\d\d\d\d):(\d\d\d)', filedate).groups())
     archfiles_row['year'] = year
@@ -925,17 +1024,19 @@ def read_derived(i, filename, filetype, row, colnames, archfiles, db):
     # the needed info will be available to do the repair.
     date = DateTime(times[0]).date
     year, doy = date[0:4], date[5:8]
-    archfiles_row = dict(filename=filename,
-                         filetime=int(index0 * time_step),
-                         year=year,
-                         doy=doy,
-                         tstart=times[0],
-                         tstop=times[-1],
-                         rowstart=row,
-                         rowstop=row + len(dat),
-                         startmjf=index0,
-                         stopmjf=index1,
-                         date=date)
+    archfiles_row = dict(
+        filename=filename,
+        filetime=int(index0 * time_step),
+        year=year,
+        doy=doy,
+        tstart=times[0],
+        tstop=times[-1],
+        rowstart=row,
+        rowstop=row + len(dat),
+        startmjf=index0,
+        stopmjf=index1,
+        date=date,
+    )
 
     return dat, archfiles_row
 
@@ -958,10 +1059,10 @@ def update_msid_files(filetype, archfiles):
     dats = []
     archfiles_processed = []
 
-    content_is_derived = (filetype['instrum'] == 'DERIVED')
+    content_is_derived = filetype['instrum'] == 'DERIVED'
 
     for i, f in enumerate(archfiles):
-        get_data = (read_derived if content_is_derived else read_archfile)
+        get_data = read_derived if content_is_derived else read_archfile
         dat, archfiles_row = get_data(i, f, filetype, row, colnames, archfiles, db)
         if dat is None:
             continue
@@ -973,8 +1074,11 @@ def update_msid_files(filetype, archfiles):
             colnames = set(dat.dtype.names)
             for colname in dat.dtype.names:
                 if len(dat[colname].shape) > 1:
-                    logger.info('Removing column {} from colnames because shape = {}'
-                                .format(colname, dat[colname].shape))
+                    logger.info(
+                        'Removing column {} from colnames because shape = {}'.format(
+                            colname, dat[colname].shape
+                        )
+                    )
                     colnames.remove(colname)
 
         # Ensure that the time gap between the end of the last ingested archive
@@ -1008,17 +1112,25 @@ def update_msid_files(filetype, archfiles):
             else:
                 max_gap = 32.9
         if time_gap > max_gap:
-            logger.warning('WARNING: found gap of %.2f secs between archfiles %s and %s',
-                           time_gap, last_archfile['filename'], archfiles_row['filename'])
+            logger.warning(
+                'WARNING: found gap of %.2f secs between archfiles %s and %s',
+                time_gap,
+                last_archfile['filename'],
+                archfiles_row['filename'],
+            )
             if opt.create:
                 logger.warning('WARNING: Allowing gap because of opt.create=True')
-            elif DateTime() - DateTime(archfiles_row['tstart']) > opt.allow_gap_after_days:
+            elif (
+                DateTime() - DateTime(archfiles_row['tstart'])
+                > opt.allow_gap_after_days
+            ):
                 # After 4 days (by default) just let it go through because this is
                 # likely a real gap and will not be fixed by subsequent processing.
                 # This can happen after normal sun mode to SIM products.
-                logger.warning('WARNING: Allowing gap because arch file '
-                               'start is more than {} days old'
-                               .format(opt.allow_gap_after_days))
+                logger.warning(
+                    'WARNING: Allowing gap because arch file '
+                    'start is more than {} days old'.format(opt.allow_gap_after_days)
+                )
             else:
                 break
         elif time_gap < 0:
@@ -1034,8 +1146,10 @@ def update_msid_files(filetype, archfiles):
         # since last_archfile is set above the gap check considers this file to
         # have been ingested.
         if not content_is_derived and dat['QUALITY'].shape[1] != len(dat.dtype.names):
-            logger.warning('WARNING: skipping because of quality size mismatch: %d %d' %
-                           (dat['QUALITY'].shape[1], len(dat.dtype.names)))
+            logger.warning(
+                'WARNING: skipping because of quality size mismatch: %d %d'
+                % (dat['QUALITY'].shape[1], len(dat.dtype.names))
+            )
             continue
 
         # Mark the archfile as ingested in the database and add to list for
@@ -1078,8 +1192,9 @@ def update_msid_files(filetype, archfiles):
             processed_cols.add(colname)
 
         if len(data_lens) != 1:
-            raise ValueError('h5 data length inconsistency {}, investigate NOW!'
-                             .format(data_lens))
+            raise ValueError(
+                'h5 data length inconsistency {}, investigate NOW!'.format(data_lens)
+            )
 
         # Process any new MSIDs (this is extremely rare)
         data_len = data_lens.pop()
@@ -1094,15 +1209,21 @@ def update_msid_files(filetype, archfiles):
 
     # If colnames or colnames_all changed then give warning and update files.
     if colnames != old_colnames:
-        logger.warning('WARNING: updating %s because colnames changed: %s'
-                       % (msid_files['colnames'].abs, old_colnames ^ colnames))
+        logger.warning(
+            'WARNING: updating %s because colnames changed: %s'
+            % (msid_files['colnames'].abs, old_colnames ^ colnames)
+        )
         if not opt.dry_run:
             pickle.dump(colnames, open(msid_files['colnames'].abs, 'wb'), protocol=0)
     if colnames_all != old_colnames_all:
-        logger.warning('WARNING: updating %s because colnames_all changed: %s'
-                       % (msid_files['colnames_all'].abs, colnames_all ^ old_colnames_all))
+        logger.warning(
+            'WARNING: updating %s because colnames_all changed: %s'
+            % (msid_files['colnames_all'].abs, colnames_all ^ old_colnames_all)
+        )
         if not opt.dry_run:
-            pickle.dump(colnames_all, open(msid_files['colnames_all'].abs, 'wb'), protocol=0)
+            pickle.dump(
+                colnames_all, open(msid_files['colnames_all'].abs, 'wb'), protocol=0
+            )
 
     return archfiles_processed
 
@@ -1123,7 +1244,7 @@ def get_archive_files(filetype):
     # Don't allow arbitrary arch files at once because of memory issues.
     files = sorted(glob.glob(filetype['fileglob']))
     if files:
-        return sorted(files)[:opt.max_arch_files]
+        return sorted(files)[: opt.max_arch_files]
 
     # Retrieve CXC archive files in a temp directory with arc5gl
     arc5 = Ska.arc5gl.Arc5gl(echo=True)
@@ -1135,8 +1256,9 @@ def get_archive_files(filetype):
     # do not look back further than --max-lookback-time
     db = Ska.DBI.DBI(dbi='sqlite', server=msid_files['archfiles'].abs)
     vals = db.fetchone("select max(filetime) from archfiles")
-    datestart = DateTime(max(vals['max(filetime)'] or 0.0,
-                             datestop.secs - opt.max_lookback_time * 86400))
+    datestart = DateTime(
+        max(vals['max(filetime)'] or 0.0, datestop.secs - opt.max_lookback_time * 86400)
+    )
 
     # For *ephem0 the query needs to extend well into the future
     # to guarantee getting all available files.  This is the archives fault.
@@ -1146,8 +1268,11 @@ def get_archive_files(filetype):
     # For instrum==EPHEM break queries into time ranges no longer than
     # 100000 sec each.  EPHEM files are at least 7 days long and generated
     # no more often than every ~3 days so this should work.
-    n_queries = (1 if filetype['instrum'] != 'EPHEM'
-                 else 1 + round((datestop.secs - datestart.secs) / 100000.))
+    n_queries = (
+        1
+        if filetype['instrum'] != 'EPHEM'
+        else 1 + round((datestop.secs - datestart.secs) / 100000.0)
+    )
     times = np.linspace(datestart.secs, datestop.secs, n_queries + 1)
 
     logger.info('********** %s %s **********' % (ft['content'], time.ctime()))
@@ -1158,8 +1283,10 @@ def get_archive_files(filetype):
             arc5.sendline('tstop=%s' % DateTime(t1).date)
             arc5.sendline('get %s' % filetype['arc5gl_query'].lower())
         else:
-            logger.info('INFO: Skipping archive query because datestop={} < datestart={}'
-                        .format(DateTime(t1).date, DateTime(t0).date))
+            logger.info(
+                'INFO: Skipping archive query because datestop={} < datestart={}'
+                .format(DateTime(t1).date, DateTime(t0).date)
+            )
 
     return sorted(glob.glob(filetype['fileglob']))
 
@@ -1175,9 +1302,11 @@ def main():
     if opt.date_start is None:
         date_nows = [opt.date_now]
     else:
-        t_starts = np.arange(DateTime(opt.date_start).secs,
-                             DateTime(opt.date_now).secs,
-                             opt.max_lookback_time * 86400.)
+        t_starts = np.arange(
+            DateTime(opt.date_start).secs,
+            DateTime(opt.date_now).secs,
+            opt.max_lookback_time * 86400.0,
+        )
         date_nows = [DateTime(t).date for t in t_starts]
         date_nows.append(opt.date_now)
 

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -106,7 +106,7 @@ def get_options(args=None):
     )
     parser.add_argument(
         "--content",
-        action='append',
+        action="append",
         help="Content type to process [match regex] (default = all)",
     )
     parser.add_argument("--log-level", help="Logging level")
@@ -123,11 +123,11 @@ if opt.create:
 
 ft = fetch.ft
 msid_files = pyyaks.context.ContextDict(
-    'update_archive.msid_files', basedir=opt.data_root
+    "update_archive.msid_files", basedir=opt.data_root
 )
 msid_files.update(file_defs.msid_files)
 arch_files = pyyaks.context.ContextDict(
-    'update_archive.arch_files', basedir=opt.data_root
+    "update_archive.arch_files", basedir=opt.data_root
 )
 arch_files.update(file_defs.arch_files)
 
@@ -135,12 +135,12 @@ arch_files.update(file_defs.arch_files)
 # provided as an option and exists, and if not fall back to the default of
 # fetch.ENG_ARCHIVE.  Fetch is a read-only process so this is safe when testing.
 if opt.data_root:
-    fetch.msid_files.basedir = ':'.join([opt.data_root, fetch.ENG_ARCHIVE])
+    fetch.msid_files.basedir = ":".join([opt.data_root, fetch.ENG_ARCHIVE])
 
 # Set up logging
 loglevel = pyyaks.logger.VERBOSE if opt.log_level is None else int(opt.log_level)
 logger = pyyaks.logger.get_logger(
-    name='engarchive', level=loglevel, format="%(asctime)s %(message)s"
+    name="engarchive", level=loglevel, format="%(asctime)s %(message)s"
 )
 
 # Also adjust fetch logging if non-default log-level supplied (mostly for debug)
@@ -148,16 +148,16 @@ if opt.log_level is not None:
     fetch.add_logging_handler(level=int(opt.log_level))
 
 archfiles_hdr_cols = (
-    'tstart',
-    'tstop',
-    'startmjf',
-    'startmnf',
-    'stopmjf',
-    'stopmnf',
-    'tlmver',
-    'ascdsver',
-    'revision',
-    'date',
+    "tstart",
+    "tstop",
+    "startmjf",
+    "startmnf",
+    "stopmjf",
+    "stopmnf",
+    "tlmver",
+    "ascdsver",
+    "revision",
+    "date",
 )
 
 
@@ -165,7 +165,7 @@ def get_colnames():
     """Get column names for the current content type (defined by ft['content'])"""
     colnames = [
         x
-        for x in pickle.load(open(msid_files['colnames'].abs, 'rb'))
+        for x in pickle.load(open(msid_files["colnames"].abs, "rb"))
         if x not in fetch.IGNORE_COLNAMES
     ]
     return colnames
@@ -179,24 +179,24 @@ def create_content_dir():
     This only works within the development (git) directory in conjunction
     with the --create option.
     """
-    dirname = msid_files['contentdir'].abs
+    dirname = msid_files["contentdir"].abs
     if not os.path.exists(dirname):
-        logger.info('Making directory {}'.format(dirname))
+        logger.info("Making directory {}".format(dirname))
         os.makedirs(dirname)
 
     empty = set()
-    if not os.path.exists(msid_files['colnames'].abs):
-        with open(msid_files['colnames'].abs, 'wb') as f:
+    if not os.path.exists(msid_files["colnames"].abs):
+        with open(msid_files["colnames"].abs, "wb") as f:
             pickle.dump(empty, f, protocol=0)
-    if not os.path.exists(msid_files['colnames_all'].abs):
-        with open(msid_files['colnames_all'].abs, 'wb') as f:
+    if not os.path.exists(msid_files["colnames_all"].abs):
+        with open(msid_files["colnames_all"].abs, "wb") as f:
             pickle.dump(empty, f, protocol=0)
 
-    if not os.path.exists(msid_files['archfiles'].abs):
-        archfiles_def = open(Path(__file__).parent / 'archfiles_def.sql').read()
-        filename = msid_files['archfiles'].abs
-        logger.info('Creating db {}'.format(filename))
-        db = Ska.DBI.DBI(dbi='sqlite', server=filename, autocommit=False)
+    if not os.path.exists(msid_files["archfiles"].abs):
+        archfiles_def = open(Path(__file__).parent / "archfiles_def.sql").read()
+        filename = msid_files["archfiles"].abs
+        logger.info("Creating db {}".format(filename))
+        db = Ska.DBI.DBI(dbi="sqlite", server=filename, autocommit=False)
         db.execute(archfiles_def)
         db.commit()
 
@@ -215,10 +215,10 @@ def fix_state_code(state_code):
     except KeyError:
         out = state_code
         for sub_in, sub_out in (
-            (r'\+', 'PLUS_'),
-            (r'\-', 'MINUS_'),
-            (r'>', '_GREATER_'),
-            (r'/', '_DIV_'),
+            (r"\+", "PLUS_"),
+            (r"\-", "MINUS_"),
+            (r">", "_GREATER_"),
+            (r"/", "_DIV_"),
         ):
             out = re.sub(sub_in, sub_out, out)
         _fix_state_code_cache[state_code] = out
@@ -231,10 +231,10 @@ def main_loop():
     Perform one full update of the eng archive based on opt parameters.
     This may be called in a loop by the program-level main().
     """
-    logger.info('Run time options: \n{}'.format(opt))
-    logger.info('Update_archive file: {}'.format(os.path.abspath(__file__)))
-    logger.info('Fetch module file: {}'.format(os.path.abspath(fetch.__file__)))
-    logger.info('')
+    logger.info("Run time options: \n{}".format(opt))
+    logger.info("Update_archive file: {}".format(os.path.abspath(__file__)))
+    logger.info("Fetch module file: {}".format(os.path.abspath(fetch.__file__)))
+    logger.info("")
 
     # Get the archive content filetypes
     filetypes = fetch.filetypes
@@ -246,32 +246,32 @@ def main_loop():
 
     # Update archive currently cannot create derived parameter content types
     if opt.create:
-        filetypes = [x for x in filetypes if not x.content.startswith('DP_')]
+        filetypes = [x for x in filetypes if not x.content.startswith("DP_")]
 
     for filetype in filetypes:
         # Update attributes of global ContextValue "ft".  This is needed for
         # rendering of "files" ContextValue.
-        ft['content'] = filetype.content.lower()
+        ft["content"] = filetype.content.lower()
 
         if opt.create:
             create_content_dir()
 
-        if not os.path.exists(msid_files['colnames'].abs):
+        if not os.path.exists(msid_files["colnames"].abs):
             logger.info(f'No colnames.pickle for {ft["content"]} - skipping')
             continue
 
-        if not os.path.exists(fetch.msid_files['archfiles'].abs):
+        if not os.path.exists(fetch.msid_files["archfiles"].abs):
             logger.info(f'No archfiles.db3 for {ft["content"]} - skipping')
             continue
 
         # Column names for stats updates (without TIME, MJF, MNF, TLM_FMT)
         colnames = [
             x
-            for x in pickle.load(open(msid_files['colnames'].abs, 'rb'))
+            for x in pickle.load(open(msid_files["colnames"].abs, "rb"))
             if x not in fetch.IGNORE_COLNAMES
         ]
 
-        logger.info('Processing %s content type', ft['content'])
+        logger.info("Processing %s content type", ft["content"])
 
         if opt.truncate:
             truncate_archive(filetype, opt.truncate)
@@ -281,12 +281,12 @@ def main_loop():
             misorder_time = fix_misorders(filetype)
             if misorder_time:
                 for colname in colnames:
-                    del_stats(colname, misorder_time, 'daily')
-                    del_stats(colname, misorder_time, '5min')
+                    del_stats(colname, misorder_time, "daily")
+                    del_stats(colname, misorder_time, "5min")
             continue
 
         if opt.update_full:
-            if filetype['instrum'] == 'DERIVED':
+            if filetype["instrum"] == "DERIVED":
                 update_derived(filetype)
             else:
                 update_archive(filetype)
@@ -297,13 +297,13 @@ def main_loop():
                     # Check if colname has a state code in the TDB or if it is in the
                     # special-case fetch.STATE_CODES dict (e.g. simdiag or simmrg telem).
                     try:
-                        Ska.tdb.msids[colname].Tsc['STATE_CODE']
+                        Ska.tdb.msids[colname].Tsc["STATE_CODE"]
                     except Exception:
                         if not colname.upper() in fetch.STATE_CODES:
                             continue
 
-                msid = update_stats(colname, 'daily')
-                update_stats(colname, '5min', msid)
+                msid = update_stats(colname, "daily")
+                update_stats(colname, "5min", msid)
 
 
 def fix_misorders(filetype):
@@ -327,29 +327,29 @@ def fix_misorders(filetype):
     :param filetype: filetype
     :returns: minimum time for all misorders found
     """
-    colnames = pickle.load(open(msid_files['colnames'].abs, 'rb'))
+    colnames = pickle.load(open(msid_files["colnames"].abs, "rb"))
 
     # Setup db handle with autocommit=False so that error along the way aborts insert transactions
-    db = Ska.DBI.DBI(dbi='sqlite', server=msid_files['archfiles'].abs, autocommit=False)
+    db = Ska.DBI.DBI(dbi="sqlite", server=msid_files["archfiles"].abs, autocommit=False)
 
     # Get misordered archive files
-    archfiles = db.fetchall('SELECT * FROM archfiles order by filename')
-    bads = archfiles['rowstart'][1:] - archfiles['rowstart'][:-1] < 0
+    archfiles = db.fetchall("SELECT * FROM archfiles order by filename")
+    bads = archfiles["rowstart"][1:] - archfiles["rowstart"][:-1] < 0
 
     if not np.any(bads):
-        logger.info('No misorders')
+        logger.info("No misorders")
         return
 
     for bad in np.flatnonzero(bads):
-        i2_0, i1_0 = archfiles['rowstart'][bad : bad + 2]
-        i2_1, i1_1 = archfiles['rowstop'][bad : bad + 2]
+        i2_0, i1_0 = archfiles["rowstart"][bad : bad + 2]
+        i2_1, i1_1 = archfiles["rowstop"][bad : bad + 2]
 
         # Update hdf5 file for each column (MSIDs + TIME, MJF, etc)
         for colname in colnames:
-            ft['msid'] = colname
-            logger.info('Fixing %s', msid_files['msid'].abs)
+            ft["msid"] = colname
+            logger.info("Fixing %s", msid_files["msid"].abs)
             if not opt.dry_run:
-                h5 = tables_open_file(msid_files['msid'].abs, mode='a')
+                h5 = tables_open_file(msid_files["msid"].abs, mode="a")
                 hrd = h5.root.data
                 hrq = h5.root.quality
 
@@ -366,31 +366,31 @@ def fix_misorders(filetype):
                 h5.close()
 
         # Update the archfiles table
-        cmd = 'UPDATE archfiles SET '
-        cols = ['rowstart', 'rowstop']
-        cmd += ', '.join(['%s=?' % x for x in cols])
-        cmd += ' WHERE filename=?'
+        cmd = "UPDATE archfiles SET "
+        cols = ["rowstart", "rowstop"]
+        cmd += ", ".join(["%s=?" % x for x in cols])
+        cmd += " WHERE filename=?"
         rowstart1 = i1_0
         rowstop1 = rowstart1 + i2_1 - i2_0
         rowstart2 = rowstop1 + 1
         rowstop2 = i2_1
-        vals1 = [rowstart1, rowstop1, archfiles['filename'][bad]]
-        vals2 = [rowstart2, rowstop2, archfiles['filename'][bad + 1]]
-        logger.info('Running %s %s', cmd, vals1)
-        logger.info('Running %s %s', cmd, vals2)
+        vals1 = [rowstart1, rowstop1, archfiles["filename"][bad]]
+        vals2 = [rowstart2, rowstop2, archfiles["filename"][bad + 1]]
+        logger.info("Running %s %s", cmd, vals1)
+        logger.info("Running %s %s", cmd, vals2)
 
         logger.info(
-            'Swapping rows %s for %s', [i1_0, i1_1, i2_0, i2_1], filetype.content
+            "Swapping rows %s for %s", [i1_0, i1_1, i2_0, i2_1], filetype.content
         )
-        logger.info('%s', archfiles[bad - 3 : bad + 5])
-        logger.info('')
+        logger.info("%s", archfiles[bad - 3 : bad + 5])
+        logger.info("")
 
         if not opt.dry_run:
             db.execute(cmd, [x.tolist() for x in vals1])
             db.execute(cmd, [x.tolist() for x in vals2])
             db.commit()
 
-    return np.min(archfiles['tstart'][bads])
+    return np.min(archfiles["tstart"][bads])
 
 
 def del_stats(colname, time0, interval):
@@ -399,21 +399,21 @@ def del_stats(colname, time0, interval):
     that result from a file misorder.  Subsequent runs of update_stats will
     refresh the values correctly.
     """
-    dt = {'5min': 328, 'daily': 86400}[interval]
+    dt = {"5min": 328, "daily": 86400}[interval]
 
-    ft['msid'] = colname
-    ft['interval'] = interval
-    stats_file = msid_files['stats'].abs
+    ft["msid"] = colname
+    ft["interval"] = interval
+    stats_file = msid_files["stats"].abs
     if not os.path.exists(stats_file):
-        raise IOError('Stats file {} not found'.format(stats_file))
+        raise IOError("Stats file {} not found".format(stats_file))
 
-    logger.info('Fixing stats file %s after time %s', stats_file, DateTime(time0).date)
+    logger.info("Fixing stats file %s after time %s", stats_file, DateTime(time0).date)
 
     stats = tables_open_file(
-        stats_file, mode='a', filters=tables.Filters(complevel=5, complib='zlib')
+        stats_file, mode="a", filters=tables.Filters(complevel=5, complib="zlib")
     )
     index0 = time0 // dt - 1
-    indexes = stats.root.data.col('index')[:]
+    indexes = stats.root.data.col("index")[:]
     row0 = np.searchsorted(indexes, [index0])[0]
     len_data = len(stats.root.data)
     if row0 < len_data:
@@ -422,13 +422,13 @@ def del_stats(colname, time0, interval):
         else:
             n_del = stats.root.data.remove_rows(row0, len_data)
         logger.info(
-            'Deleted %d rows from row %s (%s) to end',
+            "Deleted %d rows from row %s (%s) to end",
             n_del,
             row0,
             DateTime(indexes[row0] * dt).date,
         )
     else:
-        logger.info('No rows of stats data to delete - skipping')
+        logger.info("No rows of stats data to delete - skipping")
     stats.close()
 
 
@@ -452,29 +452,29 @@ def calc_stats_vals(msid, rows, indexes, interval):
 
     # If MSID data is unicode, then for stats purposes cast back to bytes
     # by creating the output array as a like-sized S-type array.
-    if msid_dtype.kind == 'U':
-        msid_dtype = re.sub(r'U', 'S', msid.vals.dtype.str)
+    if msid_dtype.kind == "U":
+        msid_dtype = re.sub(r"U", "S", msid.vals.dtype.str)
 
     # Predeclare numpy arrays of correct type and sufficient size for accumulating results.
     out = OrderedDict()
-    out['index'] = np.ndarray((n_out,), dtype=np.int32)
-    out['n'] = np.ndarray((n_out,), dtype=np.int32)
-    out['val'] = np.ndarray((n_out,), dtype=msid_dtype)
+    out["index"] = np.ndarray((n_out,), dtype=np.int32)
+    out["n"] = np.ndarray((n_out,), dtype=np.int32)
+    out["val"] = np.ndarray((n_out,), dtype=msid_dtype)
 
     if msid_is_numeric:
-        out['min'] = np.ndarray((n_out,), dtype=msid_dtype)
-        out['max'] = np.ndarray((n_out,), dtype=msid_dtype)
-        out['mean'] = np.ndarray((n_out,), dtype=np.float32)
+        out["min"] = np.ndarray((n_out,), dtype=msid_dtype)
+        out["max"] = np.ndarray((n_out,), dtype=msid_dtype)
+        out["mean"] = np.ndarray((n_out,), dtype=np.float32)
 
-        if interval == 'daily':
-            out['std'] = np.ndarray((n_out,), dtype=msid_dtype)
+        if interval == "daily":
+            out["std"] = np.ndarray((n_out,), dtype=msid_dtype)
             for quantile in quantiles:
-                out['p{:02d}'.format(quantile)] = np.ndarray((n_out,), dtype=msid_dtype)
+                out["p{:02d}".format(quantile)] = np.ndarray((n_out,), dtype=msid_dtype)
 
     # MSID may have state codes
     if msid.state_codes:
         for raw_count, state_code in msid.state_codes:
-            out['n_' + fix_state_code(state_code)] = np.zeros(n_out, dtype=np.int32)
+            out["n_" + fix_state_code(state_code)] = np.zeros(n_out, dtype=np.int32)
 
     i = 0
     for row0, row1, index in zip(rows[:-1], rows[1:], indexes[:-1]):
@@ -483,9 +483,9 @@ def calc_stats_vals(msid, rows, indexes, interval):
 
         n_vals = len(vals)
         if n_vals > 0:
-            out['index'][i] = index
-            out['n'][i] = n_vals
-            out['val'][i] = vals[n_vals // 2]
+            out["index"][i] = index
+            out["n"][i] = n_vals
+            out["val"][i] = vals[n_vals // 2]
             if msid_is_numeric:
                 if n_vals <= 2:
                     dts = np.ones(n_vals, dtype=np.float64)
@@ -503,7 +503,7 @@ def calc_stats_vals(msid, rows, indexes, interval):
                             for t, dt in zip(times[negs], dts[negs])
                         ]
                         logger.warning(
-                            'WARNING - negative dts in {} at {}'.format(
+                            "WARNING - negative dts in {} at {}".format(
                                 msid.MSID, times_dts
                             )
                         )
@@ -516,28 +516,28 @@ def calc_stats_vals(msid, rows, indexes, interval):
                     dts.clip(0.001, 300.0, out=dts)
                 sum_dts = np.sum(dts)
 
-                out['min'][i] = np.min(vals)
-                out['max'][i] = np.max(vals)
-                out['mean'][i] = np.sum(dts * vals) / sum_dts
-                if interval == 'daily':
+                out["min"][i] = np.min(vals)
+                out["max"][i] = np.max(vals)
+                out["mean"][i] = np.sum(dts * vals) / sum_dts
+                if interval == "daily":
                     # biased weighted estimator of variance (N should be big enough)
                     # http://en.wikipedia.org/wiki/Mean_square_weighted_deviation.
                     # Note casting of vals to float64 to avoid overflow in square.
-                    vals_minus_mean = vals.astype(np.float64) - out['mean'][i]
+                    vals_minus_mean = vals.astype(np.float64) - out["mean"][i]
                     with warnings.catch_warnings(record=True) as warns:
                         sigma_sq = np.sum(dts * vals_minus_mean**2) / sum_dts
                         if warns:
                             logger.warning(repr(warns[0].message))
-                            logger.warning(f'{msid=}')
-                            logger.warning(f'{np.max(np.abs(vals_minus_mean))=}')
-                            logger.warning(f'{vals_minus_mean.dtype=}')
+                            logger.warning(f"{msid=}")
+                            logger.warning(f"{np.max(np.abs(vals_minus_mean))=}")
+                            logger.warning(f"{vals_minus_mean.dtype=}")
 
-                    out['std'][i] = np.sqrt(sigma_sq)
+                    out["std"][i] = np.sqrt(sigma_sq)
                     quant_vals = scipy.stats.mstats.mquantiles(
                         vals, np.array(quantiles) / 100.0
                     )
                     for quant_val, quantile in zip(quant_vals, quantiles):
-                        out['p%02d' % quantile][i] = quant_val
+                        out["p%02d" % quantile][i] = quant_val
 
             if msid.state_codes:
                 # If MSID has state codes then count the number of values in each state
@@ -546,10 +546,10 @@ def calc_stats_vals(msid, rows, indexes, interval):
                 max_len = max(
                     len(state_code) for raw_count, state_code in msid.state_codes
                 )
-                fmtstr = '{:' + str(max_len) + 's}'
+                fmtstr = "{:" + str(max_len) + "s}"
                 for raw_count, state_code in msid.state_codes:
                     state_count = np.count_nonzero(vals == fmtstr.format(state_code))
-                    out['n_' + fix_state_code(state_code)][i] = state_count
+                    out["n_" + fix_state_code(state_code)][i] = state_count
 
             i += 1
 
@@ -557,23 +557,23 @@ def calc_stats_vals(msid, rows, indexes, interval):
 
 
 def update_stats(colname, interval, msid=None):
-    dt = {'5min': 328, 'daily': 86400}[interval]
+    dt = {"5min": 328, "daily": 86400}[interval]
 
-    ft['msid'] = colname
-    ft['interval'] = interval
-    stats_file = msid_files['stats'].abs
-    logger.info('Updating stats file %s', stats_file)
+    ft["msid"] = colname
+    ft["interval"] = interval
+    stats_file = msid_files["stats"].abs
+    logger.info("Updating stats file %s", stats_file)
 
-    if not os.path.exists(msid_files['statsdir'].abs):
-        logger.info('Making stats dir {}'.format(msid_files['statsdir'].abs))
-        os.makedirs(msid_files['statsdir'].abs)
+    if not os.path.exists(msid_files["statsdir"].abs):
+        logger.info("Making stats dir {}".format(msid_files["statsdir"].abs))
+        os.makedirs(msid_files["statsdir"].abs)
 
     stats = tables_open_file(
-        stats_file, mode='a', filters=tables.Filters(complevel=5, complib='zlib')
+        stats_file, mode="a", filters=tables.Filters(complevel=5, complib="zlib")
     )
 
     # INDEX0 is somewhat before any CXC archive data (which starts around 1999:205)
-    INDEX0 = DateTime('1999:200:00:00:00').secs // dt
+    INDEX0 = DateTime("1999:200:00:00:00").secs // dt
     try:
         index0 = stats.root.data.cols.index[-1] + 1
     except tables.NoSuchNodeError:
@@ -611,26 +611,26 @@ def update_stats(colname, interval, msid=None):
                 if not opt.dry_run:
                     try:
                         stats.root.data.append(vals_stats)
-                        logger.info('  Adding %d records', len(vals_stats))
+                        logger.info("  Adding %d records", len(vals_stats))
                     except tables.NoSuchNodeError:
                         logger.info(
-                            '  Creating table with %d records ...', len(vals_stats)
+                            "  Creating table with %d records ...", len(vals_stats)
                         )
                         stats.create_table(
                             stats.root,
-                            'data',
+                            "data",
                             vals_stats,
                             "{} sampling".format(interval),
                             expectedrows=2e7,
                         )
                     stats.root.data.flush()
             else:
-                logger.info('  No stat records within available fetched values')
+                logger.info("  No stat records within available fetched values")
         else:
-            logger.info('  No full stat intervals within fetched values')
+            logger.info("  No full stat intervals within fetched values")
     else:
         logger.info(
-            '  No MSID data found within {} to {}'.format(msid.datestart, msid.datestop)
+            "  No MSID data found within {} to {}".format(msid.datestart, msid.datestop)
         )
 
     stats.close()
@@ -641,18 +641,18 @@ def update_stats(colname, interval, msid=None):
 def update_derived(filetype):
     """Update full resolution MSID archive files for derived parameters with ``filetype``"""
     # Get the last H5 table row from archfiles table for this content type
-    db = Ska.DBI.DBI(dbi='sqlite', server=msid_files['archfiles'].abs)
-    last_row = db.fetchone('SELECT * FROM archfiles ORDER BY filetime DESC')
+    db = Ska.DBI.DBI(dbi="sqlite", server=msid_files["archfiles"].abs)
+    last_row = db.fetchone("SELECT * FROM archfiles ORDER BY filetime DESC")
 
     # Set the starting index from the last row in archfiles.  This
     # uses Python slicing conventions so that the previous "end"
     # value is exactly the next "start" values, e.g. [index0:index1]
     # For derived parameters we have stopmjf <==> index1
-    index0 = last_row['stopmjf']
+    index0 = last_row["stopmjf"]
 
     # Get the full set of rootparams for all colnames
-    colnames = pickle.load(open(msid_files['colnames'].abs, 'rb'))
-    colnames = [x for x in colnames if x.startswith('DP_')]
+    colnames = pickle.load(open(msid_files["colnames"].abs, "rb"))
+    colnames = [x for x in colnames if x.startswith("DP_")]
     msids = set()
     time_step = None
     for colname in colnames:
@@ -665,16 +665,16 @@ def update_derived(filetype):
     # occuring in the list of rootparam MSIDs.
     # fetch.content is a mapping from MSID to content type
     last_times = {}
-    ft_content = ft['content'].val
+    ft_content = ft["content"].val
     for msid in msids:
-        ft['msid'] = 'TIME'
-        content = ft['content'] = fetch.content[msid]
+        ft["msid"] = "TIME"
+        content = ft["content"] = fetch.content[msid]
         if content not in last_times:
-            h5 = tables_open_file(fetch.msid_files['msid'].abs, mode='r')
+            h5 = tables_open_file(fetch.msid_files["msid"].abs, mode="r")
             last_times[content] = h5.root.data[-1]
             h5.close()
     last_time = min(last_times.values()) - 1000
-    ft['content'] = ft_content
+    ft["content"] = ft_content
 
     # Make a list of indexes that will correspond to the index/time ranges
     # for each pseudo-"archfile".  In this context an archfile just specifies
@@ -694,11 +694,11 @@ def update_derived(filetype):
 
     archfiles = []
     for index0, index1 in zip(indexes[:-1], indexes[1:]):
-        archfiles.append('{}:{}:{}'.format(filetype['content'], index0, index1))
+        archfiles.append("{}:{}:{}".format(filetype["content"], index0, index1))
         if len(archfiles) == max_archfiles or index1 == indexes[-1]:
             update_msid_files(filetype, archfiles)
             logger.verbose(
-                'update_msid_files(filetype={}, archfiles={})'.format(
+                "update_msid_files(filetype={}, archfiles={})".format(
                     str(filetype), archfiles
                 )
             )
@@ -721,35 +721,35 @@ def update_archive(filetype):
 
 def make_h5_col_file(dats, colname):
     """Make a new h5 table to hold column from ``dat``."""
-    filename = msid_files['msid'].abs
+    filename = msid_files["msid"].abs
     filedir = os.path.dirname(filename)
     if not os.path.exists(filedir):
         os.makedirs(filedir)
 
     # Estimate the number of rows for 20 years based on available data
-    times = np.hstack([x['TIME'] for x in dats])
+    times = np.hstack([x["TIME"] for x in dats])
     dt = np.median(times[1:] - times[:-1])
     n_rows = int(86400 * 365 * 20 / dt)
 
-    filters = tables.Filters(complevel=5, complib='zlib')
-    h5 = tables_open_file(filename, mode='w', filters=filters)
+    filters = tables.Filters(complevel=5, complib="zlib")
+    h5 = tables_open_file(filename, mode="w", filters=filters)
 
     col = dats[-1][colname]
     h5shape = (0,) + col.shape[1:]
     h5type = tables.Atom.from_dtype(col.dtype)
     h5.create_earray(
-        h5.root, 'data', h5type, h5shape, title=colname, expectedrows=n_rows
+        h5.root, "data", h5type, h5shape, title=colname, expectedrows=n_rows
     )
     h5.create_earray(
         h5.root,
-        'quality',
+        "quality",
         tables.BoolAtom(),
         (0,),
-        title='Quality',
+        title="Quality",
         expectedrows=n_rows,
     )
     logger.verbose(
-        'WARNING: made new file {} for column {!r} shape={} with n_rows(1e6)={}'.format(
+        "WARNING: made new file {} for column {!r} shape={} with n_rows(1e6)={}".format(
             filename, colname, h5shape, n_rows / 1.0e6
         )
     )
@@ -771,14 +771,14 @@ def append_filled_h5_col(dats, colname, data_len):
     stacked_data = np.hstack([x[colname] for x in new_dats])
     fill_len = data_len - len(stacked_data)
     if fill_len < 0:
-        raise ValueError('impossible negative length error {}'.format(fill_len))
+        raise ValueError("impossible negative length error {}".format(fill_len))
 
     zeros = np.zeros(fill_len, dtype=stacked_data.dtype)
     quals = np.zeros(fill_len, dtype=bool)
 
     # Append zeros (for the data type) and quality=True (bad)
-    h5 = tables_open_file(msid_files['msid'].abs, mode='a')
-    logger.verbose('Appending %d zeros to %s' % (len(zeros), msid_files['msid'].abs))
+    h5 = tables_open_file(msid_files["msid"].abs, mode="a")
+    logger.verbose("Appending %d zeros to %s" % (len(zeros), msid_files["msid"].abs))
     if not opt.dry_run:
         h5.root.data.append(zeros)
         h5.root.quality.append(quals)
@@ -799,11 +799,11 @@ def append_h5_col(dats, colname, files_overlaps):
         """Return the index for `colname` in `dat`"""
         return list(dat.dtype.names).index(colname)
 
-    h5 = tables_open_file(msid_files['msid'].abs, mode='a')
+    h5 = tables_open_file(msid_files["msid"].abs, mode="a")
     stacked_data = np.hstack([x[colname] for x in dats])
-    stacked_quality = np.hstack([x['QUALITY'][:, i_colname(x)] for x in dats])
+    stacked_quality = np.hstack([x["QUALITY"][:, i_colname(x)] for x in dats])
     logger.verbose(
-        'Appending %d items to %s' % (len(stacked_data), msid_files['msid'].abs)
+        "Appending %d items to %s" % (len(stacked_data), msid_files["msid"].abs)
     )
 
     if not opt.dry_run:
@@ -814,14 +814,14 @@ def append_h5_col(dats, colname, files_overlaps):
     # Do this by setting the TIME column quality flag for the overlapping rows
     # in file0.  files_overlaps is a list of 2-tuples with consequetive files that
     # overlap.
-    if colname == 'TIME':
+    if colname == "TIME":
         for file0, file1 in files_overlaps:
-            times = h5.root.data[file0['rowstart'] : file0['rowstop']]
-            bad_rowstart = np.searchsorted(times, file1['tstart']) + file0['rowstart']
-            bad_rowstop = file0['rowstop']
+            times = h5.root.data[file0["rowstart"] : file0["rowstop"]]
+            bad_rowstart = np.searchsorted(times, file1["tstart"]) + file0["rowstart"]
+            bad_rowstop = file0["rowstop"]
             if not opt.dry_run:
                 logger.verbose(
-                    'Removing overlapping data in rows {0}:{1}'.format(
+                    "Removing overlapping data in rows {0}:{1}".format(
                         bad_rowstart, bad_rowstop
                     )
                 )
@@ -836,7 +836,7 @@ def append_h5_col(dats, colname, files_overlaps):
                     # but in this case there can a tiny overlap (<< 1 ms) that triggers an
                     # overlap entry.
                     logger.verbose(
-                        'INFO: Unexpected null file overlap file0=%s file1=%s'
+                        "INFO: Unexpected null file overlap file0=%s file1=%s"
                         % (file0, file1)
                     )
 
@@ -851,67 +851,67 @@ def truncate_archive(filetype, date):
     year:doy)
     """
     logger.info(f'Truncating {filetype["content"]} full and stat files after {date}')
-    colnames = pickle.load(open(msid_files['colnames'].abs, 'rb'))
+    colnames = pickle.load(open(msid_files["colnames"].abs, "rb"))
 
     date = DateTime(date).date
     year, doy = date[0:4], date[5:8]
 
     # Setup db handle with autocommit=False so that error along the way aborts insert transactions
-    db = Ska.DBI.DBI(dbi='sqlite', server=msid_files['archfiles'].abs, autocommit=False)
+    db = Ska.DBI.DBI(dbi="sqlite", server=msid_files["archfiles"].abs, autocommit=False)
 
     # Get the earliest row number from the archfiles table where year>=year and doy=>doy
     out = db.fetchall(
-        'SELECT rowstart FROM archfiles WHERE year>={0} AND doy>={1}'.format(year, doy)
+        "SELECT rowstart FROM archfiles WHERE year>={0} AND doy>={1}".format(year, doy)
     )
     if len(out) == 0:
-        logger.verbose(f'No rows to delete - skipping')
+        logger.verbose(f"No rows to delete - skipping")
         db.conn.close()
         return
 
-    rowstart = out['rowstart'].min()
+    rowstart = out["rowstart"].min()
     time0 = DateTime("{0}:{1}:00:00:00".format(year, doy)).secs
 
     for colname in colnames:
-        ft['msid'] = colname
-        filename = msid_files['msid'].abs
+        ft["msid"] = colname
+        filename = msid_files["msid"].abs
         if os.path.exists(filename):
             if not opt.dry_run:
-                h5 = tables_open_file(filename, mode='a')
+                h5 = tables_open_file(filename, mode="a")
                 h5.root.data.truncate(rowstart)
                 h5.root.quality.truncate(rowstart)
                 h5.close()
             logger.verbose(
-                'Removed rows from {0} for filetype {1}:{2}'.format(
-                    rowstart, filetype['content'], colname
+                "Removed rows from {0} for filetype {1}:{2}".format(
+                    rowstart, filetype["content"], colname
                 )
             )
         else:
-            logger.debug('MSID file {} not found - skipping'.format(filename))
+            logger.debug("MSID file {} not found - skipping".format(filename))
 
         if colname in fetch.IGNORE_COLNAMES:
             # Colnames like TIME, MNF etc that are not in stats
             continue
 
         # Delete the 5min and daily stats, with a little extra margin
-        for interval in ('5min', 'daily'):
-            ft['interval'] = interval
-            filename = msid_files['stats'].abs
+        for interval in ("5min", "daily"):
+            ft["interval"] = interval
+            filename = msid_files["stats"].abs
             if os.path.exists(filename):
                 if not opt.dry_run:
                     del_stats(colname, time0, interval)
-                logger.verbose(f'Removed {interval} rows from {filename}')
+                logger.verbose(f"Removed {interval} rows from {filename}")
             else:
-                logger.debug(f'Stats file {filename} not found - skipping')
+                logger.debug(f"Stats file {filename} not found - skipping")
 
     # Remove the last_date_id file if it exists
-    for interval in ('5min', 'daily'):
-        ft['interval'] = interval
-        filename = os.path.join(msid_files['statsdir'].abs, 'last_date_id')
+    for interval in ("5min", "daily"):
+        ft["interval"] = interval
+        filename = os.path.join(msid_files["statsdir"].abs, "last_date_id")
         if os.path.exists(filename):
             os.unlink(filename)
-            logger.info(f'Removed {filename}')
+            logger.info(f"Removed {filename}")
 
-    cmd = 'DELETE FROM archfiles WHERE (year>={0} AND doy>={1}) OR year>{0}'.format(
+    cmd = "DELETE FROM archfiles WHERE (year>={0} AND doy>={1}) OR year>{0}".format(
         year, doy
     )
     if not opt.dry_run:
@@ -929,30 +929,30 @@ def read_archfile(i, f, filetype, row, colnames, archfiles, db):
     """
     # Check if filename is already in archfiles.  If so then abort further processing.
     filename = os.path.basename(f)
-    if db.fetchall('SELECT filename FROM archfiles WHERE filename=?', (filename,)):
-        logger.verbose('File %s already in archfiles - unlinking and skipping' % f)
+    if db.fetchall("SELECT filename FROM archfiles WHERE filename=?", (filename,)):
+        logger.verbose("File %s already in archfiles - unlinking and skipping" % f)
         os.unlink(f)
         return None, None
 
     # Read FITS archive file and accumulate data into dats list and header into headers dict
-    logger.info('Reading (%d / %d) %s' % (i, len(archfiles), filename))
+    logger.info("Reading (%d / %d) %s" % (i, len(archfiles), filename))
     hdus = pyfits.open(f, character_as_bytes=True)
     hdu = hdus[1]
 
     try:
-        dat = converters.convert(hdu.data, filetype['content'])
+        dat = converters.convert(hdu.data, filetype["content"])
 
     except converters.NoValidDataError:
         # When creating files allow NoValidDataError
         hdus.close()
-        logger.warning('WARNING: no valid data in data file {}'.format(filename))
+        logger.warning("WARNING: no valid data in data file {}".format(filename))
         return None, None
 
     except converters.DataShapeError as err:
         hdus.close()
         logger.warning(
-            'WARNING: skipping file {} with bad data shape: ASCDSVER={} {}'.format(
-                filename, hdu.header['ASCDSVER'], err
+            "WARNING: skipping file {} with bad data shape: ASCDSVER={} {}".format(
+                filename, hdu.header["ASCDSVER"], err
             )
         )
         return None, None
@@ -961,17 +961,17 @@ def read_archfile(i, f, filetype, row, colnames, archfiles, db):
     # MSID h5 files.  Commit info before h5 ingest so if there is a failure
     # the needed info will be available to do the repair.
     archfiles_row = dict((x, hdu.header.get(x.upper())) for x in archfiles_hdr_cols)
-    archfiles_row['checksum'] = hdu.header.get('checksum') or hdu._checksum
-    archfiles_row['rowstart'] = row
-    archfiles_row['rowstop'] = row + len(dat)
-    archfiles_row['filename'] = filename
-    archfiles_row['filetime'] = int(
-        re.search(r'(\d+)', archfiles_row['filename']).group(1)
+    archfiles_row["checksum"] = hdu.header.get("checksum") or hdu._checksum
+    archfiles_row["rowstart"] = row
+    archfiles_row["rowstop"] = row + len(dat)
+    archfiles_row["filename"] = filename
+    archfiles_row["filetime"] = int(
+        re.search(r"(\d+)", archfiles_row["filename"]).group(1)
     )
-    filedate = DateTime(archfiles_row['filetime']).date
-    year, doy = (int(x) for x in re.search(r'(\d\d\d\d):(\d\d\d)', filedate).groups())
-    archfiles_row['year'] = year
-    archfiles_row['doy'] = doy
+    filedate = DateTime(archfiles_row["filetime"]).date
+    year, doy = (int(x) for x in re.search(r"(\d\d\d\d):(\d\d\d)", filedate).groups())
+    archfiles_row["year"] = year
+    archfiles_row["doy"] = doy
     hdus.close()
 
     return dat, archfiles_row
@@ -988,24 +988,24 @@ def read_derived(i, filename, filetype, row, colnames, archfiles, db):
     """
     # Check if filename is already in archfiles.  If so then abort further processing.
 
-    if db.fetchall('SELECT filename FROM archfiles WHERE filename=?', (filename,)):
-        logger.verbose('File %s already in archfiles - skipping' % filename)
+    if db.fetchall("SELECT filename FROM archfiles WHERE filename=?", (filename,)):
+        logger.verbose("File %s already in archfiles - skipping" % filename)
         return None, None
 
     # f has format <content>_<index0>_<index1>
     # <content> has format dp_<content><mnf_step> e.g. dp_thermal128
-    content, index0, index1 = filename.split(':')
+    content, index0, index1 = filename.split(":")
     index0 = int(index0)
     index1 = int(index1)
-    mnf_step = int(re.search(r'(\d+)$', content).group(1))
+    mnf_step = int(re.search(r"(\d+)$", content).group(1))
     time_step = mnf_step * derived.MNF_TIME
     times = time_step * np.arange(index0, index1)
 
-    logger.info('Reading (%d / %d) %s' % (i, len(archfiles), filename))
+    logger.info("Reading (%d / %d) %s" % (i, len(archfiles), filename))
     vals = {}
     bads = np.zeros((len(times), len(colnames)), dtype=np.bool)
     for i, colname in enumerate(colnames):
-        if colname == 'TIME':
+        if colname == "TIME":
             vals[colname] = times
             bads[:, i] = False
         else:
@@ -1016,8 +1016,8 @@ def read_derived(i, filename, filetype, row, colnames, archfiles, db):
             vals[colname] = dp.calc(dataset)[ok]
             bads[:, i] = dataset.bads[ok]
 
-    vals['QUALITY'] = bads
-    dat = Ska.Numpy.structured_array(vals, list(colnames) + ['QUALITY'])
+    vals["QUALITY"] = bads
+    dat = Ska.Numpy.structured_array(vals, list(colnames) + ["QUALITY"])
 
     # Accumlate relevant info about archfile that will be ingested into
     # MSID h5 files.  Commit info before h5 ingest so if there is a failure
@@ -1042,24 +1042,24 @@ def read_derived(i, filename, filetype, row, colnames, archfiles, db):
 
 
 def update_msid_files(filetype, archfiles):
-    colnames = pickle.load(open(msid_files['colnames'].abs, 'rb'))
-    colnames_all = pickle.load(open(msid_files['colnames_all'].abs, 'rb'))
+    colnames = pickle.load(open(msid_files["colnames"].abs, "rb"))
+    colnames_all = pickle.load(open(msid_files["colnames_all"].abs, "rb"))
     old_colnames = colnames.copy()
     old_colnames_all = colnames_all.copy()
 
     # Setup db handle with autocommit=False so that error along the way aborts insert transactions
-    db = Ska.DBI.DBI(dbi='sqlite', server=msid_files['archfiles'].abs, autocommit=False)
+    db = Ska.DBI.DBI(dbi="sqlite", server=msid_files["archfiles"].abs, autocommit=False)
 
     # Get the last row number from the archfiles table
-    out = db.fetchone('SELECT max(rowstop) FROM archfiles')
-    row = out['max(rowstop)'] or 0
-    last_archfile = db.fetchone('SELECT * FROM archfiles where rowstop=?', (row,))
+    out = db.fetchone("SELECT max(rowstop) FROM archfiles")
+    row = out["max(rowstop)"] or 0
+    last_archfile = db.fetchone("SELECT * FROM archfiles where rowstop=?", (row,))
 
     archfiles_overlaps = []
     dats = []
     archfiles_processed = []
 
-    content_is_derived = filetype['instrum'] == 'DERIVED'
+    content_is_derived = filetype["instrum"] == "DERIVED"
 
     for i, f in enumerate(archfiles):
         get_data = read_derived if content_is_derived else read_archfile
@@ -1075,7 +1075,7 @@ def update_msid_files(filetype, archfiles):
             for colname in dat.dtype.names:
                 if len(dat[colname].shape) > 1:
                     logger.info(
-                        'Removing column {} from colnames because shape = {}'.format(
+                        "Removing column {} from colnames because shape = {}".format(
                             colname, dat[colname].shape
                         )
                     )
@@ -1089,14 +1089,14 @@ def update_msid_files(filetype, archfiles):
         if last_archfile is None:
             time_gap = 0
         else:
-            time_gap = archfiles_row['tstart'] - last_archfile['tstop']
+            time_gap = archfiles_row["tstart"] - last_archfile["tstop"]
             # NOTE: tstop is the projected tstop for the next record, it is NOT the
             # actual time of the last record.  This is important for overlaps.
         max_gap = opt.max_gap
         if max_gap is None:
-            if filetype['instrum'] in ['EPHEM', 'DERIVED']:
+            if filetype["instrum"] in ["EPHEM", "DERIVED"]:
                 max_gap = 601
-            elif filetype['content'] == 'ACISDEAHK':
+            elif filetype["content"] == "ACISDEAHK":
                 max_gap = 10000
                 # From P.Plucinsky 2011-09-23
                 # If ACIS is executing an Event Histogram run while in FMT1,
@@ -1106,30 +1106,30 @@ def update_msid_files(filetype, archfiles):
                 # integrate for 5400s and then they are telemetered.  I would
                 # suggest 6000s, but perhaps you would want to double that to
                 # 12000s.
-            elif filetype['content'] in ['CPE1ENG', 'CCDM15ENG']:
+            elif filetype["content"] in ["CPE1ENG", "CCDM15ENG"]:
                 # 100 years => no max gap for safe mode telemetry or dwell mode telemetry
                 max_gap = 100 * 3.1e7
             else:
                 max_gap = 32.9
         if time_gap > max_gap:
             logger.warning(
-                'WARNING: found gap of %.2f secs between archfiles %s and %s',
+                "WARNING: found gap of %.2f secs between archfiles %s and %s",
                 time_gap,
-                last_archfile['filename'],
-                archfiles_row['filename'],
+                last_archfile["filename"],
+                archfiles_row["filename"],
             )
             if opt.create:
-                logger.warning('WARNING: Allowing gap because of opt.create=True')
+                logger.warning("WARNING: Allowing gap because of opt.create=True")
             elif (
-                DateTime() - DateTime(archfiles_row['tstart'])
+                DateTime() - DateTime(archfiles_row["tstart"])
                 > opt.allow_gap_after_days
             ):
                 # After 4 days (by default) just let it go through because this is
                 # likely a real gap and will not be fixed by subsequent processing.
                 # This can happen after normal sun mode to SIM products.
                 logger.warning(
-                    'WARNING: Allowing gap because arch file '
-                    'start is more than {} days old'.format(opt.allow_gap_after_days)
+                    "WARNING: Allowing gap because arch file "
+                    "start is more than {} days old".format(opt.allow_gap_after_days)
                 )
             else:
                 break
@@ -1145,10 +1145,10 @@ def update_msid_files(filetype, archfiles):
         # This breaks things, so in this case just skip the file.  However
         # since last_archfile is set above the gap check considers this file to
         # have been ingested.
-        if not content_is_derived and dat['QUALITY'].shape[1] != len(dat.dtype.names):
+        if not content_is_derived and dat["QUALITY"].shape[1] != len(dat.dtype.names):
             logger.warning(
-                'WARNING: skipping because of quality size mismatch: %d %d'
-                % (dat['QUALITY'].shape[1], len(dat.dtype.names))
+                "WARNING: skipping because of quality size mismatch: %d %d"
+                % (dat["QUALITY"].shape[1], len(dat.dtype.names))
             )
             continue
 
@@ -1158,7 +1158,7 @@ def update_msid_files(filetype, archfiles):
         # leave files in a tmp dir.
         archfiles_processed.append(f)
         if not opt.dry_run:
-            db.insert(archfiles_row, 'archfiles')
+            db.insert(archfiles_row, "archfiles")
 
         # Capture the data for subsequent storage in the hdf5 files
         dats.append(dat)
@@ -1175,12 +1175,12 @@ def update_msid_files(filetype, archfiles):
         row += len(dat)
 
     if dats:
-        logger.verbose('Writing accumulated column data to h5 file at ' + time.ctime())
+        logger.verbose("Writing accumulated column data to h5 file at " + time.ctime())
         data_lens = set()
         processed_cols = set()
         for colname in colnames:
-            ft['msid'] = colname
-            if not os.path.exists(msid_files['msid'].abs):
+            ft["msid"] = colname
+            if not os.path.exists(msid_files["msid"].abs):
                 make_h5_col_file(dats, colname)
                 if not opt.create:
                     # New MSID was found for this content type.  This must be associated with
@@ -1193,13 +1193,13 @@ def update_msid_files(filetype, archfiles):
 
         if len(data_lens) != 1:
             raise ValueError(
-                'h5 data length inconsistency {}, investigate NOW!'.format(data_lens)
+                "h5 data length inconsistency {}, investigate NOW!".format(data_lens)
             )
 
         # Process any new MSIDs (this is extremely rare)
         data_len = data_lens.pop()
         for colname in colnames - processed_cols:
-            ft['msid'] = colname
+            ft["msid"] = colname
             append_filled_h5_col(dats, colname, data_len)
 
     # Assuming everything worked now commit the db inserts that signify the
@@ -1210,30 +1210,30 @@ def update_msid_files(filetype, archfiles):
     # If colnames or colnames_all changed then give warning and update files.
     if colnames != old_colnames:
         logger.warning(
-            'WARNING: updating %s because colnames changed: %s'
-            % (msid_files['colnames'].abs, old_colnames ^ colnames)
+            "WARNING: updating %s because colnames changed: %s"
+            % (msid_files["colnames"].abs, old_colnames ^ colnames)
         )
         if not opt.dry_run:
-            pickle.dump(colnames, open(msid_files['colnames'].abs, 'wb'), protocol=0)
+            pickle.dump(colnames, open(msid_files["colnames"].abs, "wb"), protocol=0)
     if colnames_all != old_colnames_all:
         logger.warning(
-            'WARNING: updating %s because colnames_all changed: %s'
-            % (msid_files['colnames_all'].abs, colnames_all ^ old_colnames_all)
+            "WARNING: updating %s because colnames_all changed: %s"
+            % (msid_files["colnames_all"].abs, colnames_all ^ old_colnames_all)
         )
         if not opt.dry_run:
             pickle.dump(
-                colnames_all, open(msid_files['colnames_all'].abs, 'wb'), protocol=0
+                colnames_all, open(msid_files["colnames_all"].abs, "wb"), protocol=0
             )
 
     return archfiles_processed
 
 
 def unlink_archive_files(filetype, archfiles):
-    ft['content'] = filetype.content.lower()
+    ft["content"] = filetype.content.lower()
 
     for f in archfiles:
         if os.path.exists(f):
-            logger.verbose('Unlinking %s' % os.path.abspath(f))
+            logger.verbose("Unlinking %s" % os.path.abspath(f))
             os.unlink(f)
 
 
@@ -1242,7 +1242,7 @@ def get_archive_files(filetype):
 
     # Files could exist already in testing.
     # Don't allow arbitrary arch files at once because of memory issues.
-    files = sorted(glob.glob(filetype['fileglob']))
+    files = sorted(glob.glob(filetype["fileglob"]))
     if files:
         return sorted(files)[: opt.max_arch_files]
 
@@ -1254,15 +1254,15 @@ def get_archive_files(filetype):
 
     # Get datestart as the most-recent file time from archfiles table.  However,
     # do not look back further than --max-lookback-time
-    db = Ska.DBI.DBI(dbi='sqlite', server=msid_files['archfiles'].abs)
+    db = Ska.DBI.DBI(dbi="sqlite", server=msid_files["archfiles"].abs)
     vals = db.fetchone("select max(filetime) from archfiles")
     datestart = DateTime(
-        max(vals['max(filetime)'] or 0.0, datestop.secs - opt.max_lookback_time * 86400)
+        max(vals["max(filetime)"] or 0.0, datestop.secs - opt.max_lookback_time * 86400)
     )
 
     # For *ephem0 the query needs to extend well into the future
     # to guarantee getting all available files.  This is the archives fault.
-    if filetype['level'] == 'L0' and filetype['instrum'] == 'EPHEM':
+    if filetype["level"] == "L0" and filetype["instrum"] == "EPHEM":
         datestop = datestop + 50
 
     # For instrum==EPHEM break queries into time ranges no longer than
@@ -1270,25 +1270,26 @@ def get_archive_files(filetype):
     # no more often than every ~3 days so this should work.
     n_queries = (
         1
-        if filetype['instrum'] != 'EPHEM'
+        if filetype["instrum"] != "EPHEM"
         else 1 + round((datestop.secs - datestart.secs) / 100000.0)
     )
     times = np.linspace(datestart.secs, datestop.secs, n_queries + 1)
 
-    logger.info('********** %s %s **********' % (ft['content'], time.ctime()))
+    logger.info("********** %s %s **********" % (ft["content"], time.ctime()))
 
     for t0, t1 in zip(times[:-1], times[1:]):
         if t1 > t0:
-            arc5.sendline('tstart=%s' % DateTime(t0).date)
-            arc5.sendline('tstop=%s' % DateTime(t1).date)
-            arc5.sendline('get %s' % filetype['arc5gl_query'].lower())
+            arc5.sendline("tstart=%s" % DateTime(t0).date)
+            arc5.sendline("tstop=%s" % DateTime(t1).date)
+            arc5.sendline("get %s" % filetype["arc5gl_query"].lower())
         else:
             logger.info(
-                'INFO: Skipping archive query because datestop={} < datestart={}'
-                .format(DateTime(t1).date, DateTime(t0).date)
+                "INFO: Skipping archive query because datestop={} < datestart={}".format(
+                    DateTime(t1).date, DateTime(t0).date
+                )
             )
 
-    return sorted(glob.glob(filetype['fileglob']))
+    return sorted(glob.glob(filetype["fileglob"]))
 
 
 def main():
@@ -1323,5 +1324,5 @@ def main():
         main_loop()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/Ska/engarchive/update_archive.py
+++ b/Ska/engarchive/update_archive.py
@@ -1,35 +1,34 @@
 #!/usr/bin/env python
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import re
-import os
-import glob
-import time
-from pathlib import Path
-import warnings
-
-import pickle
 import argparse
+import glob
 import itertools
+import os
+import pickle
+import re
+import time
+import warnings
 from collections import OrderedDict
+from pathlib import Path
 
-from Chandra.Time import DateTime
-import Ska.File
-import Ska.DBI
-import Ska.Numpy
-import pyyaks.logger
-import pyyaks.context
 import astropy.io.fits as pyfits
-import tables
 import numpy as np
+import pyyaks.context
+import pyyaks.logger
 import scipy.stats.mstats
+import Ska.arc5gl
+import Ska.DBI
+import Ska.File
+import Ska.Numpy
+import tables
+from Chandra.Time import DateTime
 from ska_helpers.retry import tables_open_file
 
-import Ska.engarchive.fetch as fetch
 import Ska.engarchive.converters as converters
-import Ska.engarchive.file_defs as file_defs
 import Ska.engarchive.derived as derived
-import Ska.arc5gl
+import Ska.engarchive.fetch as fetch
+import Ska.engarchive.file_defs as file_defs
 
 
 def get_options(args=None):

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -39,7 +39,7 @@ from Ska.DBI import DBI
 from . import __version__, file_defs
 from .utils import STATS_DT, get_date_id
 
-sync_files = pyyaks.context.ContextDict('update_client_archive.sync_files')
+sync_files = pyyaks.context.ContextDict("update_client_archive.sync_files")
 sync_files.update(file_defs.sync_files)
 
 process_errors = []
@@ -49,7 +49,7 @@ def get_options(args=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--sync-root",
-        default='https://icxc.cfa.harvard.edu/aspect/cheta/',
+        default="https://icxc.cfa.harvard.edu/aspect/cheta/",
         help=(
             "URL or file dir for sync files to read from "
             "(default=https://icxc.cfa.harvard.edu/aspect/cheta/)"
@@ -64,7 +64,7 @@ def get_options(args=None):
     )
     parser.add_argument(
         "--content",
-        action='append',
+        action="append",
         help="Content type to process [match regex] (default=all)",
     )
     parser.add_argument(
@@ -77,23 +77,23 @@ def get_options(args=None):
         help="Dry run (no actual file or database updates)",
     )
     parser.add_argument(
-        '--add-msids', help='Add MSIDs specified in <file> to eng archive data files"'
+        "--add-msids", help='Add MSIDs specified in <file> to eng archive data files"'
     )
     parser.add_argument(
-        '--server-data-root',
+        "--server-data-root",
         help=(
-            'Add MSID data from root (/path/to/data, user@remote, '
-            'or user@remote:/path/to/data'
+            "Add MSID data from root (/path/to/data, user@remote, "
+            "or user@remote:/path/to/data"
         ),
     )
     parser.add_argument(
-        '--version',
-        action='version',
-        version='%(prog)s {version}'.format(version=__version__),
+        "--version",
+        action="version",
+        version="%(prog)s {version}".format(version=__version__),
     )
 
     opt = parser.parse_args(args)
-    opt.is_url = re.match(r'http[s]?://', opt.sync_root)
+    opt.is_url = re.match(r"http[s]?://", opt.sync_root)
     opt.date_stop = DateTime(opt.date_stop)
 
     return opt
@@ -106,12 +106,12 @@ class RowMismatchError(ValueError):
 
 
 @contextlib.contextmanager
-def timing_logger(logger, text, level_pre='info', level_post='info'):
+def timing_logger(logger, text, level_pre="info", level_post="info"):
     start = time.time()
     getattr(logger, level_pre)(text)
     yield
     elapsed_time = time.time() - start
-    getattr(logger, level_post)(f'  elapsed time: {elapsed_time:.3f} sec')
+    getattr(logger, level_post)(f"  elapsed time: {elapsed_time:.3f} sec")
 
 
 @contextlib.contextmanager
@@ -130,14 +130,14 @@ def get_readable(sync_root, is_url, filename, timeout=30):
     filename = str(filename)  # Not needed with pyyaks >= 4.4.
 
     if is_url:
-        uri = sync_root.rstrip('/') + '/' + Path(filename).as_posix()
+        uri = sync_root.rstrip("/") + "/" + Path(filename).as_posix()
         try:
             filename = download_file(
                 uri, show_progress=False, cache=False, timeout=timeout
             )
         except urllib.error.URLError as err:
             raise urllib.error.URLError(
-                f'unable to load {uri}. Are you on a network with icxc access?'
+                f"unable to load {uri}. Are you on a network with icxc access?"
             ) from err
 
     else:
@@ -171,14 +171,14 @@ class DelayedKeyboardInterrupt(object):
     def handler(self, sig, frame):
         self.signal_received = (sig, frame)
         self.logger.info(
-            'KEYBOARD INTERRUPT RECEIVED. Please hold tight for moment while we '
-            'finish up cleanly, otherwise the archive may get corrupted.'
+            "KEYBOARD INTERRUPT RECEIVED. Please hold tight for moment while we "
+            "finish up cleanly, otherwise the archive may get corrupted."
         )
 
     def __exit__(self, typ, value, traceback):
         signal.signal(signal.SIGINT, self.old_handler)
         if self.signal_received:
-            print('Shutting down due to keyboard interrupt', file=sys.stderr)
+            print("Shutting down due to keyboard interrupt", file=sys.stderr)
             sys.exit(1)
 
 
@@ -193,10 +193,10 @@ def add_msids(opt, logger):
     msids, msids_content = get_msids_for_add_msids(opt, logger)
     copy_files = get_copy_files(logger, msids, msids_content)
     if not copy_files:
-        logger.info(f'Local cheta archive is complete for MSIDs in {opt.add_msids}')
+        logger.info(f"Local cheta archive is complete for MSIDs in {opt.add_msids}")
         return
 
-    if '@' in opt.server_data_root:
+    if "@" in opt.server_data_root:
         copy_server_files_ssh(opt, logger, copy_files)
     else:
         copy_server_files(
@@ -221,11 +221,11 @@ def copy_server_files(opt, logger, copy_files, server_path, copy_func, as_posix=
     from astropy.utils.console import ProgressBar
 
     logger.info(
-        f'Copying {len(copy_files)} files from {opt.server_data_root} to'
-        f' {opt.data_root}'
+        f"Copying {len(copy_files)} files from {opt.server_data_root} to"
+        f" {opt.data_root}"
     )
     if opt.dry_run:
-        logger.info('DRY RUN')
+        logger.info("DRY RUN")
 
     with ProgressBar(len(copy_files)) as progress_bar:
         total_size = 0
@@ -233,15 +233,15 @@ def copy_server_files(opt, logger, copy_files, server_path, copy_func, as_posix=
         for copy_file in copy_files:
             local_file = Path(opt.data_root, copy_file)
             server_file = Path(server_path, copy_file)
-            logger.debug(f'Local file={local_file}')
-            logger.debug(f'Server file={server_file}')
+            logger.debug(f"Local file={local_file}")
+            logger.debug(f"Server file={server_file}")
             if as_posix:
                 server_file = server_file.as_posix()
             local_file.parent.mkdir(parents=True, exist_ok=True)
             if not opt.dry_run:
                 progress_bar.update()
             else:
-                logger.info(f'copy {copy_file}')
+                logger.info(f"copy {copy_file}")
             if not opt.dry_run:
                 with DelayedKeyboardInterrupt(logger):
                     copy_func(str(server_file), str(local_file))
@@ -249,8 +249,8 @@ def copy_server_files(opt, logger, copy_files, server_path, copy_func, as_posix=
     total_time = time.time() - tstart
     xfer_rate = total_size / total_time
     logger.info(
-        f'Data transfer rate = {xfer_rate:.2f} Mb/s : '
-        f'{total_size:.2f} Mb in {total_time:.2f} s'
+        f"Data transfer rate = {xfer_rate:.2f} Mb/s : "
+        f"{total_size:.2f} Mb in {total_time:.2f} s"
     )
 
 
@@ -270,21 +270,21 @@ def copy_server_files_ssh(opt, logger, copy_files):
     import paramiko
 
     username, hostname, server_path = parse_server_data_root(opt.server_data_root)
-    server_path = server_path or '/proj/sot/ska/data/eng_archive'
+    server_path = server_path or "/proj/sot/ska/data/eng_archive"
 
-    logger.info(f'Connecting to {hostname}')
+    logger.info(f"Connecting to {hostname}")
     ssh_client = paramiko.SSHClient()
     ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     for attempt in range(3):
         try:
-            password = getpass.getpass(f'Password for {username}@{hostname}: ')
+            password = getpass.getpass(f"Password for {username}@{hostname}: ")
             ssh_client.connect(hostname=hostname, username=username, password=password)
         except paramiko.ssh_exception.AuthenticationException:
             if attempt == 2:
-                print('Authentication failed', file=sys.stderr)
+                print("Authentication failed", file=sys.stderr)
                 sys.exit(1)
             else:
-                print('Incorrect password, please try again.')
+                print("Incorrect password, please try again.")
         else:
             break
 
@@ -322,29 +322,29 @@ def get_copy_files(logger, msids, msids_content):
     ft = fetch.ft
     copy_files = set()
     for msid in msids:
-        ft['content'] = msids_content[msid]
+        ft["content"] = msids_content[msid]
         copy_specs = [
-            (msid, None, 'msid'),
-            (msid, None, 'archfiles'),
-            (msid, None, 'colnames'),
-            (msid, '5min', 'stats'),
-            (msid, 'daily', 'stats'),
-            ('TIME', None, 'msid'),
+            (msid, None, "msid"),
+            (msid, None, "archfiles"),
+            (msid, None, "colnames"),
+            (msid, "5min", "stats"),
+            (msid, "daily", "stats"),
+            ("TIME", None, "msid"),
         ]
         for ft_msid, interval, filetype in copy_specs:
-            ft['msid'] = ft_msid
-            ft['interval'] = interval
+            ft["msid"] = ft_msid
+            ft["interval"] = interval
             pth = Path(msid_files[filetype].abs)
             # Copy files that do not exist locally. An exception is the colnames
             # file (colnames.pkl), which must get updated even if it exists.
-            if not pth.exists() or filetype == 'colnames':
+            if not pth.exists() or filetype == "colnames":
                 copy_files.add(str(pth.relative_to(basedir)))
 
     logger.info(
-        f'Found {len(copy_files)} local archive files that are '
-        'missing and need to be copied'
+        f"Found {len(copy_files)} local archive files that are "
+        "missing and need to be copied"
     )
-    logger.debug(f'Copy_files:')
+    logger.debug(f"Copy_files:")
     for copy_file in sorted(copy_files):
         logger.debug(copy_file)
 
@@ -375,48 +375,48 @@ def get_msids_for_add_msids(opt, logger):
     :param logger: logger
     :return: msids_out, msids_content (mapping of MSID to content type)
     """
-    logger.info(f'Reading available cheta archive MSIDs from {opt.sync_root}')
-    with get_readable(opt.sync_root, opt.is_url, sync_files['msid_contents']) as (
+    logger.info(f"Reading available cheta archive MSIDs from {opt.sync_root}")
+    with get_readable(opt.sync_root, opt.is_url, sync_files["msid_contents"]) as (
         tmpfile,
         uri,
     ):
         if tmpfile is None:
             # If index_file is not found then get_readable returns None
-            logger.info(f'No cheta MSIDs list file found at{uri}')
+            logger.info(f"No cheta MSIDs list file found at{uri}")
             return None
-        logger.info(f'Reading cheta MSIDs list file {uri}')
-        msids_content = pickle.load(gzip.open(tmpfile, 'rb'))
+        logger.info(f"Reading cheta MSIDs list file {uri}")
+        msids_content = pickle.load(gzip.open(tmpfile, "rb"))
 
     content_msids = collections.defaultdict(list)
     for msid, content in msids_content.items():
         content_msids[content].append(msid)
 
-    logger.info(f'Reading MSID specs from {opt.add_msids}')
+    logger.info(f"Reading MSID specs from {opt.add_msids}")
     with open(opt.add_msids) as fh:
         lines = [line.strip() for line in fh.readlines()]
-    msid_specs = [line.upper() for line in lines if (line and not line.startswith('#'))]
+    msid_specs = [line.upper() for line in lines if (line and not line.startswith("#"))]
 
-    logger.info('Assembling list of MSIDs that match MSID specs')
+    logger.info("Assembling list of MSIDs that match MSID specs")
     msids_out = []
     for msid_spec in msid_specs:
-        if msid_spec.startswith('**/'):
+        if msid_spec.startswith("**/"):
             msid_spec = msid_spec[3:]
             content = msids_content[msid_spec]
-            subsys = re.match(r'([^\d]+)', content).group(1)
+            subsys = re.match(r"([^\d]+)", content).group(1)
             for content, msids in content_msids.items():
                 if content.startswith(subsys):
                     logger.info(
-                        f'  Found {len(msids)} MSIDs for **/{msid_spec} with '
-                        f'content = {content}'
+                        f"  Found {len(msids)} MSIDs for **/{msid_spec} with "
+                        f"content = {content}"
                     )
                     msids_out.extend(msids)
 
-        elif msid_spec.startswith('*/'):
+        elif msid_spec.startswith("*/"):
             msid_spec = msid_spec[2:]
             content = msids_content[msid_spec]
             msids = content_msids[content]
             logger.info(
-                f'  Found {len(msids)} MSIDs for */{msid_spec} with content = {content}'
+                f"  Found {len(msids)} MSIDs for */{msid_spec} with content = {content}"
             )
             msids_out.extend(msids)
 
@@ -424,12 +424,12 @@ def get_msids_for_add_msids(opt, logger):
             msids = [msid for msid in msids_content if fnmatch(msid, msid_spec)]
             if not msids:
                 raise ValueError(
-                    f'no MSID matching {msid} (remember derived params like PITCH '
+                    f"no MSID matching {msid} (remember derived params like PITCH "
                     'must be written as"dp_<MSID>"'
                 )
-            logger.info(f'  Found {len(msids)} MSIDs for {msid_spec}')
+            logger.info(f"  Found {len(msids)} MSIDs for {msid_spec}")
             msids_out.extend(msids)
-    logger.info(f'  Found {len(msids_out)} matching MSIDs total')
+    logger.info(f"  Found {len(msids_out)} matching MSIDs total")
 
     return msids_out, msids_content
 
@@ -447,21 +447,21 @@ def sync_full_archive(opt, msid_files, logger, content, index_tbl):
     """
     # Get the last row of data from the length of the TIME.col (or archfiles?)
     ft = fetch.ft
-    ft['content'] = content
-    ft['msid'] = 'TIME'
-    ft['interval'] = 'full'
+    ft["content"] = content
+    ft["msid"] = "TIME"
+    ft["interval"] = "full"
 
     # If no TIME.h5 file then no point in going further
-    time_file = Path(msid_files['msid'].abs)
+    time_file = Path(msid_files["msid"].abs)
     if not time_file.exists():
-        logger.debug(f'Skipping full data for {content}: no {time_file} file')
+        logger.debug(f"Skipping full data for {content}: no {time_file} file")
         return
 
-    logger.info('')
-    logger.info(f'Processing full data for {content}')
+    logger.info("")
+    logger.info(f"Processing full data for {content}")
 
     # Get the 0-based index of last available full data row
-    with tables.open_file(str(time_file), 'r') as h5:
+    with tables.open_file(str(time_file), "r") as h5:
         last_row_idx = len(h5.root.data) - 1
 
     # Look for index table rows that have new data => the row ends after the last existing
@@ -469,18 +469,18 @@ def sync_full_archive(opt, msid_files, logger, content, index_tbl):
     # not including the row indexed row1 (0-based).  So for 3 existing rows,
     # last_row_idx=2 so to get the new row with index=3 you need row1=4, or equivalently
     # row1 > n_rows. By def'n we know that row0 <= 3 at this point.
-    ok = index_tbl['row1'] > last_row_idx + 1
+    ok = index_tbl["row1"] > last_row_idx + 1
 
     if np.count_nonzero(ok) == 0:
-        logger.info(f'No new sync data for {content}: no new rows in index table')
+        logger.info(f"No new sync data for {content}: no new rows in index table")
 
     index_tbl = index_tbl[ok]
 
     try:
         dats = get_full_data_sets(ft, index_tbl, logger, opt)
     except urllib.error.URLError as err:
-        if 'timed out' in str(err):
-            msg = f'  ERROR: timed out getting full data for {content}'
+        if "timed out" in str(err):
+            msg = f"  ERROR: timed out getting full data for {content}"
             logger.error(msg)
             process_errors.append(msg)
             dats = []
@@ -488,7 +488,7 @@ def sync_full_archive(opt, msid_files, logger, content, index_tbl):
             raise
 
     if dats:
-        dat, msids = concat_data_sets(dats, ['data', 'quality'])
+        dat, msids = concat_data_sets(dats, ["data", "quality"])
         with DelayedKeyboardInterrupt(logger):
             update_full_h5_files(dat, logger, msid_files, msids, opt)
             update_full_archfiles_db3(dat, logger, msid_files, opt)
@@ -496,8 +496,8 @@ def sync_full_archive(opt, msid_files, logger, content, index_tbl):
 
 def update_full_archfiles_db3(dat, logger, msid_files, opt):
     # Update the archfiles.db3 database to include the associated archive files
-    server_file = msid_files['archfiles'].abs
-    logger.debug(f'Updating {server_file}')
+    server_file = msid_files["archfiles"].abs
+    logger.debug(f"Updating {server_file}")
 
     def as_python(val):
         try:
@@ -505,19 +505,19 @@ def update_full_archfiles_db3(dat, logger, msid_files, opt):
         except AttributeError:
             return val
 
-    with timing_logger(logger, f'Updating {server_file}', 'info', 'info'):
-        with DBI(dbi='sqlite', server=server_file) as db:
-            for archfile in dat['archfiles']:
+    with timing_logger(logger, f"Updating {server_file}", "info", "info"):
+        with DBI(dbi="sqlite", server=server_file) as db:
+            for archfile in dat["archfiles"]:
                 vals = {
                     name: as_python(archfile[name]) for name in archfile.dtype.names
                 }
                 logger.debug(f'Inserting {vals["filename"]}')
                 if not opt.dry_run:
                     try:
-                        db.insert(vals, 'archfiles')
+                        db.insert(vals, "archfiles")
                     except sqlite3.IntegrityError as err:
                         # Expected exception for archfiles already in the table
-                        assert 'UNIQUE constraint failed: archfiles.filename' in str(
+                        assert "UNIQUE constraint failed: archfiles.filename" in str(
                             err
                         )
 
@@ -527,11 +527,11 @@ def update_full_archfiles_db3(dat, logger, msid_files, opt):
 
 def update_full_h5_files(dat, logger, msid_files, msids, opt):
     with timing_logger(
-        logger, f'Applying updates to {len(msids)} h5 files', 'info', 'info'
+        logger, f"Applying updates to {len(msids)} h5 files", "info", "info"
     ):
         for msid in msids:
             vals = {
-                key: dat[f'{msid}.{key}'] for key in ('data', 'quality', 'row0', 'row1')
+                key: dat[f"{msid}.{key}"] for key in ("data", "quality", "row0", "row1")
             }
             append_h5_col(opt, msid, vals, logger, msid_files)
 
@@ -542,21 +542,21 @@ def get_full_data_sets(ft, index_tbl, logger, opt):
     for row in index_tbl:
 
         # Limit processed archfiles by date
-        if row['filetime0'] > DateTime(opt.date_stop).secs:
+        if row["filetime0"] > DateTime(opt.date_stop).secs:
             break
 
         # File names like sync/acis4eng/2019-07-08T1150z/full.npz
-        ft['date_id'] = row['date_id']
+        ft["date_id"] = row["date_id"]
 
         # Read the file with all the MSID data as a hash with keys like {msid}.data
         # {msid}.quality etc, plus an `archive` key with the table of corresponding
         # archfiles rows.
-        with get_readable(opt.sync_root, opt.is_url, sync_files['data']) as (
+        with get_readable(opt.sync_root, opt.is_url, sync_files["data"]) as (
             data_input,
             uri,
         ):
-            with timing_logger(logger, f'Reading update date file {uri}'):
-                with gzip.open(data_input, 'rb') as fh:
+            with timing_logger(logger, f"Reading update date file {uri}"):
+                with gzip.open(data_input, "rb") as fh:
                     dats.append(pickle.load(fh))
     return dats
 
@@ -579,21 +579,21 @@ def sync_stat_archive(opt, msid_files, logger, content, stat, index_tbl):
     try:
         _sync_stat_archive(opt, msid_files, logger, content, stat, index_tbl)
     except RowMismatchError as err:
-        pth = Path(fetch.msid_files['last_date_id'].abs)
+        pth = Path(fetch.msid_files["last_date_id"].abs)
         if pth.exists():
             msg = (
-                f'File {pth} was out of sync with stats archive, generating exception:'
-                f' {err}'
+                f"File {pth} was out of sync with stats archive, generating exception:"
+                f" {err}"
             )
             logger.warn(msg)
             logger.warn(
-                f'Attempting to fix by removing that file and trying to sync again.'
+                f"Attempting to fix by removing that file and trying to sync again."
             )
             pth.unlink()
             _sync_stat_archive(opt, msid_files, logger, content, stat, index_tbl)
             process_errors.append(
-                f'WARNING: file {pth} was out of sync with stats archive, fixed by'
-                ' deleting it'
+                f"WARNING: file {pth} was out of sync with stats archive, fixed by"
+                " deleting it"
             )
 
 
@@ -603,27 +603,27 @@ def _sync_stat_archive(opt, msid_files, logger, content, stat, index_tbl):
     """
     # Get the last row of data from the length of the TIME.col (or archfiles?)
     ft = fetch.ft
-    ft['content'] = content
-    ft['interval'] = stat
+    ft["content"] = content
+    ft["interval"] = stat
 
-    stats_dir = Path(msid_files['statsdir'].abs)
+    stats_dir = Path(msid_files["statsdir"].abs)
     if not stats_dir.exists():
-        logger.debug(f'Skipping {stat} data for {content}: no directory')
+        logger.debug(f"Skipping {stat} data for {content}: no directory")
         return
 
-    logger.info('')
-    logger.info(f'Processing {stat} data for {content}')
+    logger.info("")
+    logger.info(f"Processing {stat} data for {content}")
 
     # Get the MSIDs that are in client archive
-    msids = [str(fn.name)[:-3] for fn in stats_dir.glob('*.h5')]
+    msids = [str(fn.name)[:-3] for fn in stats_dir.glob("*.h5")]
     if not msids:
-        logger.debug(f'Skipping {stat} data for {content}: no stats h5 files')
+        logger.debug(f"Skipping {stat} data for {content}: no stats h5 files")
         return
     else:
-        logger.debug(f'Stat msids are {msids}')
+        logger.debug(f"Stat msids are {msids}")
 
     last_date_id, last_date_id_file = get_last_date_id(msid_files, msids, stat, logger)
-    logger.verbose(f'Got {last_date_id} as last date_id that was applied to archive')
+    logger.verbose(f"Got {last_date_id} as last date_id that was applied to archive")
 
     # Get list of applicable dat objects (new data, before opt.date_stop).  Also
     # return ``date_id`` which is the date_id of the final data set in the list.
@@ -631,8 +631,8 @@ def _sync_stat_archive(opt, msid_files, logger, content, stat, index_tbl):
     try:
         dats, date_id = get_stat_data_sets(ft, index_tbl, last_date_id, logger, opt)
     except urllib.error.URLError as err:
-        if 'timed out' in str(err):
-            msg = f'  ERROR: timed out getting {stat} data for {content}'
+        if "timed out" in str(err):
+            msg = f"  ERROR: timed out getting {stat} data for {content}"
             logger.error(msg)
             process_errors.append(msg)
             return
@@ -642,49 +642,49 @@ def _sync_stat_archive(opt, msid_files, logger, content, stat, index_tbl):
     if not dats:
         return
 
-    dat, msids = concat_data_sets(dats, ['data'])
+    dat, msids = concat_data_sets(dats, ["data"])
     with DelayedKeyboardInterrupt(logger):
-        with timing_logger(logger, f'Applying updates to {len(msids)} h5 files'):
+        with timing_logger(logger, f"Applying updates to {len(msids)} h5 files"):
             for msid in msids:
-                fetch.ft['msid'] = msid
-                stat_file = msid_files['stats'].abs
+                fetch.ft["msid"] = msid
+                stat_file = msid_files["stats"].abs
                 if os.path.exists(stat_file):
                     append_stat_col(dat, stat_file, msid, date_id, opt, logger)
 
-            logger.debug(f'Updating {last_date_id_file} with {date_id}')
+            logger.debug(f"Updating {last_date_id_file} with {date_id}")
             if not opt.dry_run:
-                with open(last_date_id_file, 'w') as fh:
-                    fh.write(f'{date_id}')
+                with open(last_date_id_file, "w") as fh:
+                    fh.write(f"{date_id}")
 
 
 def get_stat_data_sets(ft, index_tbl, last_date_id, logger, opt):
     # Iterate over sync files that contain new data
     dats = []
     for row in index_tbl:
-        date_id = row['date_id']
+        date_id = row["date_id"]
 
         # Limit processed archfiles by date
-        if row['filetime0'] > DateTime(opt.date_stop).secs:
-            logger.verbose(f'Index {date_id} filetime0 > date_stop, breaking')
+        if row["filetime0"] > DateTime(opt.date_stop).secs:
+            logger.verbose(f"Index {date_id} filetime0 > date_stop, breaking")
             break
 
         # Compare date_id of this row to last one that was processed.  These
         # are lexically ordered
         if date_id <= last_date_id:
-            logger.verbose(f'Index {date_id} already processed, skipping')
+            logger.verbose(f"Index {date_id} already processed, skipping")
             continue
 
         # File names like sync/acis4eng/2019-07-08T1150z/5min.npz
-        last_date_id = ft['date_id'] = date_id
+        last_date_id = ft["date_id"] = date_id
 
         # Read the file with all the MSID data as a hash with keys {msid}.data
         # {msid}.row0, {msid}.row1
-        with get_readable(opt.sync_root, opt.is_url, sync_files['data']) as (
+        with get_readable(opt.sync_root, opt.is_url, sync_files["data"]) as (
             data_input,
             uri,
         ):
-            with timing_logger(logger, f'Reading update date file {uri}'):
-                with gzip.open(data_input, 'rb') as fh:
+            with timing_logger(logger, f"Reading update date file {uri}"):
+                with gzip.open(data_input, "rb") as fh:
                     dat = pickle.load(fh)
                     if dat:
                         # Stat pickle dict can be empty, e.g. in the case of a daily file
@@ -711,32 +711,32 @@ def concat_data_sets(dats, data_keys):
         for key, val in dat.items():
             dat_lists[key].append(val)
 
-    msids = {key[:-5] for key in dat_lists if key.endswith('.data')}
+    msids = {key[:-5] for key in dat_lists if key.endswith(".data")}
 
     dat = {}
     for msid in msids:
         lens = set()
-        lens.add(len(dat_lists[f'{msid}.row0']))
-        lens.add(len(dat_lists[f'{msid}.row1']))
+        lens.add(len(dat_lists[f"{msid}.row0"]))
+        lens.add(len(dat_lists[f"{msid}.row1"]))
         for key in data_keys:
-            lens.add(len(dat_lists[f'{msid}.{key}']))
+            lens.add(len(dat_lists[f"{msid}.{key}"]))
         if len(lens) != 1:
-            raise ValueError('inconsistency in lengths of data file inputs')
+            raise ValueError("inconsistency in lengths of data file inputs")
 
         for row1, next_row0 in zip(
-            dat_lists[f'{msid}.row1'][:-1], dat_lists[f'{msid}.row0'][1:]
+            dat_lists[f"{msid}.row1"][:-1], dat_lists[f"{msid}.row0"][1:]
         ):
             if row1 != next_row0:
-                raise ValueError('unexpected discontinuity in rows in data files')
+                raise ValueError("unexpected discontinuity in rows in data files")
 
-        dat[f'{msid}.row0'] = dat_lists[f'{msid}.row0'][0]
-        dat[f'{msid}.row1'] = dat_lists[f'{msid}.row1'][-1]
+        dat[f"{msid}.row0"] = dat_lists[f"{msid}.row0"][0]
+        dat[f"{msid}.row1"] = dat_lists[f"{msid}.row1"][-1]
         for key in data_keys:
-            dat[f'{msid}.{key}'] = np.concatenate(dat_lists[f'{msid}.{key}'])
+            dat[f"{msid}.{key}"] = np.concatenate(dat_lists[f"{msid}.{key}"])
 
-    if 'archfiles' in dats[0]:
-        dat['archfiles'] = list(
-            itertools.chain.from_iterable(dat['archfiles'] for dat in dats)
+    if "archfiles" in dats[0]:
+        dat["archfiles"] = list(
+            itertools.chain.from_iterable(dat["archfiles"] for dat in dats)
         )
 
     return dat, msids
@@ -754,45 +754,45 @@ def append_stat_col(dat, stat_file, msid, date_id, opt, logger):
     :param logger:
     :return: None
     """
-    vals = {key: dat[f'{msid}.{key}'] for key in ('data', 'row0', 'row1')}
+    vals = {key: dat[f"{msid}.{key}"] for key in ("data", "row0", "row1")}
     logger.debug(
-        f'append_stat_col msid={msid} date_id={date_id}, '
+        f"append_stat_col msid={msid} date_id={date_id}, "
         f'row0,1 = {vals["row0"]} {vals["row1"]}'
     )
 
-    mode = 'r' if opt.dry_run else 'a'
+    mode = "r" if opt.dry_run else "a"
     with tables.open_file(stat_file, mode=mode) as h5:
         last_row_idx = len(h5.root.data) - 1
 
         # Check if there is any new data in this chunk
-        if vals['row1'] - 1 <= last_row_idx:
+        if vals["row1"] - 1 <= last_row_idx:
             logger.debug(
-                f'Skipping {date_id} for {msid}: no new data '
+                f"Skipping {date_id} for {msid}: no new data "
                 f'row1={vals["row1"]} last_row_idx={last_row_idx}'
             )
             return
 
         # If this row begins before then end of current data then chop the
         # beginning of data for this row.
-        if vals['row0'] <= last_row_idx:
-            idx0 = last_row_idx + 1 - vals['row0']
-            logger.debug(f'Chopping {idx0 + 1} rows from data')
-            vals['data'] = vals['data'][idx0:]
-            vals['row0'] += idx0
+        if vals["row0"] <= last_row_idx:
+            idx0 = last_row_idx + 1 - vals["row0"]
+            logger.debug(f"Chopping {idx0 + 1} rows from data")
+            vals["data"] = vals["data"][idx0:]
+            vals["row0"] += idx0
 
-        if vals['row0'] != len(h5.root.data):
+        if vals["row0"] != len(h5.root.data):
             raise RowMismatchError(
-                f'ERROR: unexpected discontinuity for stat msid={msid} '
+                f"ERROR: unexpected discontinuity for stat msid={msid} "
                 f'content={fetch.ft["content"]}\n'
-                'Looks like your archive is in a bad state, CONTACT '
-                'your local Ska expert with this info:\n'
+                "Looks like your archive is in a bad state, CONTACT "
+                "your local Ska expert with this info:\n"
                 f'  First row0 in new data {vals["row0"]} != '
-                f'length of existing data {len(h5.root.data)}'
+                f"length of existing data {len(h5.root.data)}"
             )
 
         logger.debug(f'Appending {len(vals["data"])} rows to {stat_file}')
         if not opt.dry_run:
-            h5.root.data.append(vals['data'])
+            h5.root.data.append(vals["data"])
 
 
 def get_last_date_id(msid_files, msids, stat, logger):
@@ -807,20 +807,20 @@ def get_last_date_id(msid_files, msids, stat, logger):
     :param logger:
     :return:
     """
-    last_date_id_file = msid_files['last_date_id'].abs
+    last_date_id_file = msid_files["last_date_id"].abs
 
     if Path(last_date_id_file).exists():
-        logger.verbose(f'Reading {last_date_id_file} to get last update time')
-        with open(last_date_id_file, 'r') as fh:
+        logger.verbose(f"Reading {last_date_id_file} to get last update time")
+        with open(last_date_id_file, "r") as fh:
             last_date_id = fh.read()
     else:
-        logger.verbose(f'Reading stat h5 files to get last update time')
+        logger.verbose(f"Reading stat h5 files to get last update time")
         times = []
         for msid in msids:
-            fetch.ft['msid'] = msid
-            filename = msid_files['stats'].abs
-            logger.debug(f'Reading {filename} to check stat times')
-            with tables.open_file(filename, 'r') as h5:
+            fetch.ft["msid"] = msid
+            filename = msid_files["stats"].abs
+            logger.debug(f"Reading {filename} to check stat times")
+            with tables.open_file(filename, "r") as h5:
                 index = h5.root.data.cols.index[-1]
                 times.append((index + 0.5) * STATS_DT[stat])
 
@@ -829,7 +829,7 @@ def get_last_date_id(msid_files, msids, stat, logger):
         # when they appear in the archive they include weeks of data in the past
         # and possibly future data.
         last_time = min(times)
-        lookback = 30 if re.search(r'ephem[01]$', fetch.ft['content'].val) else 5
+        lookback = 30 if re.search(r"ephem[01]$", fetch.ft["content"].val) else 5
         last_date_id = get_date_id(DateTime(last_time - lookback * 86400).fits)
 
     return last_date_id, last_date_id_file
@@ -844,27 +844,27 @@ def append_h5_col(opt, msid, vals, logger, msid_files):
     :param logger:
     :param msid_files:
     """
-    fetch.ft['msid'] = msid
+    fetch.ft["msid"] = msid
 
-    msid_file = Path(msid_files['msid'].abs)
+    msid_file = Path(msid_files["msid"].abs)
     if not msid_file.exists():
-        logger.debug(f'Skipping MSID update no {msid_file}')
+        logger.debug(f"Skipping MSID update no {msid_file}")
         return
 
-    mode = 'r' if opt.dry_run else 'a'
+    mode = "r" if opt.dry_run else "a"
     with tables.open_file(str(msid_file), mode=mode) as h5:
         # If the vals[] data begins before the end of current data then chop the
         # beginning of data for this row.
         last_row_idx = len(h5.root.data) - 1
-        if vals['row0'] <= last_row_idx:
-            idx0 = last_row_idx + 1 - vals['row0']
-            logger.debug(f'Chopping {idx0 + 1} rows from data')
-            for key in ('data', 'quality'):
+        if vals["row0"] <= last_row_idx:
+            idx0 = last_row_idx + 1 - vals["row0"]
+            logger.debug(f"Chopping {idx0 + 1} rows from data")
+            for key in ("data", "quality"):
                 vals[key] = vals[key][idx0:]
-            vals['row0'] += idx0
+            vals["row0"] += idx0
 
-        n_vals = len(vals['data'])
-        logger.verbose(f'Appending {n_vals} rows to {msid_file}')
+        n_vals = len(vals["data"])
+        logger.verbose(f"Appending {n_vals} rows to {msid_file}")
 
         # Normally at this point there is always data to append since we got here
         # by virtue of the TIME.h5 file being incomplete relative to available sync
@@ -873,14 +873,14 @@ def append_h5_col(opt, msid, vals, logger, msid_files):
         if n_vals == 0:
             return
 
-        if vals['row0'] != len(h5.root.data):
+        if vals["row0"] != len(h5.root.data):
             raise RowMismatchError(
-                f'ERROR: unexpected discontinuity for full msid={msid} '
+                f"ERROR: unexpected discontinuity for full msid={msid} "
                 f'content={fetch.ft["content"]}\n'
-                'Looks like your archive is in a bad state, CONTACT '
-                'your local Ska expert with this info:\n'
+                "Looks like your archive is in a bad state, CONTACT "
+                "your local Ska expert with this info:\n"
                 f'  First row0 in new data {vals["row0"]} != '
-                f'length of existing data {len(h5.root.data)}'
+                f"length of existing data {len(h5.root.data)}"
             )
 
         # For the TIME column include special processing to effectively remove
@@ -890,33 +890,33 @@ def append_h5_col(opt, msid, vals, logger, msid_files):
         # overlaps in the archive data.  Here we only worry about the beginning of
         # new data because anything in the middle will have already been marked
         # bad by update_archive.py.
-        if msid == 'TIME':
-            time0 = vals['data'][0]
+        if msid == "TIME":
+            time0 = vals["data"][0]
             idx1 = len(h5.root.data) - 1
             ii = 0
             while h5.root.data[idx1 - ii] - time0 > -0.0001:
                 h5.root.quality[idx1 - ii] = True
                 ii += 1
             if ii > 0:
-                logger.verbose(f'Excluded {ii} rows due to overlap')
+                logger.verbose(f"Excluded {ii} rows due to overlap")
 
         if not opt.dry_run:
-            h5.root.data.append(vals['data'])
-            h5.root.quality.append(vals['quality'])
+            h5.root.data.append(vals["data"])
+            h5.root.quality.append(vals["quality"])
 
 
 def get_index_tbl(content, logger, opt):
     # Read the index file to know what is available for new data
-    with get_readable(opt.sync_root, opt.is_url, sync_files['index']) as (
+    with get_readable(opt.sync_root, opt.is_url, sync_files["index"]) as (
         index_input,
         uri,
     ):
         if index_input is None:
             # If index_file is not found then get_readable returns None
-            logger.info(f'No new sync data for {content}: {uri} not found')
+            logger.info(f"No new sync data for {content}: {uri} not found")
             return None
-        logger.info(f'Reading index file {uri}')
-        index_tbl = Table.read(index_input, format='ascii.ecsv')
+        logger.info(f"Reading index file {uri}")
+        index_tbl = Table.read(index_input, format="ascii.ecsv")
     return index_tbl
 
 
@@ -929,7 +929,7 @@ def main(args=None):
     # Set up logging
     loglevel = int(opt.log_level)
     logger = pyyaks.logger.get_logger(
-        name='cheta_update_client_archive',
+        name="cheta_update_client_archive",
         level=loglevel,
         format="%(asctime)s %(message)s",
     )
@@ -940,21 +940,21 @@ def main(args=None):
     if opt.data_root is not None:
         if not Path(opt.data_root).exists():
             raise FileNotFoundError(
-                f'local cheta archive directory {Path(opt.data_root).absolute()} not'
-                ' found'
+                f"local cheta archive directory {Path(opt.data_root).absolute()} not"
+                " found"
             )
-        os.environ['ENG_ARCHIVE'] = opt.data_root
+        os.environ["ENG_ARCHIVE"] = opt.data_root
 
-    fetch = importlib.import_module('.fetch', __package__)
+    fetch = importlib.import_module(".fetch", __package__)
 
     # Turn things around and define data_root based on fetch, relying on it to
     # find the archive if --data-root is not specified.
     opt.data_root = fetch.msid_files.basedir
 
-    logger.info(f'Running cheta_update_client_archive version {__version__}')
-    logger.info(f'  {__file__}')
-    logger.info('')
-    logger.info(f'Updating client archive at {fetch.msid_files.basedir}')
+    logger.info(f"Running cheta_update_client_archive version {__version__}")
+    logger.info(f"  {__file__}")
+    logger.info("")
+    logger.info(f"Updating client archive at {fetch.msid_files.basedir}")
 
     if opt.add_msids:
         add_msids(opt, logger)
@@ -970,7 +970,7 @@ def main(args=None):
     process_errors.clear()
 
     for content in sorted(contents):
-        fetch.ft['content'] = content
+        fetch.ft["content"] = content
         index_tbl = get_index_tbl(content, logger, opt)
         if index_tbl is not None:
             sync_full_archive(opt, fetch.msid_files, logger, content, index_tbl)
@@ -980,12 +980,12 @@ def main(args=None):
                 )
 
     if process_errors:
-        logger.error('')
-        logger.error('PROCESS ERRORS or WARNINGS:')
+        logger.error("")
+        logger.error("PROCESS ERRORS or WARNINGS:")
 
     for process_error in process_errors:
         logger.error(process_error)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -47,31 +47,50 @@ process_errors = []
 
 def get_options(args=None):
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--sync-root",
-                        default='https://icxc.cfa.harvard.edu/aspect/cheta/',
-                        help=("URL or file dir for sync files to read from "
-                              "(default=https://icxc.cfa.harvard.edu/aspect/cheta/)"))
-    parser.add_argument("--data-root",
-                        help=("Data directory of eng archive data files to update "
-                              "(default=usual fetch default)"))
-    parser.add_argument("--content",
-                        action='append',
-                        help="Content type to process [match regex] (default=all)")
-    parser.add_argument("--log-level",
-                        default=20,
-                        help="Logging level (default=20 (info))")
-    parser.add_argument("--date-stop",
-                        help="Stop process date (default=NOW)")
-    parser.add_argument("--dry-run",
-                        action="store_true",
-                        help="Dry run (no actual file or database updates)")
-    parser.add_argument('--add-msids',
-                        help='Add MSIDs specified in <file> to eng archive data files"')
-    parser.add_argument('--server-data-root',
-                        help=('Add MSID data from root (/path/to/data, user@remote, '
-                              'or user@remote:/path/to/data'))
-    parser.add_argument('--version', action='version',
-                        version='%(prog)s {version}'.format(version=__version__))
+    parser.add_argument(
+        "--sync-root",
+        default='https://icxc.cfa.harvard.edu/aspect/cheta/',
+        help=(
+            "URL or file dir for sync files to read from "
+            "(default=https://icxc.cfa.harvard.edu/aspect/cheta/)"
+        ),
+    )
+    parser.add_argument(
+        "--data-root",
+        help=(
+            "Data directory of eng archive data files to update "
+            "(default=usual fetch default)"
+        ),
+    )
+    parser.add_argument(
+        "--content",
+        action='append',
+        help="Content type to process [match regex] (default=all)",
+    )
+    parser.add_argument(
+        "--log-level", default=20, help="Logging level (default=20 (info))"
+    )
+    parser.add_argument("--date-stop", help="Stop process date (default=NOW)")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Dry run (no actual file or database updates)",
+    )
+    parser.add_argument(
+        '--add-msids', help='Add MSIDs specified in <file> to eng archive data files"'
+    )
+    parser.add_argument(
+        '--server-data-root',
+        help=(
+            'Add MSID data from root (/path/to/data, user@remote, '
+            'or user@remote:/path/to/data'
+        ),
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version='%(prog)s {version}'.format(version=__version__),
+    )
 
     opt = parser.parse_args(args)
     opt.is_url = re.match(r'http[s]?://', opt.sync_root)
@@ -82,6 +101,7 @@ def get_options(args=None):
 
 class RowMismatchError(ValueError):
     """Exception for row mismatch between existing archive and available sync update"""
+
     pass
 
 
@@ -112,10 +132,13 @@ def get_readable(sync_root, is_url, filename, timeout=30):
     if is_url:
         uri = sync_root.rstrip('/') + '/' + Path(filename).as_posix()
         try:
-            filename = download_file(uri, show_progress=False, cache=False, timeout=timeout)
+            filename = download_file(
+                uri, show_progress=False, cache=False, timeout=timeout
+            )
         except urllib.error.URLError as err:
             raise urllib.error.URLError(
-                f'unable to load {uri}. Are you on a network with icxc access?') from err
+                f'unable to load {uri}. Are you on a network with icxc access?'
+            ) from err
 
     else:
         uri = Path(sync_root, filename)
@@ -137,6 +160,7 @@ class DelayedKeyboardInterrupt(object):
     Taken from https://stackoverflow.com/questions/842557/
     how-to-prevent-a-block-of-code-from-being-interrupted-by-keyboardinterrupt-in-py/21919644
     """
+
     def __init__(self, logger):
         self.logger = logger
         self.signal_received = False
@@ -146,8 +170,10 @@ class DelayedKeyboardInterrupt(object):
 
     def handler(self, sig, frame):
         self.signal_received = (sig, frame)
-        self.logger.info('KEYBOARD INTERRUPT RECEIVED. Please hold tight for moment while we '
-                         'finish up cleanly, otherwise the archive may get corrupted.')
+        self.logger.info(
+            'KEYBOARD INTERRUPT RECEIVED. Please hold tight for moment while we '
+            'finish up cleanly, otherwise the archive may get corrupted.'
+        )
 
     def __exit__(self, typ, value, traceback):
         signal.signal(signal.SIGINT, self.old_handler)
@@ -173,7 +199,9 @@ def add_msids(opt, logger):
     if '@' in opt.server_data_root:
         copy_server_files_ssh(opt, logger, copy_files)
     else:
-        copy_server_files(opt, logger, copy_files, opt.server_data_root, copy_func=shutil.copyfile)
+        copy_server_files(
+            opt, logger, copy_files, opt.server_data_root, copy_func=shutil.copyfile
+        )
 
 
 def copy_server_files(opt, logger, copy_files, server_path, copy_func, as_posix=False):
@@ -192,7 +220,10 @@ def copy_server_files(opt, logger, copy_files, server_path, copy_func, as_posix=
     """
     from astropy.utils.console import ProgressBar
 
-    logger.info(f'Copying {len(copy_files)} files from {opt.server_data_root} to {opt.data_root}')
+    logger.info(
+        f'Copying {len(copy_files)} files from {opt.server_data_root} to'
+        f' {opt.data_root}'
+    )
     if opt.dry_run:
         logger.info('DRY RUN')
 
@@ -217,8 +248,10 @@ def copy_server_files(opt, logger, copy_files, server_path, copy_func, as_posix=
                 total_size += local_file.stat().st_size / 1e6
     total_time = time.time() - tstart
     xfer_rate = total_size / total_time
-    logger.info(f'Data transfer rate = {xfer_rate:.2f} Mb/s : '
-                f'{total_size:.2f} Mb in {total_time:.2f} s')
+    logger.info(
+        f'Data transfer rate = {xfer_rate:.2f} Mb/s : '
+        f'{total_size:.2f} Mb in {total_time:.2f} s'
+    )
 
 
 def copy_server_files_ssh(opt, logger, copy_files):
@@ -245,9 +278,7 @@ def copy_server_files_ssh(opt, logger, copy_files):
     for attempt in range(3):
         try:
             password = getpass.getpass(f'Password for {username}@{hostname}: ')
-            ssh_client.connect(hostname=hostname,
-                               username=username,
-                               password=password)
+            ssh_client.connect(hostname=hostname, username=username, password=password)
         except paramiko.ssh_exception.AuthenticationException:
             if attempt == 2:
                 print('Authentication failed', file=sys.stderr)
@@ -258,8 +289,9 @@ def copy_server_files_ssh(opt, logger, copy_files):
             break
 
     sftp_client = ssh_client.open_sftp()
-    copy_server_files(opt, logger, copy_files, server_path, copy_func=sftp_client.get,
-                      as_posix=True)
+    copy_server_files(
+        opt, logger, copy_files, server_path, copy_func=sftp_client.get, as_posix=True
+    )
     sftp_client.close()
     ssh_client.close()
 
@@ -267,9 +299,7 @@ def copy_server_files_ssh(opt, logger, copy_files):
 def parse_server_data_root(server_data_root):
     match = re.match(r"([a-zA-Z][-.\w]*)@([\w.]+)(:.+)?", server_data_root)
     if not match:
-        raise ValueError(
-            f"could not parse {server_data_root} into username@host:path"
-        )
+        raise ValueError(f"could not parse {server_data_root} into username@host:path")
     username, hostname, server_path = match.groups()
     return username, hostname, server_path
 
@@ -293,12 +323,14 @@ def get_copy_files(logger, msids, msids_content):
     copy_files = set()
     for msid in msids:
         ft['content'] = msids_content[msid]
-        copy_specs = [(msid, None, 'msid'),
-                      (msid, None, 'archfiles'),
-                      (msid, None, 'colnames'),
-                      (msid, '5min', 'stats'),
-                      (msid, 'daily', 'stats'),
-                      ('TIME', None, 'msid')]
+        copy_specs = [
+            (msid, None, 'msid'),
+            (msid, None, 'archfiles'),
+            (msid, None, 'colnames'),
+            (msid, '5min', 'stats'),
+            (msid, 'daily', 'stats'),
+            ('TIME', None, 'msid'),
+        ]
         for ft_msid, interval, filetype in copy_specs:
             ft['msid'] = ft_msid
             ft['interval'] = interval
@@ -308,8 +340,10 @@ def get_copy_files(logger, msids, msids_content):
             if not pth.exists() or filetype == 'colnames':
                 copy_files.add(str(pth.relative_to(basedir)))
 
-    logger.info(f'Found {len(copy_files)} local archive files that are '
-                f'missing and need to be copied')
+    logger.info(
+        f'Found {len(copy_files)} local archive files that are '
+        'missing and need to be copied'
+    )
     logger.debug(f'Copy_files:')
     for copy_file in sorted(copy_files):
         logger.debug(copy_file)
@@ -342,7 +376,10 @@ def get_msids_for_add_msids(opt, logger):
     :return: msids_out, msids_content (mapping of MSID to content type)
     """
     logger.info(f'Reading available cheta archive MSIDs from {opt.sync_root}')
-    with get_readable(opt.sync_root, opt.is_url, sync_files['msid_contents']) as (tmpfile, uri):
+    with get_readable(opt.sync_root, opt.is_url, sync_files['msid_contents']) as (
+        tmpfile,
+        uri,
+    ):
         if tmpfile is None:
             # If index_file is not found then get_readable returns None
             logger.info(f'No cheta MSIDs list file found at{uri}')
@@ -368,23 +405,28 @@ def get_msids_for_add_msids(opt, logger):
             subsys = re.match(r'([^\d]+)', content).group(1)
             for content, msids in content_msids.items():
                 if content.startswith(subsys):
-                    logger.info(f'  Found {len(msids)} MSIDs for **/{msid_spec} with '
-                                f'content = {content}')
+                    logger.info(
+                        f'  Found {len(msids)} MSIDs for **/{msid_spec} with '
+                        f'content = {content}'
+                    )
                     msids_out.extend(msids)
 
         elif msid_spec.startswith('*/'):
             msid_spec = msid_spec[2:]
             content = msids_content[msid_spec]
             msids = content_msids[content]
-            logger.info(f'  Found {len(msids)} MSIDs for */{msid_spec} with '
-                        f'content = {content}')
+            logger.info(
+                f'  Found {len(msids)} MSIDs for */{msid_spec} with content = {content}'
+            )
             msids_out.extend(msids)
 
         else:
             msids = [msid for msid in msids_content if fnmatch(msid, msid_spec)]
             if not msids:
-                raise ValueError(f'no MSID matching {msid} (remember derived params like PITCH '
-                                 'must be written as"dp_<MSID>"')
+                raise ValueError(
+                    f'no MSID matching {msid} (remember derived params like PITCH '
+                    'must be written as"dp_<MSID>"'
+                )
             logger.info(f'  Found {len(msids)} MSIDs for {msid_spec}')
             msids_out.extend(msids)
     logger.info(f'  Found {len(msids_out)} matching MSIDs total')
@@ -466,24 +508,31 @@ def update_full_archfiles_db3(dat, logger, msid_files, opt):
     with timing_logger(logger, f'Updating {server_file}', 'info', 'info'):
         with DBI(dbi='sqlite', server=server_file) as db:
             for archfile in dat['archfiles']:
-                vals = {name: as_python(archfile[name]) for name in archfile.dtype.names}
+                vals = {
+                    name: as_python(archfile[name]) for name in archfile.dtype.names
+                }
                 logger.debug(f'Inserting {vals["filename"]}')
                 if not opt.dry_run:
                     try:
                         db.insert(vals, 'archfiles')
                     except sqlite3.IntegrityError as err:
                         # Expected exception for archfiles already in the table
-                        assert 'UNIQUE constraint failed: archfiles.filename' in str(err)
+                        assert 'UNIQUE constraint failed: archfiles.filename' in str(
+                            err
+                        )
 
             if not opt.dry_run:
                 db.commit()
 
 
 def update_full_h5_files(dat, logger, msid_files, msids, opt):
-    with timing_logger(logger, f'Applying updates to {len(msids)} h5 files',
-                       'info', 'info'):
+    with timing_logger(
+        logger, f'Applying updates to {len(msids)} h5 files', 'info', 'info'
+    ):
         for msid in msids:
-            vals = {key: dat[f'{msid}.{key}'] for key in ('data', 'quality', 'row0', 'row1')}
+            vals = {
+                key: dat[f'{msid}.{key}'] for key in ('data', 'quality', 'row0', 'row1')
+            }
             append_h5_col(opt, msid, vals, logger, msid_files)
 
 
@@ -502,7 +551,10 @@ def get_full_data_sets(ft, index_tbl, logger, opt):
         # Read the file with all the MSID data as a hash with keys like {msid}.data
         # {msid}.quality etc, plus an `archive` key with the table of corresponding
         # archfiles rows.
-        with get_readable(opt.sync_root, opt.is_url, sync_files['data']) as (data_input, uri):
+        with get_readable(opt.sync_root, opt.is_url, sync_files['data']) as (
+            data_input,
+            uri,
+        ):
             with timing_logger(logger, f'Reading update date file {uri}'):
                 with gzip.open(data_input, 'rb') as fh:
                     dats.append(pickle.load(fh))
@@ -529,13 +581,20 @@ def sync_stat_archive(opt, msid_files, logger, content, stat, index_tbl):
     except RowMismatchError as err:
         pth = Path(fetch.msid_files['last_date_id'].abs)
         if pth.exists():
-            msg = f'File {pth} was out of sync with stats archive, generating exception: {err}'
+            msg = (
+                f'File {pth} was out of sync with stats archive, generating exception:'
+                f' {err}'
+            )
             logger.warn(msg)
-            logger.warn(f'Attempting to fix by removing that file and trying to sync again.')
+            logger.warn(
+                f'Attempting to fix by removing that file and trying to sync again.'
+            )
             pth.unlink()
             _sync_stat_archive(opt, msid_files, logger, content, stat, index_tbl)
             process_errors.append(
-                f'WARNING: file {pth} was out of sync with stats archive, fixed by deleting it')
+                f'WARNING: file {pth} was out of sync with stats archive, fixed by'
+                ' deleting it'
+            )
 
 
 def _sync_stat_archive(opt, msid_files, logger, content, stat, index_tbl):
@@ -563,8 +622,7 @@ def _sync_stat_archive(opt, msid_files, logger, content, stat, index_tbl):
     else:
         logger.debug(f'Stat msids are {msids}')
 
-    last_date_id, last_date_id_file = get_last_date_id(
-        msid_files, msids, stat, logger)
+    last_date_id, last_date_id_file = get_last_date_id(msid_files, msids, stat, logger)
     logger.verbose(f'Got {last_date_id} as last date_id that was applied to archive')
 
     # Get list of applicable dat objects (new data, before opt.date_stop).  Also
@@ -621,7 +679,10 @@ def get_stat_data_sets(ft, index_tbl, last_date_id, logger, opt):
 
         # Read the file with all the MSID data as a hash with keys {msid}.data
         # {msid}.row0, {msid}.row1
-        with get_readable(opt.sync_root, opt.is_url, sync_files['data']) as (data_input, uri):
+        with get_readable(opt.sync_root, opt.is_url, sync_files['data']) as (
+            data_input,
+            uri,
+        ):
             with timing_logger(logger, f'Reading update date file {uri}'):
                 with gzip.open(data_input, 'rb') as fh:
                     dat = pickle.load(fh)
@@ -662,8 +723,9 @@ def concat_data_sets(dats, data_keys):
         if len(lens) != 1:
             raise ValueError('inconsistency in lengths of data file inputs')
 
-        for row1, next_row0 in zip(dat_lists[f'{msid}.row1'][:-1],
-                                   dat_lists[f'{msid}.row0'][1:]):
+        for row1, next_row0 in zip(
+            dat_lists[f'{msid}.row1'][:-1], dat_lists[f'{msid}.row0'][1:]
+        ):
             if row1 != next_row0:
                 raise ValueError('unexpected discontinuity in rows in data files')
 
@@ -673,8 +735,9 @@ def concat_data_sets(dats, data_keys):
             dat[f'{msid}.{key}'] = np.concatenate(dat_lists[f'{msid}.{key}'])
 
     if 'archfiles' in dats[0]:
-        dat['archfiles'] = list(itertools.chain.from_iterable(
-            dat['archfiles'] for dat in dats))
+        dat['archfiles'] = list(
+            itertools.chain.from_iterable(dat['archfiles'] for dat in dats)
+        )
 
     return dat, msids
 
@@ -692,8 +755,10 @@ def append_stat_col(dat, stat_file, msid, date_id, opt, logger):
     :return: None
     """
     vals = {key: dat[f'{msid}.{key}'] for key in ('data', 'row0', 'row1')}
-    logger.debug(f'append_stat_col msid={msid} date_id={date_id}, '
-                 f'row0,1 = {vals["row0"]} {vals["row1"]}')
+    logger.debug(
+        f'append_stat_col msid={msid} date_id={date_id}, '
+        f'row0,1 = {vals["row0"]} {vals["row1"]}'
+    )
 
     mode = 'r' if opt.dry_run else 'a'
     with tables.open_file(stat_file, mode=mode) as h5:
@@ -701,8 +766,10 @@ def append_stat_col(dat, stat_file, msid, date_id, opt, logger):
 
         # Check if there is any new data in this chunk
         if vals['row1'] - 1 <= last_row_idx:
-            logger.debug(f'Skipping {date_id} for {msid}: no new data '
-                         f'row1={vals["row1"]} last_row_idx={last_row_idx}')
+            logger.debug(
+                f'Skipping {date_id} for {msid}: no new data '
+                f'row1={vals["row1"]} last_row_idx={last_row_idx}'
+            )
             return
 
         # If this row begins before then end of current data then chop the
@@ -717,10 +784,11 @@ def append_stat_col(dat, stat_file, msid, date_id, opt, logger):
             raise RowMismatchError(
                 f'ERROR: unexpected discontinuity for stat msid={msid} '
                 f'content={fetch.ft["content"]}\n'
-                f'Looks like your archive is in a bad state, CONTACT '
-                f'your local Ska expert with this info:\n'
+                'Looks like your archive is in a bad state, CONTACT '
+                'your local Ska expert with this info:\n'
                 f'  First row0 in new data {vals["row0"]} != '
-                f'length of existing data {len(h5.root.data)}')
+                f'length of existing data {len(h5.root.data)}'
+            )
 
         logger.debug(f'Appending {len(vals["data"])} rows to {stat_file}')
         if not opt.dry_run:
@@ -809,10 +877,11 @@ def append_h5_col(opt, msid, vals, logger, msid_files):
             raise RowMismatchError(
                 f'ERROR: unexpected discontinuity for full msid={msid} '
                 f'content={fetch.ft["content"]}\n'
-                f'Looks like your archive is in a bad state, CONTACT '
-                f'your local Ska expert with this info:\n'
+                'Looks like your archive is in a bad state, CONTACT '
+                'your local Ska expert with this info:\n'
                 f'  First row0 in new data {vals["row0"]} != '
-                f'length of existing data {len(h5.root.data)}')
+                f'length of existing data {len(h5.root.data)}'
+            )
 
         # For the TIME column include special processing to effectively remove
         # existing rows that are superceded by new rows in time.  This is done by
@@ -838,7 +907,10 @@ def append_h5_col(opt, msid, vals, logger, msid_files):
 
 def get_index_tbl(content, logger, opt):
     # Read the index file to know what is available for new data
-    with get_readable(opt.sync_root, opt.is_url, sync_files['index']) as (index_input, uri):
+    with get_readable(opt.sync_root, opt.is_url, sync_files['index']) as (
+        index_input,
+        uri,
+    ):
         if index_input is None:
             # If index_file is not found then get_readable returns None
             logger.info(f'No new sync data for {content}: {uri} not found')
@@ -856,8 +928,11 @@ def main(args=None):
 
     # Set up logging
     loglevel = int(opt.log_level)
-    logger = pyyaks.logger.get_logger(name='cheta_update_client_archive', level=loglevel,
-                                      format="%(asctime)s %(message)s")
+    logger = pyyaks.logger.get_logger(
+        name='cheta_update_client_archive',
+        level=loglevel,
+        format="%(asctime)s %(message)s",
+    )
 
     # If --data-root is supplied then set the fetch msid_files basedir via ENG_ARCHIVE
     # prior to importing fetch.  This ensures that ``content`` is consistent with
@@ -865,7 +940,9 @@ def main(args=None):
     if opt.data_root is not None:
         if not Path(opt.data_root).exists():
             raise FileNotFoundError(
-                f'local cheta archive directory {Path(opt.data_root).absolute()} not found')
+                f'local cheta archive directory {Path(opt.data_root).absolute()} not'
+                ' found'
+            )
         os.environ['ENG_ARCHIVE'] = opt.data_root
 
     fetch = importlib.import_module('.fetch', __package__)
@@ -898,7 +975,9 @@ def main(args=None):
         if index_tbl is not None:
             sync_full_archive(opt, fetch.msid_files, logger, content, index_tbl)
             for stat in STATS_DT:
-                sync_stat_archive(opt, fetch.msid_files, logger, content, stat, index_tbl)
+                sync_stat_archive(
+                    opt, fetch.msid_files, logger, content, stat, index_tbl
+                )
 
     if process_errors:
         logger.error('')

--- a/Ska/engarchive/update_client_archive.py
+++ b/Ska/engarchive/update_client_archive.py
@@ -12,32 +12,32 @@ import collections
 import contextlib
 import getpass
 import gzip
+import importlib
 import itertools
 import os
-import shutil
-import sys
 import pickle
 import re
+import shutil
+import signal
 import sqlite3
+import sys
+import time
 import urllib
 import urllib.error
 from fnmatch import fnmatch
 from pathlib import Path
-import importlib
-import time
-import signal
 
 import numpy as np
 import pyyaks.context
 import pyyaks.logger
 import tables
-from Chandra.Time import DateTime
-from Ska.DBI import DBI
 from astropy.table import Table
 from astropy.utils.data import download_file
+from Chandra.Time import DateTime
+from Ska.DBI import DBI
 
-from . import file_defs, __version__
-from .utils import get_date_id, STATS_DT
+from . import __version__, file_defs
+from .utils import STATS_DT, get_date_id
 
 sync_files = pyyaks.context.ContextDict('update_client_archive.sync_files')
 sync_files.update(file_defs.sync_files)

--- a/Ska/engarchive/update_server_sync.py
+++ b/Ska/engarchive/update_server_sync.py
@@ -41,13 +41,12 @@ import numpy as np
 import pyyaks.context
 import pyyaks.logger
 import tables
+from astropy.table import Table
 from Chandra.Time import DateTime
 from Ska.DBI import DBI
-from astropy.table import Table
 
-from . import fetch
-from . import file_defs
-from .utils import get_date_id, STATS_DT
+from . import fetch, file_defs
+from .utils import STATS_DT, get_date_id
 
 sync_files = pyyaks.context.ContextDict('update_server_sync.sync_files')
 sync_files.update(file_defs.sync_files)

--- a/Ska/engarchive/update_server_sync.py
+++ b/Ska/engarchive/update_server_sync.py
@@ -54,33 +54,41 @@ sync_files.update(file_defs.sync_files)
 
 def get_options(args=None):
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--sync-root",
-                        default=".",
-                        help="Root directory for sync files (default='.')")
-    parser.add_argument("--content",
-                        action='append',
-                        help="Content type to process [match regex] (default = all)")
-    parser.add_argument("--max-days",
-                        type=float,
-                        default=1.5,
-                        help="Max number of days of files per sync directory (default=1.5)")
-    parser.add_argument("--max-lookback",
-                        type=float,
-                        default=60,
-                        help="Maximum number of days to look back from --date-stop (default=60)")
-    parser.add_argument("--max-sync-dirs",
-                        type=int,
-                        default=60,
-                        help=("Number of sync directories to keep before "
-                              "removing oldest (default=60)"))
-    parser.add_argument("--log-level",
-                        default=20,
-                        help="Logging level")
-    parser.add_argument("--date-start",
-                        help=("Start process date (default=NOW - max-lookback). "
-                              "Provide this parameter when creating a new sync directory."))
-    parser.add_argument("--date-stop",
-                        help="Stop process date (default=NOW)")
+    parser.add_argument(
+        "--sync-root", default=".", help="Root directory for sync files (default='.')"
+    )
+    parser.add_argument(
+        "--content",
+        action='append',
+        help="Content type to process [match regex] (default = all)",
+    )
+    parser.add_argument(
+        "--max-days",
+        type=float,
+        default=1.5,
+        help="Max number of days of files per sync directory (default=1.5)",
+    )
+    parser.add_argument(
+        "--max-lookback",
+        type=float,
+        default=60,
+        help="Maximum number of days to look back from --date-stop (default=60)",
+    )
+    parser.add_argument(
+        "--max-sync-dirs",
+        type=int,
+        default=60,
+        help="Number of sync directories to keep before removing oldest (default=60)",
+    )
+    parser.add_argument("--log-level", default=20, help="Logging level")
+    parser.add_argument(
+        "--date-start",
+        help=(
+            "Start process date (default=NOW - max-lookback). "
+            "Provide this parameter when creating a new sync directory."
+        ),
+    )
+    parser.add_argument("--date-stop", help="Stop process date (default=NOW)")
     return parser.parse_args(args)
 
 
@@ -112,8 +120,11 @@ def main(args=None):
 
     # Set up logging
     loglevel = int(opt.log_level)
-    logger = pyyaks.logger.get_logger(name='cheta_update_server_sync', level=loglevel,
-                                      format="%(asctime)s %(message)s")
+    logger = pyyaks.logger.get_logger(
+        name='cheta_update_server_sync',
+        level=loglevel,
+        format="%(asctime)s %(message)s",
+    )
 
     if opt.content:
         contents = opt.content
@@ -177,7 +188,9 @@ def update_sync_repo(opt, logger, content):
 
     if index_tbl is None:
         # Index table was not created, nothing more to do here
-        logger.warning(f'WARNING: No index table for {content} (use --date-start to create)')
+        logger.warning(
+            f'WARNING: No index table for {content} (use --date-start to create)'
+        )
         return
 
     for row in index_tbl:
@@ -196,11 +209,13 @@ def get_row_from_archfiles(archfiles):
     # date like 2019-02-20T2109z, human-readable and Windows-friendly (no :) for a unique
     # identifier for this set of updates.
     date_id = get_date_id(DateTime(archfiles[0]['filetime']).fits)
-    row = {'date_id': date_id,
-           'filetime0': archfiles[0]['filetime'],
-           'filetime1': archfiles[-1]['filetime'],
-           'row0': archfiles[0]['rowstart'],
-           'row1': archfiles[-1]['rowstop']}
+    row = {
+        'date_id': date_id,
+        'filetime0': archfiles[0]['filetime'],
+        'filetime1': archfiles[-1]['filetime'],
+        'row0': archfiles[0]['rowstart'],
+        'row1': archfiles[-1]['rowstop'],
+    }
     return row
 
 
@@ -266,21 +281,26 @@ def update_index_file(index_file, opt, logger):
     with DBI(dbi='sqlite', server=filename) as dbi:
         while True:
             filetime1 = min(filetime0 + max_secs, time_stop)
-            logger.verbose(f'select from archfiles '
-                           f'filetime > {DateTime(filetime0).fits[:-4]} {filetime0} '
-                           f'filetime <= {DateTime(filetime1).fits[:-4]} {filetime1} '
-                           )
-            archfiles = dbi.fetchall(f'select * from archfiles '
-                                     f'where filetime > {filetime0} '
-                                     f'and filetime <= {filetime1} '
-                                     f'order by filetime ')
+            logger.verbose(
+                'select from archfiles '
+                f'filetime > {DateTime(filetime0).fits[:-4]} {filetime0} '
+                f'filetime <= {DateTime(filetime1).fits[:-4]} {filetime1} '
+            )
+            archfiles = dbi.fetchall(
+                'select * from archfiles '
+                f'where filetime > {filetime0} '
+                f'and filetime <= {filetime1} '
+                'order by filetime '
+            )
 
             # Found new archfiles?  If so get a new index table row for them.
             if len(archfiles) > 0:
                 rows.append(get_row_from_archfiles(archfiles))
                 filedates = DateTime(archfiles['filetime']).fits
-                logger.verbose(f'Got {len(archfiles)} archfiles rows from '
-                               f'{filedates[0]} to {filedates[-1]}')
+                logger.verbose(
+                    f'Got {len(archfiles)} archfiles rows from '
+                    f'{filedates[0]} to {filedates[-1]}'
+                )
 
             filetime0 = filetime1
 
@@ -346,10 +366,12 @@ def update_sync_data_full(content, logger, row):
     # for the archfiles to be included  in this row.  They do not overlap, so
     # the selection below must be equality.
     with DBI(dbi='sqlite', server=fetch.msid_files['archfiles'].abs) as dbi:
-        query = (f'select * from archfiles '
-                 f'where filetime >= {row["filetime0"]} '
-                 f'and filetime <= {row["filetime1"]} '
-                 f'order by filetime ')
+        query = (
+            'select * from archfiles '
+            f'where filetime >= {row["filetime0"]} '
+            f'and filetime <= {row["filetime1"]} '
+            'order by filetime '
+        )
         archfiles = dbi.fetchall(query)
         out['archfiles'] = archfiles
 
@@ -399,8 +421,10 @@ def _get_stat_data_from_archive(filename, stat, tstart, tstop, last_row1, logger
     """
     dt = STATS_DT[stat]
 
-    logger.verbose(f'_get_stat_data({filename}, {stat}, {DateTime(tstart).fits}, '
-                   f'{DateTime(tstop).fits}, {last_row1})')
+    logger.verbose(
+        f'_get_stat_data({filename}, {stat}, {DateTime(tstart).fits}, '
+        f'{DateTime(tstop).fits}, {last_row1})'
+    )
 
     with tables.open_file(filename, 'r') as h5:
         # Check if tstart is beyond the end of the table.  If so, return an empty table
@@ -408,8 +432,10 @@ def _get_stat_data_from_archive(filename, stat, tstart, tstop, last_row1, logger
         last_index = table[-1]['index']
         last_time = (last_index + 0.5) * dt
         if tstart > last_time:
-            logger.verbose(f'No available stats data {DateTime(tstart).fits} > '
-                           f'{DateTime(last_time).fits} (returning empty table)')
+            logger.verbose(
+                f'No available stats data {DateTime(tstart).fits} > '
+                f'{DateTime(last_time).fits} (returning empty table)'
+            )
             row0 = row1 = len(table)
             table_rows = table[row0:row1]
         else:
@@ -504,7 +530,8 @@ def update_sync_data_stat(content, logger, row, stat):
 
         n_msids += 1
         stat_rows, row0, row1 = _get_stat_data_from_archive(
-            filename, stat, tstart, tstop, last_row1, logger)
+            filename, stat, tstart, tstop, last_row1, logger
+        )
         logger.verbose(f'Got stat rows {row0} {row1} for stat {stat} {msid}')
         n_rows_set.add(row1 - row0)
         if row1 > row0:

--- a/Ska/engarchive/utils.py
+++ b/Ska/engarchive/utils.py
@@ -13,7 +13,7 @@ from Chandra.Time import DateTime
 FETCH_SIZES = {}
 
 # Standard intervals for 5min and daily telemetry
-STATS_DT = {'5min': 328, 'daily': 86400}
+STATS_DT = {"5min": 328, "daily": 86400}
 
 
 def get_fetch_size(msids, start, stop, stat=None, interpolate_dt=None, fast=True):
@@ -61,7 +61,7 @@ def get_fetch_size(msids, start, stop, stat=None, interpolate_dt=None, fast=True
         if (msid, stat) in FETCH_SIZES:
             fetch_bytes, fetch_rows = FETCH_SIZES[msid, stat]
         else:
-            dat = fetch.MSID(msid, '2010:001:00:00:01', '2010:004:00:00:01', stat=stat)
+            dat = fetch.MSID(msid, "2010:001:00:00:01", "2010:004:00:00:01", stat=stat)
             fetch_bytes = sum(getattr(dat, attr).nbytes for attr in dat.colnames)
             fetch_rows = len(dat.vals)
             FETCH_SIZES[msid, stat] = (fetch_bytes, fetch_rows)
@@ -82,7 +82,7 @@ def get_fetch_size(msids, start, stop, stat=None, interpolate_dt=None, fast=True
     return round(fetch_bytes / 1e6, 2), round(out_bytes / 1e6, 2)
 
 
-def ss_vector(start, stop=None, obj='Earth'):
+def ss_vector(start, stop=None, obj="Earth"):
     """Calculate vector to Earth, Sun, or Moon in Chandra body coordinates
     between ``start`` and ``stop`` dates at 5 minute (328 sec) intervals.
 
@@ -137,32 +137,32 @@ def ss_vector(start, stop=None, obj='Earth'):
     sign = dict(earth=-1, sun=1, moon=1)
     obj = obj.lower()
     if obj not in sign:
-        raise ValueError('obj parameter must be one of {0}'.format(list(sign.keys())))
+        raise ValueError("obj parameter must be one of {0}".format(list(sign.keys())))
 
     tstart = DateTime(start).secs
     tstop = DateTime(stop).secs
-    q_att_msids = ['aoattqt1', 'aoattqt2', 'aoattqt3', 'aoattqt4']
-    q_atts = fetch.MSIDset(q_att_msids, tstart, tstop, stat='5min')
+    q_att_msids = ["aoattqt1", "aoattqt2", "aoattqt3", "aoattqt4"]
+    q_atts = fetch.MSIDset(q_att_msids, tstart, tstop, stat="5min")
 
     q_atts_times = set(len(q_atts[x].times) for x in q_att_msids)
     if len(q_atts_times) != 1:
-        raise ValueError('Inconsistency in sampling for aoattqt<N>')
+        raise ValueError("Inconsistency in sampling for aoattqt<N>")
 
-    axes = ['x', 'y', 'z']
-    prefixes = {'earth': 'orbitephem1', 'sun': 'solarephem1', 'moon': 'lunarephem1'}
-    objs = set(['earth', obj])
-    msids = ['{0}_{1}'.format(prefixes[y], x) for x in axes for y in objs]
+    axes = ["x", "y", "z"]
+    prefixes = {"earth": "orbitephem1", "sun": "solarephem1", "moon": "lunarephem1"}
+    objs = set(["earth", obj])
+    msids = ["{0}_{1}".format(prefixes[y], x) for x in axes for y in objs]
 
     # Pad the fetch so interp always works
     ephem = fetch.MSIDset(msids, tstart - 1000, tstop + 1000, filter_bad=True)
-    times = q_atts['aoattqt1'].times
+    times = q_atts["aoattqt1"].times
     times0 = times - tstart
     obj_ecis = np.zeros(shape=(len(times0), 3), dtype=float)
     for i, axis in enumerate(axes):
         for obj in objs:
-            msid = '{0}_{1}'.format(prefixes[obj], axis)
+            msid = "{0}_{1}".format(prefixes[obj], axis)
             ephem_interp = interp1d(
-                ephem[msid].times - tstart, ephem[msid].vals, kind='linear'
+                ephem[msid].times - tstart, ephem[msid].vals, kind="linear"
             )
             obj_ecis[:, i] += sign[obj] * ephem_interp(times0)
 
@@ -175,10 +175,10 @@ def ss_vector(start, stop=None, obj='Earth'):
         obj_ecis,
         distances,
         times0,
-        q_atts['aoattqt1'].midvals,
-        q_atts['aoattqt2'].midvals,
-        q_atts['aoattqt3'].midvals,
-        q_atts['aoattqt4'].midvals,
+        q_atts["aoattqt1"].midvals,
+        q_atts["aoattqt2"].midvals,
+        q_atts["aoattqt3"].midvals,
+        q_atts["aoattqt4"].midvals,
     ):
         try:
             q_att = Quat([q1, q2, q3, q4])
@@ -198,24 +198,24 @@ def ss_vector(start, stop=None, obj='Earth'):
             obj_ecis[:, 0] / distances,
             obj_ecis[:, 1] / distances,
             obj_ecis[:, 2] / distances,
-            q_atts['aoattqt1'].midvals,
-            q_atts['aoattqt2'].midvals,
-            q_atts['aoattqt3'].midvals,
-            q_atts['aoattqt4'].midvals,
+            q_atts["aoattqt1"].midvals,
+            q_atts["aoattqt2"].midvals,
+            q_atts["aoattqt3"].midvals,
+            q_atts["aoattqt4"].midvals,
         ],
         names=[
-            'times',
-            'distance',
-            'body_x',
-            'body_y',
-            'body_z',
-            'eci_x',
-            'eci_y',
-            'eci_z',
-            'q1',
-            'q2',
-            'q3',
-            'q4',
+            "times",
+            "distance",
+            "body_x",
+            "body_y",
+            "body_z",
+            "eci_x",
+            "eci_y",
+            "eci_z",
+            "q1",
+            "q2",
+            "q3",
+            "q4",
         ],
     )
     if bad_q_atts:
@@ -289,13 +289,13 @@ def logical_intervals(times, bools, complete_intervals=True, max_gap=None):
     intervals = state_intervals(times, bools)
 
     if complete_intervals:
-        if len(intervals) > 0 and intervals['val'][0]:
+        if len(intervals) > 0 and intervals["val"][0]:
             intervals = intervals[1:]
-        if len(intervals) > 0 and intervals['val'][-1]:
+        if len(intervals) > 0 and intervals["val"][-1]:
             intervals = intervals[:-1]
 
-    ok = intervals['val']  # Intervals where bools is True
-    del intervals['val']
+    ok = intervals["val"]  # Intervals where bools is True
+    del intervals["val"]
     return intervals[ok]
 
 
@@ -331,7 +331,7 @@ def state_intervals(times, vals):
     from astropy.table import Table
 
     if len(vals) < 2:
-        raise ValueError('Filtered data length must be at least 2')
+        raise ValueError("Filtered data length must be at least 2")
 
     transitions = np.hstack([[True], vals[:-1] != vals[1:], [True]])
     t0 = times[0] - (times[1] - times[0]) / 2
@@ -342,12 +342,12 @@ def state_intervals(times, vals):
     state_times = midtimes[transitions]
 
     intervals = {
-        'datestart': DateTime(state_times[:-1]).date,
-        'datestop': DateTime(state_times[1:]).date,
-        'tstart': state_times[:-1],
-        'tstop': state_times[1:],
-        'duration': state_times[1:] - state_times[:-1],
-        'val': state_vals,
+        "datestart": DateTime(state_times[:-1]).date,
+        "datestop": DateTime(state_times[1:]).date,
+        "tstart": state_times[:-1],
+        "tstop": state_times[1:],
+        "duration": state_times[1:] - state_times[:-1],
+        "val": state_vals,
     }
 
     return Table(intervals, names=sorted(intervals))
@@ -361,7 +361,7 @@ def get_date_id(date):
     :return: date_id
     """
     date_id = DateTime(date).fits
-    date_id = re.sub(':', '', date_id[:16]) + 'z'
+    date_id = re.sub(":", "", date_id[:16]) + "z"
     return date_id
 
 

--- a/Ska/engarchive/utils.py
+++ b/Ska/engarchive/utils.py
@@ -5,10 +5,9 @@ Utilities for the engineering archive.
 import re
 from contextlib import contextmanager
 
-import six
 import numpy as np
+import six
 from Chandra.Time import DateTime
-
 
 # Cache the results of fetching 3 days of telemetry keyed by MSID
 FETCH_SIZES = {}
@@ -128,8 +127,10 @@ def ss_vector(start, stop=None, obj='Earth'):
     :returns: table of vector values
     """
     from itertools import count
+
     from Quaternion import Quat
     from scipy.interpolate import interp1d
+
     from . import fetch
 
     sign = dict(earth=-1, sun=1, moon=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.black]
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import sys
 import glob
 import os
+import sys
 
 from setuptools import setup
-
 
 try:
     from testr.setup_helper import cmdclass

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,15 @@ try:
 except ImportError:
     cmdclass = {}
 
-console_scripts = ['ska_fetch = cheta.get_telem:main',
-                   'cheta_sync = cheta.update_client_archive:main',
-                   'cheta_update_server_sync = cheta.update_server_sync:main',
-                   'cheta_update_server_archive = cheta.update_archive:main',
-                   'cheta_check_integrity = cheta.check_integrity:main',
-                   'cheta_fix_bad_values = cheta.fix_bad_values:main',
-                   'cheta_add_derived = cheta.add_derived:main']
+console_scripts = [
+    'ska_fetch = cheta.get_telem:main',
+    'cheta_sync = cheta.update_client_archive:main',
+    'cheta_update_server_sync = cheta.update_server_sync:main',
+    'cheta_update_server_archive = cheta.update_archive:main',
+    'cheta_check_integrity = cheta.check_integrity:main',
+    'cheta_fix_bad_values = cheta.fix_bad_values:main',
+    'cheta_add_derived = cheta.add_derived:main',
+]
 
 # Install following into sys.prefix/share/eng_archive/ via the data_files directive.
 if "--user" not in sys.argv:
@@ -31,24 +33,27 @@ packages = ['Ska', 'Ska.engarchive', 'Ska.engarchive.derived', 'Ska.engarchive.t
 for package in list(packages)[1:]:
     packages.append(package.replace('Ska.engarchive', 'cheta'))
 
-package_data = {'Ska.engarchive': ['*.dat', 'units_*.pkl', 'archfiles_def.sql'],
-                'Ska.engarchive.tests': ['*.dat']}
+package_data = {
+    'Ska.engarchive': ['*.dat', 'units_*.pkl', 'archfiles_def.sql'],
+    'Ska.engarchive.tests': ['*.dat'],
+}
 for key in list(package_data):
     cheta_key = key.replace('Ska.engarchive', 'cheta')
     package_data[cheta_key] = package_data[key]
 
-setup(name='Ska.engarchive',
-      author='Tom Aldcroft',
-      description='Modules supporting Ska engineering telemetry archive',
-      author_email='taldcroft@cfa.harvard.edu',
-      entry_points={'console_scripts': console_scripts},
-      use_scm_version=True,
-      setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
-      zip_safe=False,
-      package_dir={'Ska': 'Ska', 'cheta': 'Ska/engarchive'},
-      packages=packages,
-      package_data=package_data,
-      data_files=data_files,
-      tests_require=['pytest'],
-      cmdclass=cmdclass,
-      )
+setup(
+    name='Ska.engarchive',
+    author='Tom Aldcroft',
+    description='Modules supporting Ska engineering telemetry archive',
+    author_email='taldcroft@cfa.harvard.edu',
+    entry_points={'console_scripts': console_scripts},
+    use_scm_version=True,
+    setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
+    zip_safe=False,
+    package_dir={'Ska': 'Ska', 'cheta': 'Ska/engarchive'},
+    packages=packages,
+    package_data=package_data,
+    data_files=data_files,
+    tests_require=['pytest'],
+    cmdclass=cmdclass,
+)

--- a/setup.py
+++ b/setup.py
@@ -11,49 +11,49 @@ except ImportError:
     cmdclass = {}
 
 console_scripts = [
-    'ska_fetch = cheta.get_telem:main',
-    'cheta_sync = cheta.update_client_archive:main',
-    'cheta_update_server_sync = cheta.update_server_sync:main',
-    'cheta_update_server_archive = cheta.update_archive:main',
-    'cheta_check_integrity = cheta.check_integrity:main',
-    'cheta_fix_bad_values = cheta.fix_bad_values:main',
-    'cheta_add_derived = cheta.add_derived:main',
+    "ska_fetch = cheta.get_telem:main",
+    "cheta_sync = cheta.update_client_archive:main",
+    "cheta_update_server_sync = cheta.update_server_sync:main",
+    "cheta_update_server_archive = cheta.update_archive:main",
+    "cheta_check_integrity = cheta.check_integrity:main",
+    "cheta_fix_bad_values = cheta.fix_bad_values:main",
+    "cheta_add_derived = cheta.add_derived:main",
 ]
 
 # Install following into sys.prefix/share/eng_archive/ via the data_files directive.
 if "--user" not in sys.argv:
     share_path = os.path.join("share", "eng_archive")
-    task_files = glob.glob('task_schedule*.cfg')
+    task_files = glob.glob("task_schedule*.cfg")
     data_files = [(share_path, task_files)]
 else:
     data_files = None
 
 # Duplicate Ska.engarchive packages and package_data to cheta
-packages = ['Ska', 'Ska.engarchive', 'Ska.engarchive.derived', 'Ska.engarchive.tests']
+packages = ["Ska", "Ska.engarchive", "Ska.engarchive.derived", "Ska.engarchive.tests"]
 for package in list(packages)[1:]:
-    packages.append(package.replace('Ska.engarchive', 'cheta'))
+    packages.append(package.replace("Ska.engarchive", "cheta"))
 
 package_data = {
-    'Ska.engarchive': ['*.dat', 'units_*.pkl', 'archfiles_def.sql'],
-    'Ska.engarchive.tests': ['*.dat'],
+    "Ska.engarchive": ["*.dat", "units_*.pkl", "archfiles_def.sql"],
+    "Ska.engarchive.tests": ["*.dat"],
 }
 for key in list(package_data):
-    cheta_key = key.replace('Ska.engarchive', 'cheta')
+    cheta_key = key.replace("Ska.engarchive", "cheta")
     package_data[cheta_key] = package_data[key]
 
 setup(
-    name='Ska.engarchive',
-    author='Tom Aldcroft',
-    description='Modules supporting Ska engineering telemetry archive',
-    author_email='taldcroft@cfa.harvard.edu',
-    entry_points={'console_scripts': console_scripts},
+    name="Ska.engarchive",
+    author="Tom Aldcroft",
+    description="Modules supporting Ska engineering telemetry archive",
+    author_email="taldcroft@cfa.harvard.edu",
+    entry_points={"console_scripts": console_scripts},
     use_scm_version=True,
-    setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
+    setup_requires=["setuptools_scm", "setuptools_scm_git_archive"],
     zip_safe=False,
-    package_dir={'Ska': 'Ska', 'cheta': 'Ska/engarchive'},
+    package_dir={"Ska": "Ska", "cheta": "Ska/engarchive"},
     packages=packages,
     package_data=package_data,
     data_files=data_files,
-    tests_require=['pytest'],
+    tests_require=["pytest"],
     cmdclass=cmdclass,
 )


### PR DESCRIPTION
## Description

Apply black and isort and update configuration files:
- Update `.github/workflows/flake8.yml`
- New `pyproject.toml`
- New `.pre-commit-config.yaml`

Based on experience from the astropy black project, the changes were done as such, with a commit between each step:
```
isort
black --skip-string-normalization --preview
black
```

The `--preview` flag (in 2022) includes very useful string munging to get strings within the width limit and generally does a slightly better job with formatting.

The final black run does all the single-quote to double-quote changes. In addition, there are a few things that plain `black` changes from what is in `--preview`. Since the default is running plain black, we need to make those changes those now.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
