### PR TITLE
Better missing units handling

### DIFF
--- a/cheta/tests/test_fetch.py
+++ b/cheta/tests/test_fetch.py
@@ -7,7 +7,7 @@ import pytest
 from Chandra.Time import DateTime
 from cxotime import CxoTime
 
-from .. import fetch, fetch_eng
+from .. import fetch, fetch_eng, fetch_sci
 
 print(fetch.__file__)
 
@@ -540,6 +540,38 @@ def test_interpolate_time_precision():
     dt = dat.times[-1] - dat.times[0]
     dt_frac = dt * 100 - round(dt * 100)
     assert abs(dt_frac) < 0.001
+
+
+@pytest.mark.skipif(not HAS_MAUDE, reason="MAUDE server not available")
+def test_2tlev2rt_units_maude():
+    msid = "2TLEV2RT"
+    start = "2026:065:13:39:10"
+    stop = "2026:065:13:40:30"
+
+    with fetch.data_source("MAUDE"):
+        dat_cxc = fetch.Msid(msid, start, stop)
+        assert dat_cxc.unit == "count"
+
+        dat_eng = fetch_eng.Msid(msid, start, stop)
+        assert dat_eng.unit == "HZ"
+
+        dat_sci = fetch_sci.Msid(msid, start, stop)
+        assert dat_sci.unit == "count"
+
+
+def test_2tlev2rt_units():
+    msid = "2TLEV2RT"
+    start = "2026:065:13:39:10"
+    stop = "2026:065:13:40:30"
+
+    dat_cxc = fetch.Msid(msid, start, stop)
+    assert dat_cxc.unit == "count"
+
+    dat_eng = fetch_eng.Msid(msid, start, stop)
+    assert dat_eng.unit == "HZ"
+
+    dat_sci = fetch_sci.Msid(msid, start, stop)
+    assert dat_sci.unit == "count"
 
 
 def _assert_msid_equal(msid1, msid2):

--- a/cheta/units.py
+++ b/cheta/units.py
@@ -315,7 +315,7 @@ class Units(dict):
                     MSID, conversion[0], conversion[1]
                 )
             )
-
-        vals = converters[conversion](vals, delta_val)
+        else:
+            vals = converters[conversion](vals, delta_val)
 
         return vals

--- a/cheta/units.py
+++ b/cheta/units.py
@@ -72,6 +72,7 @@ equiv_units = set(
         ("ASEC", "arcsec"),
         ("DEG", "deg"),
         ("DEGPS", "deg/s"),
+        ("HZ", "count"),  # Strange equivalence but e.g. 2TLEV2RT
         ("KHZ", "kHz"),
         ("KM", "km"),
         ("KMPS", "km/s"),


### PR DESCRIPTION
## Description

This fixes a couple of issues:
- Unknown unit transform between `count` and `HZ`. Although formally these are not equivalent, for `2TLEV2RT` the CXC and MSFC1949 do use those so just make it work.
- Do not raise an exception for an unknown unit transformation, just issue a loud warning. I think this was the intent of the original code.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  cheta git:(better-missing-units-handling) git rev-parse --short HEAD
1098b39
(ska3) ➜  cheta git:(better-missing-units-handling) pytest
================================================== test session starts ==================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 196 items                                                                                                     

cheta/tests/test_comps.py ..............s.......................................................                  [ 35%]
cheta/tests/test_data_source.py ...........                                                                       [ 41%]
cheta/tests/test_fetch.py ..........................................                                              [ 62%]
cheta/tests/test_intervals.py .........................                                                           [ 75%]
cheta/tests/test_orbit.py .                                                                                       [ 76%]
cheta/tests/test_remote_access.py ......                                                                          [ 79%]
cheta/tests/test_sync.py ........                                                                                 [ 83%]
cheta/tests/test_units.py ...........                                                                             [ 88%]
cheta/tests/test_units_reversed.py ...........                                                                    [ 94%]
cheta/tests/test_utils.py ...........                                                                             [100%]

====================================== 195 passed, 1 skipped in 104.00s (0:01:44) =======================================
```

Independent check of unit tests by [REVIEWER NAME]
- [x] OSX
```
(ska3-latest) flame:cheta jean$ pytest
================================================================ test session starts ================================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 196 items                                                                                                                                 

cheta/tests/test_comps.py ..............s.......................................................                                              [ 35%]
cheta/tests/test_data_source.py ...........                                                                                                   [ 41%]
cheta/tests/test_fetch.py ..........................................                                                                          [ 62%]
cheta/tests/test_intervals.py .........................                                                                                       [ 75%]
cheta/tests/test_orbit.py .                                                                                                                   [ 76%]
cheta/tests/test_remote_access.py ......                                                                                                      [ 79%]
cheta/tests/test_sync.py ........                                                                                                             [ 83%]
cheta/tests/test_units.py ...........                                                                                                         [ 88%]
cheta/tests/test_units_reversed.py ...........                                                                                                [ 94%]
cheta/tests/test_utils.py ...........                                                                                                         [100%]

================================================================= warnings summary ==================================================================
cheta/cheta/tests/test_comps.py::test_cmd_states
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.13/site-packages/setuptools_scm/git.py:427: UserWarning: git archive did not support describe output
    warnings.warn("git archive did not support describe output")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================== 195 passed, 1 skipped, 1 warning in 151.36s (0:02:31) ===============================================
(ska3-latest) flame:cheta jean$ git rev-parse HEAD
1098b39f3b68ced1c7b4c71f5a4cab653eae361e
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
With the new unit equivalence commented out, the warning appears.
```
>>> from cheta import fetch, fetch_eng, fetch_sci
...
... msid = "2TLEV2RT"
... start = "2026:065:13:39:10"
... stop = "2026:065:13:40:30"
... dat_cxc = fetch.Msid(msid, start, stop)
... dat_cxc.unit
'count'

>>> dat_eng = fetch_eng.Msid(msid, start, stop)
... dat_eng.unit
/Users/aldcroft/git/cheta/cheta/units.py:309: UserWarning: 


**** WARNING ****
For MSID 2TLEV2RT the requested unit conversion from count to HZ
does not have a defined transformation function.
You may be getting incorrect results now.

PLEASE REPORT THIS to the Ska developers!

  warnings.warn(
'HZ'

>>> dat_sci = fetch_sci.Msid(msid, start, stop)
... dat_sci.unit
'count'
```

