### PR TITLE
Change logical_intervals() default complete_intervals from True to False

### DIFF
--- a/Ska/engarchive/fetch.py
+++ b/Ska/engarchive/fetch.py
@@ -1331,16 +1331,16 @@ class MSID(object):
         )
         f.close()
 
-    def logical_intervals(self, op, val, complete_intervals=True, max_gap=None):
+    def logical_intervals(self, op, val, complete_intervals=False, max_gap=None):
         """Determine contiguous intervals during which the logical comparison
         expression "MSID.vals op val" is True.  Allowed values for ``op``
         are::
 
           ==  !=  >  <  >=  <=
 
-        If ``complete_intervals`` is True (default) then the intervals are guaranteed to
-        be complete so that the all reported intervals had a transition before and after
-        within the telemetry interval.
+        If ``complete_intervals`` is True (default is False) then the intervals
+        are guaranteed to be complete so that the all reported intervals had a
+        transition before and after within the telemetry interval.
 
         If ``max_gap`` is specified then any time gaps longer than ``max_gap`` are
         filled with a fictitious False value to create an artificial interval
@@ -1358,10 +1358,10 @@ class MSID(object):
         Examples::
 
           >>> dat = fetch.MSID('aomanend', '2010:001', '2010:005')
-          >>> manvs = dat.logical_intervals('==', 'NEND')
+          >>> manvs = dat.logical_intervals('==', 'NEND', complete_intervals=True)
 
           >>> dat = fetch.MSID('61PSTS02', '1999:200', '2000:001')
-          >>> safe_suns = dat.logical_intervals('==', 'SSM', complete_intervals=False, max_gap=66)
+          >>> safe_suns = dat.logical_intervals('==', 'SSM', max_gap=66)
 
         :param op: logical operator, one of ==  !=  >  <  >=  <=
         :param val: comparison value

--- a/Ska/engarchive/tests/test_intervals.py
+++ b/Ska/engarchive/tests/test_intervals.py
@@ -181,14 +181,14 @@ def test_msid_logical_intervals():
     """
     dat = fetch.Msid("aopcadmd", "2013:001:00:00:00", "2013:001:02:00:00")
 
-    # default complete_intervals=True
-    intervals = dat.logical_intervals("==", "NPNT")
+    intervals = dat.logical_intervals("==", "NPNT", complete_intervals=True)
     assert len(intervals) == 1
     assert np.all(intervals["datestart"] == ["2013:001:01:03:37.032"])
     assert np.all(intervals["datestop"] == ["2013:001:01:26:13.107"])
 
+    # default complete_intervals=False
     # Now with incomplete intervals on each end
-    intervals = dat.logical_intervals("==", "NPNT", complete_intervals=False)
+    intervals = dat.logical_intervals("==", "NPNT")
     assert len(intervals) == 3
     assert np.all(
         intervals["datestart"]
@@ -230,11 +230,11 @@ def test_util_logical_intervals_gap():
     """
     times = np.array([1, 2, 3, 200, 201, 202])
     bools = np.ones(len(times), dtype=bool)
-    out = utils.logical_intervals(times, bools, complete_intervals=False, max_gap=10)
+    out = utils.logical_intervals(times, bools, max_gap=10)
     assert np.allclose(out["tstart"], [0.5, 197.5])
     assert np.allclose(out["tstop"], [5.5, 202.5])
 
-    out = utils.logical_intervals(times, bools, complete_intervals=False)
+    out = utils.logical_intervals(times, bools)
     assert np.allclose(out["tstart"], [0.5])
     assert np.allclose(out["tstop"], [202.5])
 

--- a/Ska/engarchive/utils.py
+++ b/Ska/engarchive/utils.py
@@ -242,12 +242,12 @@ def _pad_long_gaps(times, bools, max_gap):
     return times, bools
 
 
-def logical_intervals(times, bools, complete_intervals=True, max_gap=None):
+def logical_intervals(times, bools, complete_intervals=False, max_gap=None):
     """Determine contiguous intervals during which `bools` is True.
 
-    If ``complete_intervals`` is True (default) then the intervals are guaranteed to
-    be complete so that the all reported intervals had a transition before and after
-    within the telemetry interval.
+    If ``complete_intervals`` is True (default is False) then the intervals are
+    guaranteed to be complete so that the all reported intervals had a
+    transition before and after within the telemetry interval.
 
     If ``max_gap`` is specified then any time gaps longer than ``max_gap`` are
     filled with a fictitious False value to create an artificial interval
@@ -270,7 +270,7 @@ def logical_intervals(times, bools, complete_intervals=True, max_gap=None):
                     & (dat['aorwbias'].vals == 'DISA')
                     & (dat['coradmen'].vals == 'DISA'))
       >>> scs107s = utils.logical_intervals(dat.times, scs107)
-      >>> print scs107s['datestart', 'datestop', 'duration']
+      >>> print(scs107s['datestart', 'datestop', 'duration'])
             datestart              datestop          duration
       --------------------- --------------------- -------------
       2012:194:20:00:31.652 2012:194:20:04:21.252 229.600000083
@@ -315,9 +315,9 @@ def state_intervals(times, vals):
     Example::
 
       >>> from Ska.engarchive import fetch, utils
-      >>> dat = fetch.Msid('cobsrqid', '2010:003', '2010:004')
+      >>> dat = fetch.Msid('cobsrqid', '2010:003:12:00:00', '2010:004:12:00:00')
       >>> obsids = utils.state_intervals(dat.times, dat.vals)
-      >>> print obsids['datestart', 'datestop', 'val']
+      >>> print(obsids['datestart', 'datestop', 'val'])
             datestart              datestop         val
       --------------------- --------------------- -------
       2010:003:12:00:00.976 2010:004:09:07:44.180 11011.0

--- a/docs/fetch_tutorial.rst
+++ b/docs/fetch_tutorial.rst
@@ -700,7 +700,7 @@ content type as follows::
 
   msids = fetch.MSIDset(['aorate1', 'aorate2', 'aogyrct1', 'aogyrct2'], '2009:001', '2009:002')
   for msid in msids.values():
-      print msid.msid, msid.content
+      print(msid.msid, msid.content)
 
 In this case if we apply the ``filter_bad()`` method then ``aorate1`` and
 ``aorate2`` will be grouped separately from ``aogyrct1`` and ``aogyrct2``.  In
@@ -865,13 +865,13 @@ Example::
   import Ska.engarchive.fetch_sci as fetch_sci
 
   t1 = fetch_cxc.MSID('tephin', '2010:001', '2010:002')
-  print t1.unit  # prints "K"
+  print(t1.unit  # prints "K")
 
   t2 = fetch_eng.MSID('tephin', '2010:001', '2010:002')
-  print t2.unit  # prints "DEGF"
+  print(t2.unit  # prints "DEGF")
 
   t3 = fetch_sci.MSID('tephin', '2010:001', '2010:002')
-  print t3.unit  # prints "DEGC"
+  print(t3.unit  # prints "DEGC")
 
 MSID globs
 =============================


### PR DESCRIPTION
## Description

The utility function `cheta.utils.logical_intervals()` has a poor choice of default with `complete_intervals=True`, with only myself to blame. This means that any `True` intervals that extend to the start or stop of interval are dropped. This behavior is good and necessary in certain situations (like kadi events where you don't want to store partial/incomplete events), but **most** of the time you expect to get all the intervals within the data.

This default setting cost me a couple hours debugging in https://github.com/sot/kadi/pull/261 finding an issue that depended oddly on the start / stop times.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
This changes a default that may impact code. For the most part I would expect that this will fix latent bugs where the code is actually assuming `complete_intervals=False`, but we'll need to advertise this.

### Impacts to code in the `sot` repository.

I have a directory that has a clone of every `sot` repository, and did the following audit to identify a 

```
➜  sot_repos find . -name '*.py' | grep -v "/build/" | grep -v "./eng_archive/Ska" \
   | xargs grep -A 5 "logical_intervals(" | grep -v "/build/"
```
```
# DON'T CARE but OK with complete_intervals=False
./gyro_bias/kalman_threshold/search_scripts/get_low_kalstr.py:    lowkals = dat.logical_intervals('<=', '2 ')
./gyro_bias/kalman_threshold/search_scripts/get_low_kalstr.py-    lowkals = lowkals[lowkals['duration'] < 120]  # too-long intervals are spurious
./gyro_bias/kalman_threshold/search_scripts/get_low_kalstr.py-    bad = lowkals['duration'] > 60
./gyro_bias/kalman_threshold/search_scripts/get_low_kalstr.py-    lowkals = lowkals[bad]
./gyro_bias/kalman_threshold/search_scripts/get_low_kalstr.py-    for interval in lowkals:
./gyro_bias/kalman_threshold/search_scripts/get_low_kalstr.py-        ds = events.dwells.filter(start=interval['tstart'], stop=interval['tstop'])
```
```
# CHANGE: could split an interval in two
./kalman_watch/kalman_watch/low_kalman_mon.py:    lowkals = logical_intervals(
./kalman_watch/kalman_watch/low_kalman_mon.py-        dat["aokalstr"].times,
./kalman_watch/kalman_watch/low_kalman_mon.py-        (dat["aokalstr"].vals.astype(int) <= 1)
./kalman_watch/kalman_watch/low_kalman_mon.py-        & (dat["aoacaseq"].vals == "KALM")
./kalman_watch/kalman_watch/low_kalman_mon.py-        & (dat["aopcadmd"].vals == "NPNT"),
./kalman_watch/kalman_watch/low_kalman_mon.py-        max_gap=10.0,
```
```
# CORRECT with complete_intervals=False (intervals not written to file, incomplete
# intervals should be displayed on plot)
./kalman_watch/kalman_watch/kalman_perigee_mon.py:            ints_low = logical_intervals(self.data["times"], vals <= n_kalstr)
./kalman_watch/kalman_watch/kalman_perigee_mon.py-            ints_low = ints_low[ints_low["duration"] > dur_limit]
./kalman_watch/kalman_watch/kalman_perigee_mon.py-
./kalman_watch/kalman_watch/kalman_perigee_mon.py-            for int_low in ints_low:
./kalman_watch/kalman_watch/kalman_perigee_mon.py-                p0 = int_low["tstart"] - self.perigee.cxcsec
./kalman_watch/kalman_watch/kalman_perigee_mon.py-                p1 = int_low["tstop"] - self.perigee.cxcsec
```
```
# CHANGE: this is important
./kadi/kadi/events/models.py:            states = utils.logical_intervals(times, bools, max_gap=MAX_GAP)
./kadi/kadi/events/models.py-        except (IndexError, ValueError):
./kadi/kadi/events/models.py-            if event_time_fuzz is None:
./kadi/kadi/events/models.py-                logger.warn(
./kadi/kadi/events/models.py-                    "Warning: No telemetry available for {}".format(cls.__name__)
./kadi/kadi/events/models.py-                )
```
```
# DON'T CARE (code being replaced)
./validate_states/validate_states.py:    dith_disa_states = logical_intervals(tlm['date'], tlm['aodithen'] == 'DISA')
./validate_states/validate_states.py-    for state in dith_disa_states:
./validate_states/validate_states.py-        # Index back into telemetry for each of these constant dither disable states
./validate_states/validate_states.py-        idx0 = np.searchsorted(tlm['date'], state['tstart'], side='left')
./validate_states/validate_states.py-        idx1 = np.searchsorted(tlm['date'], state['tstop'], side='right')
./validate_states/validate_states.py-        # If any samples have aca calibration flag, mark interval for exclusion.
```
```
# CORRECT with complete_intervals=False (JEAN?)
./aca_weekly_report/aca_weekly_report/report.py:        intervals = logical_intervals(dat['AOKALSTR'].times,
./aca_weekly_report/aca_weekly_report/report.py-                                      low_kal,
./aca_weekly_report/aca_weekly_report/report.py-                                      max_gap=10)
./aca_weekly_report/aca_weekly_report/report.py-        kalman_data['consec_lt_two'] = np.max(intervals['duration'])
./aca_weekly_report/aca_weekly_report/report.py-    return kalman_data
./aca_weekly_report/aca_weekly_report/report.py-
```
```
# DON'T CARE: Local logical_intervals()
./aca_status_flags/analysis_plots.py:    low = logical_intervals(dat['times'], tlm_n_kalman, '<=', 1)
./aca_status_flags/analysis_plots.py:    low = logical_intervals(dat['times'], pred_n_kalman, '<=', 1)
./aca_status_flags/analysis_plots.py:def logical_intervals(times, vals, op, val):
./aca_status_flags/analysis_plots.py-    """Determine contiguous intervals during which the logical comparison
./aca_status_flags/analysis_plots.py-    expression "MSID.vals op val" is True.  Allowed values for ``op``"""
```
```
# CORRECT with complete_intervals=False
./aca_status_flags/analysis_plots.py:      manvs = dat.logical_intervals('==', 'NEND')
./aca_status_flags/analysis_plots.py-      manvs['duration']
./aca_status_flags/analysis_plots.py-
./aca_status_flags/analysis_plots.py-    :param vals: input values
./aca_status_flags/analysis_plots.py-    :param op: logical operator, one of ==  !=  >  <  >=  <=
./aca_status_flags/analysis_plots.py-    :param val: comparison value
```
```
# DON'T CARE
./safemode_2015264/plot_fish.py:    # ok = logical_intervals(roll.times, np.abs(roll.midvals) < 20.1)
./safemode_2015264/plot_fish.py-    # roll.select_intervals(ok)
./safemode_2015264/plot_fish.py-    # pitch.select_intervals(ok)
./safemode_2015264/plot_fish.py-
./safemode_2015264/plot_fish.py:    off_nom = logical_intervals(roll.times, np.abs(roll.midvals) > 3)
./safemode_2015264/plot_fish.py-    roll_off_nom = roll.select_intervals(off_nom, copy=True)
./safemode_2015264/plot_fish.py-    pitch_off_nom = pitch.select_intervals(off_nom, copy=True)
./safemode_2015264/plot_fish.py-
./safemode_2015264/plot_fish.py-if 'greta' not in globals():
./safemode_2015264/plot_fish.py-    greta = Table.read('greta_values.dat', format='ascii.basic')
```

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
