### PR TITLE
Computed MSID for pitch/off-nominal roll + data gap + docs fixes

### DIFF
--- a/Ska/engarchive/derived/base.py
+++ b/Ska/engarchive/derived/base.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import logging
+
 import numpy as np
 import Ska.Numpy
 from Chandra.Time import DateTime
@@ -9,6 +11,8 @@ from .. import cache
 __all__ = ["MNF_TIME", "times_indexes", "DerivedParameter"]
 
 MNF_TIME = 0.25625  # Minor Frame duration (seconds)
+
+logger = logging.getLogger("Ska.engarchive.fetch")
 
 
 def times_indexes(start, stop, dt):
@@ -90,7 +94,7 @@ class DerivedParameter(object):
             max_gap = self.max_gaps.get(msidname, self.max_gap)
             gap_bads = abs(data.times - times) > max_gap
             if np.any(gap_bads):
-                print(
+                logger.info(
                     "Setting bads because of gaps in {} between {} to {}".format(
                         msidname,
                         DateTime(times[gap_bads][0]).date,

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -9,10 +9,12 @@ Support computed MSIDs in the cheta archive.
 See: https://nbviewer.jupyter.org/urls/cxc.harvard.edu/mta/ASPECT/ipynb/misc/DAWG-mups-valve-xija-filtering.ipynb
 """  # noqa
 
+import functools
 import re
 
+import astropy.table as tbl
 import numpy as np
-from Chandra.Time import DateTime
+from cxotime import CxoTime
 
 from ..units import converters as unit_converter_funcs
 
@@ -92,7 +94,7 @@ def calc_stats_vals(msid, rows, indexes, interval):
                     negs = dts < 0.0
                     if np.any(negs):
                         times_dts = [
-                            (DateTime(t).date, dt)
+                            (CxoTime(t).date, dt)
                             for t, dt in zip(times[negs], dts[negs])
                         ]
                         raise ValueError(
@@ -531,4 +533,204 @@ class Comp_KadiCommandState(ComputedMsid):
             "unit": None,
         }
 
+        return out
+
+
+@functools.lru_cache(maxsize=1)
+def get_roll_pitch_tlm(start, stop):
+    from .. import fetch
+
+    msids = ["6sares1", "6sares2", "6sunsa1", "6sunsa2", "6sunsa3"]
+    dat = fetch.MSIDset(msids, start, stop)
+
+    # Filter out of range values. This happens just at the beginning of safe mode.
+    for msid in msids:
+        if "6sares" in msid:
+            x0, x1 = 0, 180
+        else:
+            x0, x1 = -1, 1
+        dat[msid].bads |= (dat[msid].vals < x0) | (dat[msid].vals > x1)
+
+    dat.interpolate(times=dat[msids[0]].times, bad_union=True)
+    return dat
+
+
+def calc_css_pitch_safe(start, stop):
+    from .pcad import arccos_clip
+
+    # Get the raw telemetry value in user-requested unit system
+    dat = get_roll_pitch_tlm(start, stop)
+
+    sa_ang_avg = (1.0 * dat["6sares1"].vals + 1.0 * dat["6sares2"].vals) / 2
+    sinang = np.sin(np.radians(sa_ang_avg))
+    cosang = np.cos(np.radians(sa_ang_avg))
+    # Rotate CSS sun vector from SA to ACA frame
+    css_aca = np.array(
+        [
+            sinang * dat["6sunsa1"].vals - cosang * dat["6sunsa3"].vals,
+            dat["6sunsa2"].vals * 1.0,
+            cosang * dat["6sunsa1"].vals + sinang * dat["6sunsa3"].vals,
+        ]
+    )
+    # Normalize sun vec (again) and compute pitch
+    magnitude = np.sqrt((css_aca * css_aca).sum(axis=0))
+    magnitude[magnitude == 0.0] = 1.0
+    sun_vec_norm = css_aca / magnitude
+    vals = np.degrees(arccos_clip(sun_vec_norm[0]))
+
+    return dat.times, vals
+
+
+def calc_css_roll_safe(start, stop):
+    """Off-Nominal Roll Angle from CSS Data in ACA Frame [Deg]
+
+    Defined as the rotation about the ACA X-axis required to align the sun
+    vector with the ACA X/Z plane.
+
+    Calculated by rotating the CSS sun vector from the SA-1 frame to ACA frame
+    based on the solar array angles 6SARES1 and 6SARES2.
+
+    """
+    # Get the raw telemetry value in user-requested unit system
+    dat = get_roll_pitch_tlm(start, stop)
+
+    sa_ang_avg = (dat["6sares1"].vals + dat["6sares2"].vals) / 2
+    sinang = np.sin(np.radians(sa_ang_avg))
+    cosang = np.cos(np.radians(sa_ang_avg))
+    # Rotate CSS sun vector from SA to ACA frame
+    css_aca = np.array(
+        [
+            sinang * dat["6sunsa1"].vals - cosang * dat["6sunsa3"].vals,
+            dat["6sunsa2"].vals,
+            cosang * dat["6sunsa1"].vals + sinang * dat["6sunsa3"].vals,
+        ]
+    )
+    # Normalize sun vec (again) and compute pitch
+    magnitude = np.sqrt((css_aca * css_aca).sum(axis=0))
+    # Don't exactly know why zero values can happen, but it does, so just drop those.
+    ok = magnitude > 0
+    magnitude = magnitude[ok]
+    times = dat.times[ok]
+
+    sun_vec_norm = css_aca / magnitude
+    vals = np.degrees(np.arctan2(-sun_vec_norm[1, :], -sun_vec_norm[2, :]))
+
+    return times, vals
+
+
+def calc_pitch_roll_obc(start, stop, pitch_roll):
+    """Use the code in the PCAD derived parameter classes to get the pitch and off
+    nominal roll from OBC quaternion data."""
+    from .pcad import DP_PITCH, DP_ROLL
+
+    dp = DP_PITCH() if pitch_roll == "pitch" else DP_ROLL()
+    tlm = dp.fetch(start, stop)
+    vals = dp.calc(tlm)
+    return tlm.times, vals
+
+
+# Class name is arbitrary, but by convention start with `Comp_`
+class Comp_Pitch_Roll_OBC_Safe(ComputedMsid):
+    """
+    Computed MSID to return pitch or off-nominal roll angle which is valid in NPNT,
+    NMAN, NSUN, and Safe Mode.
+
+    Logic is:
+    - Get logical intervals:
+      - CONLOFP == "NRML":
+        - AOPCADMD in ["NPNT", "NMAN"] => compute pitch/roll from AOATTQT1/2/3/4
+        - AOPCADMD == "NSUN" => get pitch/roll from PITCH/ROLL_CSS derived params.
+          These are also in MAUDE.
+      - CONLOFP == "SAFE":
+        - Compute pitch/roll from PITCH/ROLL_CSS_SAFE via calc_pitch/roll_css_safe()
+      - Intervals for other CONLOFP values are ignored.
+
+    """
+
+    msid_match = r"(roll|pitch)_obc_safe"
+
+    # `msid_match` is a class attribute that defines a regular expresion to
+    # match for this computed MSID.  This must be defined and it must be
+    # unambiguous (not matching an existing MSID or other computed MSID).
+    #
+    # The two groups in parentheses specify the arguments <MSID> and <offset>.
+    # These are passed to `get_msid_attrs` as msid_args[0] and msid_args[1].
+    # The \w symbol means to match a-z, A-Z, 0-9 and underscore (_).
+    # The \d symbol means to match digits 0-9.
+
+    def get_msid_attrs(self, tstart, tstop, msid, msid_args):
+        """
+        Get attributes for computed MSID: ``vals``, ``bads``, ``times``,
+        ``unit``, ``raw_vals``, and ``offset``.  The first four must always
+        be provided.
+
+        :param tstart: start time (CXC secs)
+        :param tstop: stop time (CXC secs)
+        :param msid: full MSID name e.g. tephin_plus_5
+        :param msid_args: tuple of regex match groups (msid_name,)
+        :returns: dict of MSID attributes
+        """
+        from kadi.commands.utils import get_ofp_states
+
+        from .. import fetch
+        from ..utils import logical_intervals
+
+        start = CxoTime(tstart)
+        stop = CxoTime(tstop)
+
+        # Whether we are computing "pitch" or "roll", parsed from MSID name
+        pitch_roll: str = msid_args[0]
+
+        ofp_states = get_ofp_states(stop, days=(stop - start).jd)
+
+        tlms = []
+        for ofp_state in ofp_states:
+            if ofp_state["val"] == "NRML":
+                dat = fetch.Msid("aopcadmd", ofp_state["tstart"], ofp_state["tstop"])
+
+                # Get states of either NPNT / NMAN or NSUN
+                vals = np.isin(dat.vals, ["NPNT", "NMAN"])
+                states_npnt_nman = logical_intervals(
+                    dat.times, vals, complete_intervals=False
+                )
+                states_npnt_nman["val"] = np.repeat("NPNT_NMAN", len(states_npnt_nman))
+                # Require at least 10 minutes => 2 samples of the ephem data. This is
+                # needed for the built-in derived parameter calculation to work.
+                ok = states_npnt_nman["duration"] > 10 * 60 + 1
+                states_npnt_nman = states_npnt_nman[ok]
+
+                states_nsun = logical_intervals(dat.times, dat.vals == "NSUN")
+                states_nsun["val"] = np.repeat("NSUN", len(states_nsun))
+                states = tbl.vstack([states_npnt_nman, states_nsun])
+                states.sort("tstart")
+
+                for state in states:
+                    if state["val"] == "NPNT_NMAN":
+                        tlm = calc_pitch_roll_obc(
+                            state["tstart"], state["tstop"], pitch_roll
+                        )
+                        tlms.append(tlm)
+                    elif state["val"] == "NSUN":
+                        tlm = fetch.Msid(
+                            f"{pitch_roll}_css", state["tstart"], state["tstop"]
+                        )
+                        tlms.append((tlm.times, tlm.vals))
+
+            elif ofp_state["val"] == "SAFE":
+                calc_func = globals()[f"calc_css_{msid_args[0]}_safe"]
+                tlm = calc_func(ofp_state["datestart"], ofp_state["datestop"])
+                tlms.append(tlm)
+
+        times = np.concatenate([tlm[0] for tlm in tlms])
+        vals = np.concatenate([tlm[1] for tlm in tlms])
+
+        # Return a dict with at least `vals`, `times`, `bads`, and `unit`.
+        # Additional attributes are allowed and will be set on the
+        # final MSID object.
+        out = {
+            "vals": vals,
+            "bads": np.zeros(len(vals), dtype=bool),
+            "times": times,
+            "unit": "DEG",
+        }
         return out

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -691,7 +691,7 @@ class Comp_Pitch_Roll_OBC_Safe(ComputedMsid):
                 # Get states of either NPNT / NMAN or NSUN
                 vals = np.isin(dat.vals, ["NPNT", "NMAN"])
                 states_npnt_nman = logical_intervals(
-                    dat.times, vals, complete_intervals=False
+                    dat.times, vals, complete_intervals=False, max_gap=2.1
                 )
                 states_npnt_nman["val"] = np.repeat("NPNT_NMAN", len(states_npnt_nman))
                 # Require at least 10 minutes => 2 samples of the ephem data. This is
@@ -699,7 +699,9 @@ class Comp_Pitch_Roll_OBC_Safe(ComputedMsid):
                 ok = states_npnt_nman["duration"] > 10 * 60 + 1
                 states_npnt_nman = states_npnt_nman[ok]
 
-                states_nsun = logical_intervals(dat.times, dat.vals == "NSUN")
+                states_nsun = logical_intervals(
+                    dat.times, dat.vals == "NSUN", max_gap=2.1, complete_intervals=False
+                )
                 states_nsun["val"] = np.repeat("NSUN", len(states_nsun))
                 states = tbl.vstack([states_npnt_nman, states_nsun])
                 states.sort("tstart")
@@ -717,7 +719,7 @@ class Comp_Pitch_Roll_OBC_Safe(ComputedMsid):
                         tlms.append((tlm.times, tlm.vals))
 
             elif ofp_state["val"] == "SAFE":
-                calc_func = globals()[f"calc_css_{msid_args[0]}_safe"]
+                calc_func = globals()[f"calc_css_{pitch_roll}_safe"]
                 tlm = calc_func(ofp_state["datestart"], ofp_state["datestop"])
                 tlms.append(tlm)
 

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -681,7 +681,7 @@ class Comp_Pitch_Roll_OBC_Safe(ComputedMsid):
         # Whether we are computing "pitch" or "roll", parsed from MSID name
         pitch_roll: str = msid_args[0]
 
-        ofp_states = get_ofp_states(stop, days=(stop - start).jd)
+        ofp_states = get_ofp_states(stop.date, days=(stop - start).jd)
 
         tlms = []
         for ofp_state in ofp_states:

--- a/Ska/engarchive/derived/comps.py
+++ b/Ska/engarchive/derived/comps.py
@@ -647,7 +647,7 @@ class Comp_Pitch_Roll_OBC_Safe(ComputedMsid):
 
     """
 
-    msid_match = r"(roll|pitch)_obc_safe"
+    msid_match = r"(roll|pitch)_comp"
 
     # `msid_match` is a class attribute that defines a regular expresion to
     # match for this computed MSID.  This must be defined and it must be

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -2296,6 +2296,10 @@ def create_msid_data_gap(msid_obj: MSID, data_gap_spec: str):
     if msid_matches_data_gap_spec(msid_obj.MSID, args.include, args.exclude):
         tstart = as_abs_time(args.start)
         tstop = as_abs_time(args.stop)
+        logger.info(
+            f"Creating data gap for {msid_obj.MSID} "
+            f"from {CxoTime(tstart).date} to {CxoTime(tstop).date}"
+        )
         i0, i1 = np.searchsorted(msid_obj.times, [tstart, tstop])
         for attr in msid_obj.colnames:
             val = getattr(msid_obj, attr)

--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -577,6 +577,9 @@ class MSID(object):
         if filter_bad:
             self.filter_bad()
 
+        if "CHETA_FETCH_DATA_GAP" in os.environ:
+            create_msid_data_gap(self, os.environ["CHETA_FETCH_DATA_GAP"])
+
     def __len__(self):
         return len(self.vals)
 
@@ -2189,3 +2192,113 @@ def _plural(x):
     known small set of cases within fetch where it will get applied.
     """
     return x + "es" if (x.endswith("x") or x.endswith("s")) else x + "s"
+
+
+def get_data_gap_spec_parser():
+    """
+    Get parser for fetch data gap specification.
+
+    This env var is in the form of a command line argument string with the following
+    command line options::
+
+        --include INCLUDE  Include MSIDs matching glob (default="*", can be repeated)
+        --exclude EXCLUDE  Exclude MSIDs matching glob (default=None, can be repeated)
+        --start START      Gap start (relative seconds or abs time)
+        --stop STOP        Gap stop (relative seconds or abs time)
+
+    For example::
+
+        "--exclude=*EPHEM* --start=-25000 --stop=-2000"
+
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--include",
+        default=[],
+        action="append",
+        help="Include MSIDs matching glob (default='*', can be repeated)",
+    )
+    parser.add_argument(
+        "--exclude",
+        default=[],
+        action="append",
+        help="Exclude MSIDs matching glob (default=None, can be repeated)",
+    )
+    parser.add_argument(
+        "--start", default=-30000, help="Gap start (relative seconds or abs time)"
+    )
+    parser.add_argument(
+        "--stop", default=-3000, help="Gap stop (relative seconds or abs time)"
+    )
+    return parser
+
+
+def msid_matches_data_gap_spec(msid, includes, excludes):
+    from fnmatch import fnmatch
+
+    msid = msid.upper()
+    includes = includes or ["*"]
+    match = any(fnmatch(msid, include.upper()) for include in includes) and not any(
+        fnmatch(msid, exclude.upper()) for exclude in excludes
+    )
+    return match
+
+
+def create_msid_data_gap(msid_obj: MSID, data_gap_spec: str):
+    """
+    Make a data gap in the ``msid_obj`` (in-place) by removing data points.
+
+    This is mostly useful for testing via setting the ``CHETA_FETCH_DATA_GAP``
+    environment variable.
+
+    The ``data_gap_spec`` string corresponds to a command line argument string with the
+    following options::
+
+        --include INCLUDE  Include MSIDs matching glob (default="*", can be repeated)
+        --exclude EXCLUDE  Exclude MSIDs matching glob (default=None, can be repeated)
+        --start START      Gap start (relative seconds or abs time)
+        --stop STOP        Gap stop (relative seconds or abs time)
+
+    For example::
+
+        >>> dat1 = fetch.MSID('aopcadmd', '2010:001', '2010:002')
+        >>> fetch.create_msid_data_gap(dat1, "--start=-25000 --stop=-2000")
+
+        >>> dat2 = fetch.MSID('aopcadmd', '2010:001', '2010:002')
+        >>> gap_spec = "--start=-2010:001:12:00:00 --stop=2010:001:12:30:00"
+        >>> fetch.create_msid_data_gap(dat2, gap_spec)
+
+
+    :param msid_obj: MSID object
+    :param data_gap_spec: data gap specification
+    """
+    import shlex
+    from typing import Union
+
+    from cxotime import CxoTime
+
+    def as_abs_time(delta_time_or_date: Union[float, str]) -> float:
+        """Convert a relative time (from MSID stop time) or absolute date to an
+        absolute time (CXC secs)."""
+        try:
+            dt = float(delta_time_or_date)
+        except Exception:
+            abs_time = CxoTime(delta_time_or_date).secs
+        else:
+            abs_time = msid_obj.tstop + dt
+        return abs_time
+
+    parser = get_data_gap_spec_parser()
+    args = parser.parse_args(shlex.split(data_gap_spec))
+
+    if msid_matches_data_gap_spec(msid_obj.MSID, args.include, args.exclude):
+        tstart = as_abs_time(args.start)
+        tstop = as_abs_time(args.stop)
+        i0, i1 = np.searchsorted(msid_obj.times, [tstart, tstop])
+        for attr in msid_obj.colnames:
+            val = getattr(msid_obj, attr)
+            if val is not None:
+                val = np.concatenate([val[:i0], val[i1:]])
+                setattr(msid_obj, attr, val)

--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -299,3 +299,56 @@ def test_roll_comp():
     )
     # fmt: on
     assert np.allclose(dat.vals, exp, rtol=0, atol=2e-2)
+
+
+def test_dp_pitch_css():
+    """Test dp_roll_css_derived during a time with NPNT, NMAN, NSUN"""
+    from cheta.derived import pcad
+
+    start = "2022:292"
+    stop = "2022:294"
+    dp = pcad.DP_PITCH_CSS()
+    tlm = dp.fetch(start, stop)
+    vals = dp.calc(tlm)
+    vals = np.round(vals[::1000], 4)
+    # fmt: off
+    exp = np.array(
+        [
+           125.1838, 125.1838, 125.1811, 125.2076,  47.6423,  48.248 ,  # noqa
+           100.2035, 100.0847, 112.813 , 171.7346, 171.697 ,  52.9446,  # noqa
+            48.1135,  50.0441, 167.0614, 167.0853, 167.0853, 167.1091,  # noqa
+            61.0159,  61.0188,  60.9992,  61.0245, 150.7093, 167.196 ,  # noqa
+           167.2436, 167.2436, 148.7973,  61.0963,  61.1217,  61.0996,  # noqa
+            61.1278,  92.0449, 167.3727, 167.4203, 167.8648, 171.0578,  # noqa
+            90.8391,  90.122 ,  90.0533,  90.122 ,  90.0744,  90.0506,  # noqa
+            90.0506  # noqa
+        ]
+    )
+    # fmt: on
+    assert np.allclose(vals, exp, rtol=0, atol=2e-4)
+
+
+def test_dp_roll_css():
+    """Test dp_roll_css_derived during a time with NPNT, NMAN, NSUN"""
+    from cheta.derived import pcad
+
+    start = "2022:292"
+    stop = "2022:294"
+    dp = pcad.DP_ROLL_CSS()
+    tlm = dp.fetch(start, stop)
+    vals = dp.calc(tlm)
+    vals = np.round(vals[::1000], 4)
+    # fmt: off
+    exp = np.array(
+        [
+            -0.1177, -0.1177, -0.0841, -0.1009, -0.1116, -0.1474, -0.0838,  # noqa
+             1.5221, -0.7457, -1.9128, -1.2376, -0.1206, -0.1477, -0.1614,  # noqa
+            -0.2456, -0.1845, -0.1845, -0.    ,  4.0894,  4.1838,  4.2319,  # noqa
+             4.2781,  3.4863,  0.1241,  0.1245,  0.1245,  3.9834,  4.5902,  # noqa
+             4.6363,  4.6845,  4.7305,  6.936 ,  0.6917,  0.6943, -0.1962,  # noqa
+            -0.6191, -0.1237, -0.0962, -0.0825, -0.0962, -0.0962, -0.0825,  # noqa
+            -0.0825  # noqa
+        ]
+    )
+    # fmt: on
+    assert np.allclose(vals, exp, rtol=0, atol=2e-4)

--- a/Ska/engarchive/tests/test_comps.py
+++ b/Ska/engarchive/tests/test_comps.py
@@ -260,3 +260,42 @@ def test_quat_comp_exception(msid):
     with pytest.raises(ValueError, match=f"quat_{msid} is not available from MAUDE"):
         with fetch_eng.data_source("maude"):
             fetch_eng.MSID(f"quat_{msid}", start, stop)
+
+
+def test_pitch_comp():
+    """Test pitch_comp during a time with NPNT, NMAN, NSUN and Safe Sun"""
+    start = "2022:293"
+    stop = "2022:297"
+    dat = fetch_eng.Msid("pitch_comp", start, stop)
+    dat.interpolate(dt=10000)
+    # fmt: off
+    exp = np.array(
+        [
+            60.8, 167.26, 159.54, 60.84, 60.86, 167.38, 144., 90.1 ,
+            90.12, 90.12, 90.05, 90.12, 90.1 , 90.1 , 90.12, 90.09,
+            90.07, 90.14, 90.02, 90.04, 90.02, 90.02, 90.02, 90.02,
+            90.15, 90.23, 90.18, 90.18, 90.18, 90.21, 90.21, 90.21,
+            90.21, 89.94, 153.9
+        ]
+    )
+    # fmt: on
+    assert np.allclose(dat.vals, exp, rtol=0, atol=2e-2)
+
+
+def test_roll_comp():
+    """Test roll_comp during a time with NPNT, NMAN, NSUN and Safe Sun"""
+    start = "2022:293"
+    stop = "2022:297"
+    dat = fetch_eng.Msid("roll_comp", start, stop)
+    dat.interpolate(dt=10000)
+    # fmt: off
+    exp = np.array(
+        [
+            7.32, 4.61, 7.51, 7.7, 7.84, 6.61, 0.02, -0.08, -0.1, -0.1, -0.08, -0.1,
+            -0.11, -0.11, -0.1, -0.41, -0.37, -0.41, -0.19, -0.32, -0.32, -0.34, -0.34,
+            -0.34, -0.08, -0.1, -0.07, -0.04, -0.1, -0.08, -0.08, -0.08, -0.08, 0.03,
+            0.11
+        ]
+    )
+    # fmt: on
+    assert np.allclose(dat.vals, exp, rtol=0, atol=2e-2)

--- a/docs/fetch.rst
+++ b/docs/fetch.rst
@@ -4,7 +4,7 @@
 Fetch API documentation
 ====================================
 
-.. automodule:: Ska.engarchive.fetch
+.. automodule:: cheta.fetch
 
 Classes
 --------

--- a/docs/fetch.rst
+++ b/docs/fetch.rst
@@ -26,6 +26,8 @@ Classes
 
 Functions
 -----------
+.. autofunction:: create_msid_data_gap
+
 .. autofunction:: get_telem
 
 .. autofunction:: get_time_range

--- a/docs/fetch_tutorial.rst
+++ b/docs/fetch_tutorial.rst
@@ -1,15 +1,15 @@
 :tocdepth: 3
 
-.. |fetch_MSID| replace:: :func:`~Ska.engarchive.fetch.MSID`
-.. |fetch_MSIDset| replace:: :func:`~Ska.engarchive.fetch.MSIDset`
-.. |fetch_MSIDset_interpolate| replace:: :func:`~Ska.engarchive.fetch.MSIDset.interpolate`
-.. |get_telem| replace:: :func:`~Ska.engarchive.fetch.get_telem`
+.. |fetch_MSID| replace:: :func:`~cheta.fetch.MSID`
+.. |fetch_MSIDset| replace:: :func:`~cheta.fetch.MSIDset`
+.. |fetch_MSIDset_interpolate| replace:: :func:`~cheta.fetch.MSIDset.interpolate`
+.. |get_telem| replace:: :func:`~cheta.fetch.get_telem`
 
 ================================
 Fetch Tutorial
 ================================
 
-The python module ``Ska.engarchive.fetch`` provides a simple interface to the
+The python module ``cheta.fetch`` provides a simple interface to the
 engineering archive data files.  Using the module functions it is easy to
 retrieve data over a time range for a single MSID or a related set of MSIDs.
 The data are return as MSID objects that contain not only the telemetry timestamps
@@ -23,10 +23,10 @@ Getting started
 The basic process of fetching data always starts with importing the module
 into the python session::
 
-  import Ska.engarchive.fetch as fetch
+  import cheta.fetch as fetch
 
 The ``as fetch`` part of the ``import`` statement just creates an short alias
-to avoid always typing the somewhat lengthy ``Ska.engarchive.fetch.MSID(..)``.
+to avoid always typing the somewhat lengthy ``cheta.fetch.MSID(..)``.
 Fetching and plotting full time-resolution data for a single MSID is then quite
 easy::
 
@@ -86,7 +86,7 @@ listings of available MSIDs.
 **Other details**
 
 If you are wondering what time range of data is available for a particular MSID
-use the :func:`~Ska.engarchive.fetch.get_time_range` function::
+use the :func:`~cheta.fetch.get_time_range` function::
 
   fetch.get_time_range('tephin', format='date')
   ('1999:365:22:40:33.076', '2013:276:12:04:39.361')
@@ -173,7 +173,7 @@ function of the ``Ska.Matplotlib`` module::
   plot_cxctime(tephin.times, tephin.vals)
 
 An even simpler way to make the same plot is with the
-:func:`~Ska.engarchive.fetch.MSID.plot` function::
+:func:`~cheta.fetch.MSID.plot` function::
 
   tephin.plot()
 
@@ -183,7 +183,7 @@ That looks better:
 
 .. tip::
 
-   The :func:`~Ska.engarchive.fetch.MSID.plot` method accepts any arguments
+   The :func:`~cheta.fetch.MSID.plot` method accepts any arguments
    work with the Matplotlib `plot_date()
    <http://matplotlib.sourceforge.net/api/pyplot_api.html#matplotlib.pyplot.plot_date>`_
    function
@@ -191,7 +191,7 @@ That looks better:
 Interactive plotting
 =====================
 
-The :func:`~Ska.engarchive.fetch.MSID.iplot` function is a handy way to quickly
+The :func:`~cheta.fetch.MSID.iplot` function is a handy way to quickly
 explore MSID data over a wide range of time scales, from seconds to the entire
 mission in a few key presses.  The function automatically fetches data from
 the archive as needed.
@@ -219,8 +219,8 @@ Example::
   dat = fetch.Msid('aoattqt1', '2011:001', '2012:001', stat='5min')
   dat.iplot()
 
-The :func:`~Ska.engarchive.fetch.MSID.iplot` and
-:func:`~Ska.engarchive.fetch.MSID.plot` functions support plotting
+The :func:`~cheta.fetch.MSID.iplot` and
+:func:`~cheta.fetch.MSID.plot` functions support plotting
 state-valued MSIDs such as ``AOPCADMD`` or ``AOUNLOAD``::
 
   dat = fetch.Msid('aopcadmd', '2011:185', '2011:195')
@@ -231,10 +231,10 @@ state-valued MSIDs such as ``AOPCADMD`` or ``AOUNLOAD``::
 
 .. Note::
 
-   The :func:`~Ska.engarchive.fetch.MSID.iplot` method is not meant for use
+   The :func:`~cheta.fetch.MSID.iplot` method is not meant for use
    within scripts, and may give unexpected results if used in combination with
    other plotting commands directed at the same plot figure.  Instead one
-   should use the MSID :func:`~Ska.engarchive.fetch.MSID.plot` method in this
+   should use the MSID :func:`~cheta.fetch.MSID.plot` method in this
    case.
 
 
@@ -260,8 +260,8 @@ unreliable.
 Using Kadi
 ^^^^^^^^^^^
 
-Frequently one can handle this with the :func:`~Ska.engarchive.fetch.MSID.remove_intervals`
-:func:`~Ska.engarchive.fetch.MSID.select_intervals` methods in conjunction with the `kadi event
+Frequently one can handle this with the :func:`~cheta.fetch.MSID.remove_intervals`
+:func:`~cheta.fetch.MSID.select_intervals` methods in conjunction with the `kadi event
 intervals <http://cxc.cfa.harvard.edu/mta/ASPECT/tool_doc/kadi/#event-intervals>`_
 mechanism.
 
@@ -278,7 +278,7 @@ highlights the large rates during maneuvers::
 
 .. plot::
 
-   from Ska.engarchive import fetch
+   from cheta import fetch
    import matplotlib.pyplot as plt
    plt.figure(figsize=(6, 4), dpi=75)
 
@@ -290,7 +290,7 @@ highlights the large rates during maneuvers::
    aorate2.plot('.r')
    plt.tight_layout()
 
-The following code illustrates use of the :func:`~Ska.engarchive.fetch.MSID.remove_intervals`
+The following code illustrates use of the :func:`~cheta.fetch.MSID.remove_intervals`
 method to select all all time intervals when the spacecraft is *not* maneuvering.  In this
 case we include a pad time of 600 seconds before the start of a maneuver and 300 seconds
 after the end of each maneuver.
@@ -302,7 +302,7 @@ after the end of each maneuver.
 
 .. plot::
 
-   from Ska.engarchive import fetch
+   from cheta import fetch
    import matplotlib.pyplot as plt
    from kadi import events
 
@@ -319,15 +319,15 @@ Using logical intervals
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 For cases where the intervals to be filtered cannot be expressed as Kadi events,
-the approach is to use the :func:`~Ska.engarchive.utils.logical_intervals` function
-located in the ``Ska.engarchive.utils`` module.  This function creates an intervals
+the approach is to use the :func:`~cheta.utils.logical_intervals` function
+located in the ``cheta.utils`` module.  This function creates an intervals
 table where each row represents a desired interval and includes a ``datestart`` and
 ``datestop`` column.
 
 For example to extract solar array temperatures when the off-nominal roll
 angle is between 5 and 10 degrees you would do::
 
-  >>> from Ska.engarchive.utils import logical_intervals
+  >>> from cheta.utils import logical_intervals
 
   >>> sa_temps = fetch.Msid('TSAPYT','2010:001',stat='5min')
   >>> roll = fetch.Msid('ROLL','2010:001',stat='5min')
@@ -342,8 +342,8 @@ angle is between 5 and 10 degrees you would do::
 
 .. plot::
 
-   from Ska.engarchive import fetch_eng as fetch
-   from Ska.engarchive.utils import logical_intervals
+   from cheta import fetch_eng as fetch
+   from cheta.utils import logical_intervals
    import matplotlib.pyplot as plt
    sa_temps = fetch.Msid('TSAPYT','2010:001',stat='5min')
    roll = fetch.Msid('ROLL','2010:001',stat='5min')
@@ -361,8 +361,8 @@ Notice that we created a new version of the solar array temperatures MSID object
 ``sa_temps_off_nom`` (using ``copy=True``) instead of filtering in place.  Sometimes it is
 convenient to have both the original and filtered data, e.g. when you want to plot both.
 
-Note also that :func:`~Ska.engarchive.fetch.MSID.remove_intervals`
-:func:`~Ska.engarchive.fetch.MSID.select_intervals` will accept *any* table
+Note also that :func:`~cheta.fetch.MSID.remove_intervals`
+:func:`~cheta.fetch.MSID.select_intervals` will accept *any* table
 with columns ``datestart`` / ``datestop`` or ``tstart`` / ``tstop`` as input.
 
 Fetching only small intervals
@@ -376,7 +376,7 @@ and then selecting intervals is prohibitively expensive in memory and time.
 
 There is a different mechanism that can work in these situations.  The ``start``
 argument to a ``fetch.MSID`` or ``fetch.MSIDset`` query can be an interval
-specifier.  This might be the output of :func:`~Ska.engarchive.utils.logical_intervals`
+specifier.  This might be the output of :func:`~cheta.utils.logical_intervals`
 or it might just be a list of ``(start, stop)`` tuples.  If that is the
 case then fetch will iterate through those start / stop pairs, do the
 fetch individually, and then stitch the whole thing back together into
@@ -842,14 +842,14 @@ The simplest way to select a different unit system is to alter the
 canonical command for importing the ``fetch`` module.  To always use OCC
 engineering units use the following command::
 
-  from Ska.engarchive import fetch_eng as fetch
+  from cheta import fetch_eng as fetch
 
 This uses a special Python syntax to import the ``fetch_eng`` module
 but then refer to it as ``fetch``.  In this way there is no need to
 change existing codes (except one line) or habits.  To always use "science"
 units use the command::
 
-  from Ska.engarchive import fetch_sci as fetch
+  from cheta import fetch_sci as fetch
 
 Mixing units
 ---------------
@@ -860,9 +860,9 @@ same script or Python process.
 
 Example::
 
-  import Ska.engarchive.fetch as fetch_cxc  # CXC units
-  import Ska.engarchive.fetch_eng as fetch_eng
-  import Ska.engarchive.fetch_sci as fetch_sci
+  import cheta.fetch as fetch_cxc  # CXC units
+  import cheta.fetch_eng as fetch_eng
+  import cheta.fetch_sci as fetch_sci
 
   t1 = fetch_cxc.MSID('tephin', '2010:001', '2010:002')
   print t1.unit  # prints "K"
@@ -898,7 +898,7 @@ choose a few related MSIDs::
 
     dat = fetch.MSIDset(['orb*1*_[xyz]', 'aoattqt*'], ...)
 
-The :func:`~Ska.engarchive.fetch.msid_glob()` method will show you exactly what
+The :func:`~cheta.fetch.msid_glob()` method will show you exactly what
 matches a given ``msid``::
 
     >>> fetch.msid_glob('orb*1*_?')
@@ -976,7 +976,7 @@ the duty cycle for an ON/OFF bi-level for mission trending::
 .. image:: fetchplots/state_bins_4ohtrz10.png
 
 .. # Could use a plot directive here
-   from Ska.engarchive import fetch
+   from cheta import fetch
    from Ska.Matplotlib import plot_cxctime
    import matplotlib.pyplot as plt
    plt.figure(figsize=(6, 4), dpi=75)
@@ -1253,7 +1253,7 @@ to tell it to order by memory usage.  Now go back to your main window and get
 all the ``TEIO`` data for the mission::
 
   ipython --matplotlib
-  import Ska.engarchive.fetch as fetch
+  import cheta.fetch as fetch
   import matplotlib.pyplot as plt
   from Ska.Matplotlib import plot_cxctime
   time teio = fetch.MSID('teio', '2000:001', '2010:001', filter_bad=True)
@@ -1314,7 +1314,7 @@ Estimating fetch size
 -----------------------
 
 You can do a better than the above rules of thumb using the
-:func:`~Ska.engarchive.utils.get_fetch_size` function in the ``Ska.engarchive.utils``
+:func:`~cheta.utils.get_fetch_size` function in the ``cheta.utils``
 module to estimate the size of a fetch request prior to making the call.  This is
 especially useful for applications that want to avoid unreasonably large data requests.
 
@@ -1322,7 +1322,7 @@ As an example, compute the estimated size in Megabytes for fetching full-resolut
 for TEPHIN and AOPCADMD for a period of 3 years, both of which are then interpolated at a
 time sampling of 32.8 seconds::
 
-  >>> from Ska.engarchive.utils import get_fetch_size
+  >>> from cheta.utils import get_fetch_size
   >>> get_fetch_size(['TEPHIN', 'AOPCADMD'], '2011:001', '2014:001', interpolate_dt=32.8)
   (1248.19, 75.06)
 
@@ -1386,7 +1386,7 @@ Example::
 
   % ska
   % ipython --pylab
-  >>> from Ska.engarchive.fetch import get_telem
+  >>> from cheta.fetch import get_telem
   >>> dat = get_telem(['tephin', 'tcylaft6'], '2010:001', '2010:030', sampling='5min')
   >>> clf()
   >>> dat['tephin'].plot(label='TEPHIN', color='r')
@@ -1494,7 +1494,7 @@ As a final example here is a real-world problem of wanting to compare OBC
 rates to those derived on the ground using raw gyro data.
 ::
 
-  import Ska.engarchive.fetch as fetch
+  import cheta.fetch as fetch
   from Ska.Matplotlib import plot_cxctime
   import Ska.Numpy
 

--- a/docs/ipython_tutorial.rst
+++ b/docs/ipython_tutorial.rst
@@ -87,7 +87,7 @@ For a more concrete example, say you want to fetch some daily telemetry values
 but forgot exactly how to do the query and what are the available columns.  Use
 help and TAB completion to remind yourself::
 
-  import Ska.engarchive.fetch as fetch
+  import cheta.fetch as fetch
   help fetch
   tephin = fetch.MSID('tephin', '2009:001', '2009:002', stat='daily')
   tephin.<TAB>

--- a/docs/plot.rst
+++ b/docs/plot.rst
@@ -4,10 +4,10 @@
 Plotting API documentation
 =============================
 
-.. automodule:: Ska.engarchive.plot
+.. automodule:: cheta.plot
 
 Classes
 -----------
-.. autoclass:: Ska.engarchive.plot.MsidPlot
+.. autoclass:: cheta.plot.MsidPlot
    :show-inheritance:
    :members:

--- a/docs/pseudo_msids.rst
+++ b/docs/pseudo_msids.rst
@@ -151,7 +151,7 @@ The first two of these are detected by looking at "spare" bits in the MSID ``SCI
 ``HRC_SS_HK_BAD`` contain a copy of the 7 bits in ``SCIDPREN`` which must be 0 for good
 data.  The following code illustrates detecting conditions (1) or (2)::
 
-  >>> from Ska.engarchive import fetch
+  >>> from cheta import fetch
   >>> from Chandra.Time import DateTime
   >>> dat = fetch.Msid('HRC_SS_HK_BAD', '1999:300', '1999:310')
   >>> bad = (dat.vals & 0x7f) > 0
@@ -180,7 +180,7 @@ stat data as well.  For instance::
 
 .. plot::
 
-   from Ska.engarchive import fetch
+   from cheta import fetch
    import matplotlib.pyplot as plt
    plt.figure(figsize=(6, 4), dpi=75)
    dat = fetch.Msid('2S2ONST', '2002:200', '2002:250', stat='5min')
@@ -199,7 +199,7 @@ instance to get 5-minute telemetry for ``2SHEV1RT`` use::
 
 .. plot::
 
-   from Ska.engarchive import fetch
+   from cheta import fetch
    import matplotlib.pyplot as plt
    plt.figure(figsize=(6, 4), dpi=75)
    dat = fetch.HrcSsMsid('2SHEV1RT', '2002:200', '2002:250', stat='5min')
@@ -655,29 +655,29 @@ sequence with step size ``time_step``.
 
 ACIS Power
 ^^^^^^^^^^^
-.. automodule:: Ska.engarchive.derived.acispow
+.. automodule:: cheta.derived.acispow
    :members:
 
 EPS
 ^^^^^^^^^^^^^^^^^
-.. automodule:: Ska.engarchive.derived.eps
+.. automodule:: cheta.derived.eps
    :members:
    :undoc-members:
 
 Orbital elements
 ^^^^^^^^^^^^^^^^^
-.. automodule:: Ska.engarchive.derived.orbit
+.. automodule:: cheta.derived.orbit
    :members:
    :undoc-members:
 
 PCAD
 ^^^^^
-.. automodule:: Ska.engarchive.derived.pcad
+.. automodule:: cheta.derived.pcad
    :members:
 
 Thermal
 ^^^^^^^^^
-.. automodule:: Ska.engarchive.derived.thermal
+.. automodule:: cheta.derived.thermal
    :members:
    :undoc-members:
 
@@ -692,6 +692,9 @@ Cheta provides support for on-the-fly computed MSIDs with the following features
 * Computed MSIDs can included embedded parameters to allow further customization
   or application of a function to any other MSID.
 * Support for 5-minute and daily stats also included.
+
+See the `Built-in computed MSIDs and API`_ section for a list of the available
+computed MSIDs.
 
 See the `DAWG computed MSIDs notebook
 <https://nbviewer.jupyter.org/urls/cxc.harvard.edu/mta/ASPECT/ipynb/misc/DAWG-cheta-computed-msids.ipynb>`_
@@ -787,7 +790,7 @@ in the user-requested system.  In other words, if the user did a call
 In some cases the unit handling may require additional specification. This
 can happen if the computation needs to be done in a particular unit, as is
 the case for the built-in
-:class:`~Ska.engarchive.derived.comps.Comp_MUPS_Valve_Temp_Clean` class.
+:class:`~cheta.derived.comps.Comp_MUPS_Valve_Temp_Clean` class.
 Here the class must define an additional ``units`` attribute with the
 following structure::
 
@@ -805,11 +808,10 @@ following structure::
     }
 
 The specified units must all be convertable using functions defined in the
-``converters`` dict in the ``Ska.engarchive.units`` module.
+``converters`` dict in the ``cheta.units`` module.
 
 Built-in computed MSIDs and API
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  .. automodule:: Ska.engarchive.derived.comps
-   :members:
-   :undoc-members:
+  .. automodule:: cheta.derived.comps
+    :members:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -58,7 +58,7 @@ You should see something that looks like::
 
 Now read some data and make a simple plot by copying the following lines in ``ipython``::
 
-  import Ska.engarchive.fetch as fetch
+  import cheta.fetch as fetch
   import matplotlib.pyplot as plt
   tephin = fetch.MSID('tephin', '2009:001', '2009:002')
   plt.plot(tephin.times, tephin.vals)
@@ -72,12 +72,12 @@ Tools overview
 There are four key elements that are the basis for doing plotting and analysis
 with the engineering archive.
 
-* Ska.engarchive.fetch: module to read and manipulate telemetry data
+* cheta.fetch: module to read and manipulate telemetry data
 * `IPython`_: interactive python interpreter
 * `matplotlib`_: python plotting package with an interface similar to Matlab
 * `NumPy`_: python numerical package for fast vector and array math
 
-Ska.engarchive.fetch
+cheta.fetch
 ~~~~~~~~~~~~~~~~~~~~~~
 The tools to access and manipulate telemetry with the Ska engineering archive
 are described in the :doc:`fetch_tutorial`.

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -4,5 +4,5 @@
 Utilities API documentation
 ================================================
 
-.. automodule:: Ska.engarchive.utils
+.. automodule:: cheta.utils
    :members:


### PR DESCRIPTION
## Description

This is a new computed MSID to return the Sun pitch angle or off-nominal roll angle which is valid in NPNT, NMAN, NSUN, and Safe Mode. This new computed MSID also works with `MAUDE` as the back-end telemetry server (unlike e.g.  `dp_pitch/roll`).

Current available MSIDs are limited in scope. For instance `dp_pitch` is only good for `NPNT` or `NMAN` when PCAD processing is maintaining `AOATTQT1-4` accurately. Querying `dp_pitch` in other modes will return a value that is wrong.

The logic is:
- Get logical intervals for the online flight program (OFP) state:
  - CONLOFP == "NRML":
    - AOPCADMD in ["NPNT", "NMAN"] => compute pitch/roll from AOATTQT1/2/3/4 and ephemeris
    - AOPCADMD == "NSUN" => get pitch/roll from PITCH/ROLL_CSS derived params. These are also in MAUDE.
  - CONLOFP == "SAFE":
    - Compute pitch/roll from PITCH/ROLL_CSS_SAFE via `calc_pitch/roll_css_safe()`. Basically the same as the OBC NSUN computation but using solar array and CSS sun angle values available in safe mode.
  - Intervals for other CONLOFP values are ignored.

### Additional changes

A couple more things crept into this PR for convenience:

- Functionality to introduce a data gap in the returned result (547173d)
- Change `Ska.engarchive` to `cheta` in all the RST files (ac6d377)

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds new MSIDs `pitch_comp` and `roll_comp`.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Used in https://github.com/sot/kadi/pull/261.
